### PR TITLE
add square,cube,recip to docs

### DIFF
--- a/openmmapi/include/openmm/CustomAngleForce.h
+++ b/openmmapi/include/openmm/CustomAngleForce.h
@@ -65,8 +65,9 @@ namespace OpenMM {
  * </pre></tt>
  *
  * Expressions may involve the operators + (add), - (subtract), * (multiply), / (divide), and ^ (power), and the following
- * functions: sqrt, exp, log, sin, cos, sec, csc, tan, cot, asin, acos, atan, sinh, cosh, tanh, erf, erfc, min, max, abs, step, delta.  All trigonometric functions
- * are defined in radians, and log is the natural logarithm.  step(x) = 0 if x is less than 0, 1 otherwise.  delta(x) = 1 if x is 0, 0 otherwise.
+ * functions: sqrt, exp, log, sin, cos, sec, csc, tan, cot, asin, acos, atan, sinh, cosh, tanh, erf, erfc, min, max, abs, step, delta, square, cube, recip.  All trigonometric functions
+ * are defined in radians, and log is the natural logarithm.  step(x) = 0 if x is less than 0, 1 otherwise.  delta(x) = 1 if x is 0, 0 otherwise.  square(x) = x*x.  cube(x) = x*x*x.  recip(x) = 1/x.  An expression
+ * may also involve intermediate quantities that are defined following the main expression, using ";" as a separator.
  */
 
 class OPENMM_EXPORT CustomAngleForce : public Force {

--- a/openmmapi/include/openmm/CustomBondForce.h
+++ b/openmmapi/include/openmm/CustomBondForce.h
@@ -65,8 +65,9 @@ namespace OpenMM {
  * </pre></tt>
  *
  * Expressions may involve the operators + (add), - (subtract), * (multiply), / (divide), and ^ (power), and the following
- * functions: sqrt, exp, log, sin, cos, sec, csc, tan, cot, asin, acos, atan, sinh, cosh, tanh, erf, erfc, min, max, abs, step, delta.  All trigonometric functions
- * are defined in radians, and log is the natural logarithm.  step(x) = 0 if x is less than 0, 1 otherwise.  delta(x) = 1 if x is 0, 0 otherwise.
+ * functions: sqrt, exp, log, sin, cos, sec, csc, tan, cot, asin, acos, atan, sinh, cosh, tanh, erf, erfc, min, max, abs, step, delta, square, cube, recip.  All trigonometric functions
+ * are defined in radians, and log is the natural logarithm.  step(x) = 0 if x is less than 0, 1 otherwise.  delta(x) = 1 if x is 0, 0 otherwise.  square(x) = x*x.  cube(x) = x*x*x.  recip(x) = 1/x.  An expression
+ * may also involve intermediate quantities that are defined following the main expression, using ";" as a separator.
  */
 
 class OPENMM_EXPORT CustomBondForce : public Force {

--- a/openmmapi/include/openmm/CustomCompoundBondForce.h
+++ b/openmmapi/include/openmm/CustomCompoundBondForce.h
@@ -89,8 +89,9 @@ namespace OpenMM {
  * </pre></tt>
  *
  * Expressions may involve the operators + (add), - (subtract), * (multiply), / (divide), and ^ (power), and the following
- * functions: sqrt, exp, log, sin, cos, sec, csc, tan, cot, asin, acos, atan, sinh, cosh, tanh, erf, erfc, min, max, abs, step, delta.  All trigonometric functions
- * are defined in radians, and log is the natural logarithm.  step(x) = 0 if x is less than 0, 1 otherwise.  delta(x) = 1 if x is 0, 0 otherwise.
+ * functions: sqrt, exp, log, sin, cos, sec, csc, tan, cot, asin, acos, atan, sinh, cosh, tanh, erf, erfc, min, max, abs, step, delta, square, cube, recip.  All trigonometric functions
+ * are defined in radians, and log is the natural logarithm.  step(x) = 0 if x is less than 0, 1 otherwise.  delta(x) = 1 if x is 0, 0 otherwise.  square(x) = x*x.  cube(x) = x*x*x.  recip(x) = 1/x.  An expression
+ * may also involve intermediate quantities that are defined following the main expression, using ";" as a separator.
  *
  * In addition, you can call addTabulatedFunction() to define a new function based on tabulated values.  You specify the function by
  * creating a TabulatedFunction object.  That function can then appear in the expression.

--- a/openmmapi/include/openmm/CustomExternalForce.h
+++ b/openmmapi/include/openmm/CustomExternalForce.h
@@ -68,8 +68,9 @@ namespace OpenMM {
  * </pre></tt>
  *
  * Expressions may involve the operators + (add), - (subtract), * (multiply), / (divide), and ^ (power), and the following
- * functions: sqrt, exp, log, sin, cos, sec, csc, tan, cot, asin, acos, atan, sinh, cosh, tanh, erf, erfc, min, max, abs, step, delta.  All trigonometric functions
- * are defined in radians, and log is the natural logarithm.  step(x) = 0 if x is less than 0, 1 otherwise.  delta(x) = 1 if x is 0, 0 otherwise.
+ * functions: sqrt, exp, log, sin, cos, sec, csc, tan, cot, asin, acos, atan, sinh, cosh, tanh, erf, erfc, min, max, abs, step, delta, square, cube, recip.  All trigonometric functions
+ * are defined in radians, and log is the natural logarithm.  step(x) = 0 if x is less than 0, 1 otherwise.  delta(x) = 1 if x is 0, 0 otherwise.  square(x) = x*x.  cube(x) = x*x*x.  recip(x) = 1/x.  An expression
+ * may also involve intermediate quantities that are defined following the main expression, using ";" as a separator.
  */
 
 class OPENMM_EXPORT CustomExternalForce : public Force {

--- a/openmmapi/include/openmm/CustomGBForce.h
+++ b/openmmapi/include/openmm/CustomGBForce.h
@@ -129,11 +129,11 @@ namespace OpenMM {
  * particular piece of the computation.
  *
  * Expressions may involve the operators + (add), - (subtract), * (multiply), / (divide), and ^ (power), and the following
- * functions: sqrt, exp, log, sin, cos, sec, csc, tan, cot, asin, acos, atan, sinh, cosh, tanh, erf, erfc, min, max, abs, step, delta.  All trigonometric functions
- * are defined in radians, and log is the natural logarithm.  step(x) = 0 if x is less than 0, 1 otherwise.  delta(x) = 1 if x is 0, 0 otherwise.  In expressions for
- * particle pair calculations, the names of per-particle parameters and computed values
- * have the suffix "1" or "2" appended to them to indicate the values for the two interacting particles.  As seen in the above example,
- * an expression may also involve intermediate quantities that are defined following the main expression, using ";" as a separator.
+ * functions: sqrt, exp, log, sin, cos, sec, csc, tan, cot, asin, acos, atan, sinh, cosh, tanh, erf, erfc, min, max, abs, step, delta, square, cube, recip.  All trigonometric functions
+ * are defined in radians, and log is the natural logarithm.  step(x) = 0 if x is less than 0, 1 otherwise.  delta(x) = 1 if x is 0, 0 otherwise.  square(x) = x*x.  cube(x) = x*x*x.  recip(x) = 1/x.  An expression
+ * may also involve intermediate quantities that are defined following the main expression, using ";" as a separator.
+ * In expressions for particle pair calculations, the names of per-particle parameters and computed values
+ * have the suffix "1" or "2" appended to them to indicate the values for the two interacting particles.
  *
  * In addition, you can call addTabulatedFunction() to define a new function based on tabulated values.  You specify the function by
  * creating a TabulatedFunction object.  That function can then appear in expressions.

--- a/openmmapi/include/openmm/CustomHbondForce.h
+++ b/openmmapi/include/openmm/CustomHbondForce.h
@@ -89,8 +89,9 @@ namespace OpenMM {
  * </pre></tt>
  *
  * Expressions may involve the operators + (add), - (subtract), * (multiply), / (divide), and ^ (power), and the following
- * functions: sqrt, exp, log, sin, cos, sec, csc, tan, cot, asin, acos, atan, sinh, cosh, tanh, erf, erfc, min, max, abs, step, delta.  All trigonometric functions
- * are defined in radians, and log is the natural logarithm.  step(x) = 0 if x is less than 0, 1 otherwise.  delta(x) = 1 if x is 0, 0 otherwise.
+ * functions: sqrt, exp, log, sin, cos, sec, csc, tan, cot, asin, acos, atan, sinh, cosh, tanh, erf, erfc, min, max, abs, step, delta, square, cube, recip.  All trigonometric functions
+ * are defined in radians, and log is the natural logarithm.  step(x) = 0 if x is less than 0, 1 otherwise.  delta(x) = 1 if x is 0, 0 otherwise.  square(x) = x*x.  cube(x) = x*x*x.  recip(x) = 1/x.  An expression
+ * may also involve intermediate quantities that are defined following the main expression, using ";" as a separator.
  *
  * In addition, you can call addTabulatedFunction() to define a new function based on tabulated values.  You specify the function by
  * creating a TabulatedFunction object.  That function can then appear in the expression.

--- a/openmmapi/include/openmm/CustomIntegrator.h
+++ b/openmmapi/include/openmm/CustomIntegrator.h
@@ -204,8 +204,8 @@ namespace OpenMM {
  * the force from a single force group, or a random number.
  * 
  * Expressions may involve the operators + (add), - (subtract), * (multiply), / (divide), and ^ (power), and the following
- * functions: sqrt, exp, log, sin, cos, sec, csc, tan, cot, asin, acos, atan, sinh, cosh, tanh, erf, erfc, min, max, abs, step, delta.  All trigonometric functions
- * are defined in radians, and log is the natural logarithm.  step(x) = 0 if x is less than 0, 1 otherwise.  delta(x) = 1 if x is 0, 0 otherwise.  An expression
+ * functions: sqrt, exp, log, sin, cos, sec, csc, tan, cot, asin, acos, atan, sinh, cosh, tanh, erf, erfc, min, max, abs, step, delta, square, cube, recip.  All trigonometric functions
+ * are defined in radians, and log is the natural logarithm.  step(x) = 0 if x is less than 0, 1 otherwise.  delta(x) = 1 if x is 0, 0 otherwise.  square(x) = x*x.  cube(x) = x*x*x.  recip(x) = 1/x.  An expression
  * may also involve intermediate quantities that are defined following the main expression, using ";" as a separator.
  */
 

--- a/openmmapi/include/openmm/CustomManyParticleForce.h
+++ b/openmmapi/include/openmm/CustomManyParticleForce.h
@@ -149,8 +149,8 @@ namespace OpenMM {
  * still only be evaluated once for each triplet, so it must still be symmetric with respect to p2 and p3.
  * 
  * Expressions may involve the operators + (add), - (subtract), * (multiply), / (divide), and ^ (power), and the following
- * functions: sqrt, exp, log, sin, cos, sec, csc, tan, cot, asin, acos, atan, sinh, cosh, tanh, erf, erfc, min, max, abs, step, delta.  All trigonometric functions
- * are defined in radians, and log is the natural logarithm.  step(x) = 0 if x is less than 0, 1 otherwise.  delta(x) = 1 if x is 0, 0 otherwise.
+ * functions: sqrt, exp, log, sin, cos, sec, csc, tan, cot, asin, acos, atan, sinh, cosh, tanh, erf, erfc, min, max, abs, step, delta, square, cube, recip.  All trigonometric functions
+ * are defined in radians, and log is the natural logarithm.  step(x) = 0 if x is less than 0, 1 otherwise.  delta(x) = 1 if x is 0, 0 otherwise.  square(x) = x*x.  cube(x) = x*x*x.  recip(x) = 1/x.
  * The names of per-particle parameters have the suffix "1", "2", etc. appended to them to indicate the values for the multiple interacting particles.
  * For example, if you define a per-particle parameter called "charge", then the variable "charge2" is the charge of particle p2.
  * As seen above, the expression may also involve intermediate quantities that are defined following the main expression, using ";" as a separator.

--- a/openmmapi/include/openmm/CustomNonbondedForce.h
+++ b/openmmapi/include/openmm/CustomNonbondedForce.h
@@ -120,8 +120,8 @@ namespace OpenMM {
  * frequently, the long range correction can be very slow.  For this reason, it is disabled by default.
  * 
  * Expressions may involve the operators + (add), - (subtract), * (multiply), / (divide), and ^ (power), and the following
- * functions: sqrt, exp, log, sin, cos, sec, csc, tan, cot, asin, acos, atan, sinh, cosh, tanh, erf, erfc, min, max, abs, step, delta.  All trigonometric functions
- * are defined in radians, and log is the natural logarithm.  step(x) = 0 if x is less than 0, 1 otherwise.  delta(x) = 1 if x is 0, 0 otherwise.  The names of per-particle parameters
+ * functions: sqrt, exp, log, sin, cos, sec, csc, tan, cot, asin, acos, atan, sinh, cosh, tanh, erf, erfc, min, max, abs, step, delta, square, cube, recip.  All trigonometric functions
+ * are defined in radians, and log is the natural logarithm.  step(x) = 0 if x is less than 0, 1 otherwise.  delta(x) = 1 if x is 0, 0 otherwise.  square(x) = x*x.  cube(x) = x*x*x.  recip(x) = 1/x.  The names of per-particle parameters
  * have the suffix "1" or "2" appended to them to indicate the values for the two interacting particles.  As seen in the above example,
  * the expression may also involve intermediate quantities that are defined following the main expression, using ";" as a separator.
  *

--- a/openmmapi/include/openmm/CustomTorsionForce.h
+++ b/openmmapi/include/openmm/CustomTorsionForce.h
@@ -65,8 +65,9 @@ namespace OpenMM {
  * </pre></tt>
  *
  * Expressions may involve the operators + (add), - (subtract), * (multiply), / (divide), and ^ (power), and the following
- * functions: sqrt, exp, log, sin, cos, sec, csc, tan, cot, asin, acos, atan, sinh, cosh, tanh, erf, erfc, min, max, abs, step, delta.  All trigonometric functions
- * are defined in radians, and log is the natural logarithm.  step(x) = 0 if x is less than 0, 1 otherwise.  delta(x) = 1 if x is 0, 0 otherwise.
+ * functions: sqrt, exp, log, sin, cos, sec, csc, tan, cot, asin, acos, atan, sinh, cosh, tanh, erf, erfc, min, max, abs, step, delta, square, cube, recip.  All trigonometric functions
+ * are defined in radians, and log is the natural logarithm.  step(x) = 0 if x is less than 0, 1 otherwise.  delta(x) = 1 if x is 0, 0 otherwise.  square(x) = x*x.  cube(x) = x*x*x.  recip(x) = 1/x.  An expression
+ * may also involve intermediate quantities that are defined following the main expression, using ";" as a separator.
  */
 
 class OPENMM_EXPORT CustomTorsionForce : public Force {


### PR DESCRIPTION
`square`, `cube`, and `recip` are functions that [have long been available](https://github.com/SimTk/openmm/blob/master/libraries/lepton/src/Parser.cpp#L318-L320) in lepton expressions, but were not mentioned as such in the Custom*.h header docs. 