### PR TITLE
Added usesPeriodicBoxVectors() methods to Force and System

### DIFF
--- a/openmmapi/include/openmm/AndersenThermostat.h
+++ b/openmmapi/include/openmm/AndersenThermostat.h
@@ -117,6 +117,14 @@ public:
     void setRandomNumberSeed(int seed) {
         randomNumberSeed = seed;
     }
+    /**
+     * Query whether this Force uses the System periodic box vectors in computing interactions.
+     *
+     * @return         true if this Force uses periodic box vectors, false otherwise.
+     */
+    virtual bool usesPeriodicBoxVectors() const {
+      return false;
+    }
 protected:
     ForceImpl* createImpl() const;
 private:

--- a/openmmapi/include/openmm/CMAPTorsionForce.h
+++ b/openmmapi/include/openmm/CMAPTorsionForce.h
@@ -148,6 +148,14 @@ public:
      * @param b4    the index of the fourth particle forming the second torsion
      */
     void setTorsionParameters(int index, int map, int a1, int a2, int a3, int a4, int b1, int b2, int b3, int b4);
+    /**
+     * Query whether this Force uses the System periodic box vectors in computing interactions.
+     *
+     * @return         true if this Force uses periodic box vectors, false otherwise.
+     */
+    virtual bool usesPeriodicBoxVectors() const {
+      return false;
+    }
 protected:
     ForceImpl* createImpl() const;
 private:

--- a/openmmapi/include/openmm/CMMotionRemover.h
+++ b/openmmapi/include/openmm/CMMotionRemover.h
@@ -61,6 +61,14 @@ public:
     void setFrequency(int freq) {
         frequency = freq;
     }
+    /**
+     * Query whether this Force uses the System periodic box vectors in computing interactions.
+     *
+     * @return         true if this Force uses periodic box vectors, false otherwise.
+     */
+    virtual bool usesPeriodicBoxVectors() const {
+      return false;
+    }
 protected:
     ForceImpl* createImpl() const;
 private:

--- a/openmmapi/include/openmm/CustomAngleForce.h
+++ b/openmmapi/include/openmm/CustomAngleForce.h
@@ -202,6 +202,14 @@ public:
      * the Context.  The set of particles involved in a angle cannot be changed, nor can new angles be added.
      */
     void updateParametersInContext(Context& context);
+    /**
+     * Query whether this Force uses the System periodic box vectors in computing interactions.
+     *
+     * @return         true if this Force uses periodic box vectors, false otherwise.
+     */
+    virtual bool usesPeriodicBoxVectors() const {
+      return false;
+    }
 protected:
     ForceImpl* createImpl() const;
 private:

--- a/openmmapi/include/openmm/CustomBondForce.h
+++ b/openmmapi/include/openmm/CustomBondForce.h
@@ -199,6 +199,14 @@ public:
      * the Context.  The set of particles involved in a bond cannot be changed, nor can new bonds be added.
      */
     void updateParametersInContext(Context& context);
+    /**
+     * Query whether this Force uses the System periodic box vectors in computing interactions.
+     *
+     * @return         true if this Force uses periodic box vectors, false otherwise.
+     */
+    virtual bool usesPeriodicBoxVectors() const {
+      return false;
+    }
 protected:
     ForceImpl* createImpl() const;
 private:

--- a/openmmapi/include/openmm/CustomCompoundBondForce.h
+++ b/openmmapi/include/openmm/CustomCompoundBondForce.h
@@ -297,6 +297,14 @@ public:
      * the Context.  The set of particles involved in a bond cannot be changed, nor can new bonds be added.
      */
     void updateParametersInContext(Context& context);
+    /**
+     * Query whether this Force uses the System periodic box vectors in computing interactions.
+     *
+     * @return         true if this Force uses periodic box vectors, false otherwise.
+     */
+    virtual bool usesPeriodicBoxVectors() const {
+      return false;
+    }
 protected:
     ForceImpl* createImpl() const;
 private:

--- a/openmmapi/include/openmm/CustomExternalForce.h
+++ b/openmmapi/include/openmm/CustomExternalForce.h
@@ -199,6 +199,14 @@ public:
      * the Context.  Also, this method cannot be used to add new particles, only to change the parameters of existing ones.
      */
     void updateParametersInContext(Context& context);
+    /**
+     * Query whether this Force uses the System periodic box vectors in computing interactions.
+     *
+     * @return         true if this Force uses periodic box vectors, false otherwise.
+     */
+    virtual bool usesPeriodicBoxVectors() const {
+      return false;
+    }
 protected:
     ForceImpl* createImpl() const;
 private:

--- a/openmmapi/include/openmm/CustomGBForce.h
+++ b/openmmapi/include/openmm/CustomGBForce.h
@@ -523,6 +523,14 @@ public:
      * the Context.  Also, this method cannot be used to add new particles, only to change the parameters of existing ones.
      */
     void updateParametersInContext(Context& context);
+    /**
+     * Query whether this Force uses the System periodic box vectors in computing interactions.
+     *
+     * @return         true if this Force uses periodic box vectors, false otherwise.
+     */
+    virtual bool usesPeriodicBoxVectors() const {
+      return (nonbondedMethod == CutoffPeriodic);
+    }
 protected:
     ForceImpl* createImpl() const;
 private:

--- a/openmmapi/include/openmm/CustomHbondForce.h
+++ b/openmmapi/include/openmm/CustomHbondForce.h
@@ -443,6 +443,14 @@ public:
      * new donors or acceptors be added.
      */
     void updateParametersInContext(Context& context);
+    /**
+     * Query whether this Force uses the System periodic box vectors in computing interactions.
+     *
+     * @return         true if this Force uses periodic box vectors, false otherwise.
+     */
+    virtual bool usesPeriodicBoxVectors() const {
+      return (nonbondedMethod == CutoffPeriodic);
+    }
 protected:
     ForceImpl* createImpl() const;
 private:

--- a/openmmapi/include/openmm/CustomNonbondedForce.h
+++ b/openmmapi/include/openmm/CustomNonbondedForce.h
@@ -452,6 +452,14 @@ public:
      * the parameters of existing ones.
      */
     void updateParametersInContext(Context& context);
+    /**
+     * Query whether this Force uses the System periodic box vectors in computing interactions.
+     *
+     * @return         true if this Force uses periodic box vectors, false otherwise.
+     */
+    bool usesPeriodicBoxVectors() const {
+      return (nonbondedMethod == CustomNonbondedForce::CutoffPeriodic);
+    }
 protected:
     ForceImpl* createImpl() const;
 private:

--- a/openmmapi/include/openmm/CustomNonbondedForce.h
+++ b/openmmapi/include/openmm/CustomNonbondedForce.h
@@ -457,8 +457,8 @@ public:
      *
      * @return         true if this Force uses periodic box vectors, false otherwise.
      */
-    bool usesPeriodicBoxVectors() const {
-      return (nonbondedMethod == CustomNonbondedForce::CutoffPeriodic);
+    virtual bool usesPeriodicBoxVectors() const {
+      return (nonbondedMethod == CutoffPeriodic);
     }
 protected:
     ForceImpl* createImpl() const;

--- a/openmmapi/include/openmm/CustomTorsionForce.h
+++ b/openmmapi/include/openmm/CustomTorsionForce.h
@@ -205,6 +205,15 @@ public:
      * the Context.  The set of particles involved in a torsion cannot be changed, nor can new torsions be added.
      */
     void updateParametersInContext(Context& context);
+    /**
+     * Query whether this Force uses the System periodic box vectors in computing interactions.
+     *
+     * @return         true if this Force uses periodic box vectors, false otherwise.
+     */
+    virtual bool usesPeriodicBoxVectors() const {
+      return false;
+    }
+
 protected:
     ForceImpl* createImpl() const;
 private:

--- a/openmmapi/include/openmm/Force.h
+++ b/openmmapi/include/openmm/Force.h
@@ -78,6 +78,15 @@ public:
      * @param group    the group index.  Legal values are between 0 and 31 (inclusive).
      */
     void setForceGroup(int group);
+    /**
+     * Query whether this Force uses the System periodic box vectors in computing interactions.
+     *
+     * @return         true if this Force uses periodic box vectors, false otherwise.
+     */
+    bool usesPeriodicBoxVectors() const{
+      // Default implementation returns false.
+      return false;
+    }
 protected:
     friend class ContextImpl;
     /**

--- a/openmmapi/include/openmm/Force.h
+++ b/openmmapi/include/openmm/Force.h
@@ -83,10 +83,7 @@ public:
      *
      * @return         true if this Force uses periodic box vectors, false otherwise.
      */
-    bool usesPeriodicBoxVectors() const{
-      // Default implementation returns false.
-      return false;
-    }
+    virtual bool usesPeriodicBoxVectors() const = 0;
 protected:
     friend class ContextImpl;
     /**

--- a/openmmapi/include/openmm/GBSAOBCForce.h
+++ b/openmmapi/include/openmm/GBSAOBCForce.h
@@ -172,6 +172,14 @@ public:
      * change the parameters of existing ones.
      */
     void updateParametersInContext(Context& context);
+    /**
+     * Query whether this Force uses the System periodic box vectors in computing interactions.
+     *
+     * @return         true if this Force uses periodic box vectors, false otherwise.
+     */
+    virtual bool usesPeriodicBoxVectors() const {
+      return (nonbondedMethod == CutoffPeriodic);
+    }
 protected:
     ForceImpl* createImpl() const;
 private:

--- a/openmmapi/include/openmm/GBVIForce.h
+++ b/openmmapi/include/openmm/GBVIForce.h
@@ -227,6 +227,14 @@ public:
      * Set the upper limit used in the quintic spline scaling method, measured in nm (~5.0)
      */
     void setQuinticUpperBornRadiusLimit(double quinticUpperBornRadiusLimit);
+    /**
+     * Query whether this Force uses the System periodic box vectors in computing interactions.
+     *
+     * @return         true if this Force uses periodic box vectors, false otherwise.
+     */
+    virtual bool usesPeriodicBoxVectors() const {
+      return (nonbondedMethod == CutoffPeriodic);
+    }
 protected:
     ForceImpl* createImpl() const;
 private:

--- a/openmmapi/include/openmm/HarmonicAngleForce.h
+++ b/openmmapi/include/openmm/HarmonicAngleForce.h
@@ -102,6 +102,14 @@ public:
      * in a angle cannot be changed, nor can new angles be added.
      */
     void updateParametersInContext(Context& context);
+    /**
+     * Query whether this Force uses the System periodic box vectors in computing interactions.
+     *
+     * @return         true if this Force uses periodic box vectors, false otherwise.
+     */
+    virtual bool usesPeriodicBoxVectors() const {
+      return false;
+    }
 protected:
     ForceImpl* createImpl() const;
 private:

--- a/openmmapi/include/openmm/HarmonicBondForce.h
+++ b/openmmapi/include/openmm/HarmonicBondForce.h
@@ -99,6 +99,14 @@ public:
      * in a bond cannot be changed, nor can new bonds be added.
      */
     void updateParametersInContext(Context& context);
+    /**
+     * Query whether this Force uses the System periodic box vectors in computing interactions.
+     *
+     * @return         true if this Force uses periodic box vectors, false otherwise.
+     */
+    virtual bool usesPeriodicBoxVectors() const {
+      return false;
+    }
 protected:
     ForceImpl* createImpl() const;
 private:

--- a/openmmapi/include/openmm/MonteCarloAnisotropicBarostat.h
+++ b/openmmapi/include/openmm/MonteCarloAnisotropicBarostat.h
@@ -176,7 +176,7 @@ public:
      *
      * @return         true if this Force uses periodic box vectors, false otherwise.
      */
-    bool usesPeriodicBoxVectors() const {
+    virtual bool usesPeriodicBoxVectors() const {
       return true;
     }
 protected:

--- a/openmmapi/include/openmm/MonteCarloAnisotropicBarostat.h
+++ b/openmmapi/include/openmm/MonteCarloAnisotropicBarostat.h
@@ -177,7 +177,7 @@ public:
      * @return         true if this Force uses periodic box vectors, false otherwise.
      */
     bool usesPeriodicBoxVectors() const {
-      return True;
+      return true;
     }
 protected:
     ForceImpl* createImpl() const;

--- a/openmmapi/include/openmm/MonteCarloAnisotropicBarostat.h
+++ b/openmmapi/include/openmm/MonteCarloAnisotropicBarostat.h
@@ -171,6 +171,14 @@ public:
     void setRandomNumberSeed(int seed) {
         randomNumberSeed = seed;
     }
+    /**
+     * Query whether this Force uses the System periodic box vectors in computing interactions.
+     *
+     * @return         true if this Force uses periodic box vectors, false otherwise.
+     */
+    bool usesPeriodicBoxVectors() const {
+      return True;
+    }
 protected:
     ForceImpl* createImpl() const;
 private:

--- a/openmmapi/include/openmm/MonteCarloBarostat.h
+++ b/openmmapi/include/openmm/MonteCarloBarostat.h
@@ -127,6 +127,14 @@ public:
     void setRandomNumberSeed(int seed) {
         randomNumberSeed = seed;
     }
+    /**
+     * Query whether this Force uses the System periodic box vectors in computing interactions.
+     *
+     * @return         true if this Force uses periodic box vectors, false otherwise.
+     */
+    bool usesPeriodicBoxVectors() const {
+      return true;
+    }
 protected:
     ForceImpl* createImpl() const;
 private:

--- a/openmmapi/include/openmm/MonteCarloBarostat.h
+++ b/openmmapi/include/openmm/MonteCarloBarostat.h
@@ -132,7 +132,7 @@ public:
      *
      * @return         true if this Force uses periodic box vectors, false otherwise.
      */
-    bool usesPeriodicBoxVectors() const {
+    virtual bool usesPeriodicBoxVectors() const {
       return true;
     }
 protected:

--- a/openmmapi/include/openmm/NonbondedForce.h
+++ b/openmmapi/include/openmm/NonbondedForce.h
@@ -352,6 +352,14 @@ public:
      * to add new particles or exceptions, only to change the parameters of existing ones.
      */
     void updateParametersInContext(Context& context);
+    /**
+     * Query whether this Force uses the System periodic box vectors in computing interactions.
+     *
+     * @return         true if this Force uses periodic box vectors, false otherwise.
+     */
+    bool usesPeriodicBoxVectors() const {
+      return (nonbondedMethod == NonbondedForce::CutoffPeriodic) || (nonbondedMethod == NonbondedForce::Ewald) || (nonbondedMethod == NonbondedForce::PME);
+    }
 protected:
     ForceImpl* createImpl() const;
 private:

--- a/openmmapi/include/openmm/NonbondedForce.h
+++ b/openmmapi/include/openmm/NonbondedForce.h
@@ -357,8 +357,8 @@ public:
      *
      * @return         true if this Force uses periodic box vectors, false otherwise.
      */
-    bool usesPeriodicBoxVectors() const {
-      return (nonbondedMethod == NonbondedForce::CutoffPeriodic) || (nonbondedMethod == NonbondedForce::Ewald) || (nonbondedMethod == NonbondedForce::PME);
+    virtual bool usesPeriodicBoxVectors() const {
+      return (nonbondedMethod == CutoffPeriodic) || (nonbondedMethod == Ewald) || (nonbondedMethod == PME);
     }
 protected:
     ForceImpl* createImpl() const;

--- a/openmmapi/include/openmm/PeriodicTorsionForce.h
+++ b/openmmapi/include/openmm/PeriodicTorsionForce.h
@@ -108,6 +108,14 @@ public:
      * in a torsion cannot be changed, nor can new torsions be added.
      */
     void updateParametersInContext(Context& context);
+    /**
+     * Query whether this Force uses the System periodic box vectors in computing interactions.
+     *
+     * @return         true if this Force uses periodic box vectors, false otherwise.
+     */
+    virtual bool usesPeriodicBoxVectors() const {
+      return false;
+    }
 protected:
     ForceImpl* createImpl() const;
 private:

--- a/openmmapi/include/openmm/RBTorsionForce.h
+++ b/openmmapi/include/openmm/RBTorsionForce.h
@@ -117,6 +117,14 @@ public:
      * in a torsion cannot be changed, nor can new torsions be added.
      */
     void updateParametersInContext(Context& context);
+    /**
+     * Query whether this Force uses the System periodic box vectors in computing interactions.
+     *
+     * @return         true if this Force uses periodic box vectors, false otherwise.
+     */
+    virtual bool usesPeriodicBoxVectors() const {
+      return false;
+    }
 protected:
     ForceImpl* createImpl() const;
 private:

--- a/openmmapi/include/openmm/System.h
+++ b/openmmapi/include/openmm/System.h
@@ -224,6 +224,12 @@ public:
      * @param c      the vector defining the third edge of the periodic box
      */
     void setDefaultPeriodicBoxVectors(const Vec3& a, const Vec3& b, const Vec3& c);
+    /**
+     * Query whether any Force objects associated with this System use the periodic box vectors in computing interactions.
+     *
+     * @return       true if any Force objects use periodic box vectors, false otherwise.
+     */
+    bool usesPeriodicBoxVectors();
 private:
     class ConstraintInfo;
     Vec3 periodicBoxVectors[3];

--- a/openmmapi/src/System.cpp
+++ b/openmmapi/src/System.cpp
@@ -119,3 +119,11 @@ void System::setDefaultPeriodicBoxVectors(const Vec3& a, const Vec3& b, const Ve
     periodicBoxVectors[1] = b;
     periodicBoxVectors[2] = c;
 }
+
+bool System::usesPeriodicBoxVectors() {
+  if (forces.size() == 0) return false;
+  bool result = true;
+  for (int i; 0 < getNumForces(); i++)
+    result = result & getForce(i).usesPeriodicBoxVectors();
+  return result;
+}

--- a/plugins/amoeba/openmmapi/include/openmm/AmoebaAngleForce.h
+++ b/plugins/amoeba/openmmapi/include/openmm/AmoebaAngleForce.h
@@ -166,6 +166,14 @@ public:
      * in an angle cannot be changed, nor can new angles be added.
      */
     void updateParametersInContext(Context& context);
+    /**
+     * Query whether this Force uses the System periodic box vectors in computing interactions.
+     *
+     * @return         true if this Force uses periodic box vectors, false otherwise.
+     */
+    virtual bool usesPeriodicBoxVectors() const {
+      return false;
+    }
 
 protected:
     ForceImpl* createImpl() const;

--- a/plugins/amoeba/openmmapi/include/openmm/AmoebaBondForce.h
+++ b/plugins/amoeba/openmmapi/include/openmm/AmoebaBondForce.h
@@ -138,6 +138,14 @@ public:
      * in a bond cannot be changed, nor can new bonds be added.
      */
     void updateParametersInContext(Context& context);
+    /**
+     * Query whether this Force uses the System periodic box vectors in computing interactions.
+     *
+     * @return         true if this Force uses periodic box vectors, false otherwise.
+     */
+    virtual bool usesPeriodicBoxVectors() const {
+      return false;
+    }
 
 protected:
     double _globalQuarticK, _globalCubicK;

--- a/plugins/amoeba/openmmapi/include/openmm/AmoebaGeneralizedKirkwoodForce.h
+++ b/plugins/amoeba/openmmapi/include/openmm/AmoebaGeneralizedKirkwoodForce.h
@@ -163,6 +163,14 @@ public:
      * (the probe radius, the surface area factor, etc.) are unaffected and can only be changed by reinitializing the Context.
      */
     void updateParametersInContext(Context& context);
+    /**
+     * Query whether this Force uses the System periodic box vectors in computing interactions.
+     *
+     * @return         true if this Force uses periodic box vectors, false otherwise.
+     */
+    virtual bool usesPeriodicBoxVectors() const {
+      return false;
+    }
 
 protected:
     ForceImpl* createImpl() const;

--- a/plugins/amoeba/openmmapi/include/openmm/AmoebaInPlaneAngleForce.h
+++ b/plugins/amoeba/openmmapi/include/openmm/AmoebaInPlaneAngleForce.h
@@ -171,6 +171,14 @@ public:
      * in an angle cannot be changed, nor can new angles be added.
      */
     void updateParametersInContext(Context& context);
+    /**
+     * Query whether this Force uses the System periodic box vectors in computing interactions.
+     *
+     * @return         true if this Force uses periodic box vectors, false otherwise.
+     */
+    virtual bool usesPeriodicBoxVectors() const {
+      return false;
+    }
 
 protected:
     ForceImpl* createImpl() const;

--- a/plugins/amoeba/openmmapi/include/openmm/AmoebaMultipoleForce.h
+++ b/plugins/amoeba/openmmapi/include/openmm/AmoebaMultipoleForce.h
@@ -349,7 +349,14 @@ public:
      * only to change the parameters of existing ones.
      */
     void updateParametersInContext(Context& context);
-
+    /**
+     * Query whether this Force uses the System periodic box vectors in computing interactions.
+     *
+     * @return         true if this Force uses periodic box vectors, false otherwise.
+     */
+    virtual bool usesPeriodicBoxVectors() const {
+      return (nonbondedMethod == PME);
+    }
 protected:
     ForceImpl* createImpl() const;
 private:

--- a/plugins/amoeba/openmmapi/include/openmm/AmoebaMultipoleForce.h
+++ b/plugins/amoeba/openmmapi/include/openmm/AmoebaMultipoleForce.h
@@ -357,6 +357,7 @@ public:
     virtual bool usesPeriodicBoxVectors() const {
       return (nonbondedMethod == PME);
     }
+
 protected:
     ForceImpl* createImpl() const;
 private:

--- a/plugins/amoeba/openmmapi/include/openmm/AmoebaOutOfPlaneBendForce.h
+++ b/plugins/amoeba/openmmapi/include/openmm/AmoebaOutOfPlaneBendForce.h
@@ -163,6 +163,14 @@ public:
      * in a term cannot be changed, nor can new terms be added.
      */
     void updateParametersInContext(Context& context);
+    /**
+     * Query whether this Force uses the System periodic box vectors in computing interactions.
+     *
+     * @return         true if this Force uses periodic box vectors, false otherwise.
+     */
+    virtual bool usesPeriodicBoxVectors() const {
+      return false;
+    }
 
 protected:
     ForceImpl* createImpl() const;

--- a/plugins/amoeba/openmmapi/include/openmm/AmoebaPiTorsionForce.h
+++ b/plugins/amoeba/openmmapi/include/openmm/AmoebaPiTorsionForce.h
@@ -113,6 +113,14 @@ public:
      * in a torsion cannot be changed, nor can new torsions be added.
      */
     void updateParametersInContext(Context& context);
+    /**
+     * Query whether this Force uses the System periodic box vectors in computing interactions.
+     *
+     * @return         true if this Force uses periodic box vectors, false otherwise.
+     */
+    virtual bool usesPeriodicBoxVectors() const {
+      return false;
+    }
 
 protected:
     ForceImpl* createImpl() const;

--- a/plugins/amoeba/openmmapi/include/openmm/AmoebaStretchBendForce.h
+++ b/plugins/amoeba/openmmapi/include/openmm/AmoebaStretchBendForce.h
@@ -116,6 +116,14 @@ public:
      * in a term cannot be changed, nor can new terms be added.
      */
     void updateParametersInContext(Context& context);
+    /**
+     * Query whether this Force uses the System periodic box vectors in computing interactions.
+     *
+     * @return         true if this Force uses periodic box vectors, false otherwise.
+     */
+    virtual bool usesPeriodicBoxVectors() const {
+      return false;
+    }
 
 protected:
     ForceImpl* createImpl() const;

--- a/plugins/amoeba/openmmapi/include/openmm/AmoebaTorsionTorsionForce.h
+++ b/plugins/amoeba/openmmapi/include/openmm/AmoebaTorsionTorsionForce.h
@@ -135,6 +135,14 @@ public:
      *                         grid[x][y][5] = dfd(xy) value
      */
     void setTorsionTorsionGrid(int index, const std::vector<std::vector<std::vector<double> > >& grid);
+    /**
+     * Query whether this Force uses the System periodic box vectors in computing interactions.
+     *
+     * @return         true if this Force uses periodic box vectors, false otherwise.
+     */
+    virtual bool usesPeriodicBoxVectors() const {
+      return false;
+    }
 
 protected:
     ForceImpl* createImpl() const;

--- a/plugins/amoeba/openmmapi/include/openmm/AmoebaVdwForce.h
+++ b/plugins/amoeba/openmmapi/include/openmm/AmoebaVdwForce.h
@@ -212,7 +212,14 @@ public:
      * (the nonbonded method, the cutoff distance, etc.) are unaffected and can only be changed by reinitializing the Context.
      */
     void updateParametersInContext(Context& context);
-
+    /**
+     * Query whether this Force uses the System periodic box vectors in computing interactions.
+     *
+     * @return         true if this Force uses periodic box vectors, false otherwise.
+     */
+    virtual bool usesPeriodicBoxVectors() const {
+      return (nonbondedMethod == CutoffPeriodic);
+    }
 protected:
     ForceImpl* createImpl() const;
 private:

--- a/plugins/amoeba/openmmapi/include/openmm/AmoebaWcaDispersionForce.h
+++ b/plugins/amoeba/openmmapi/include/openmm/AmoebaWcaDispersionForce.h
@@ -99,6 +99,14 @@ public:
      * are unaffected and can only be changed by reinitializing the Context.
      */
     void updateParametersInContext(Context& context);
+    /**
+     * Query whether this Force uses the System periodic box vectors in computing interactions.
+     *
+     * @return         true if this Force uses periodic box vectors, false otherwise.
+     */
+    virtual bool usesPeriodicBoxVectors() const {
+      return true;
+    }
 
     /* 
      * Constants


### PR DESCRIPTION
I've added `usesPeriodicBoxVectors()` methods to both `Force` and `System`.  This method returns `true` if the force (or any force in the system) uses the periodic box vectors in the energy calculation.