### PR TITLE
Add a check and raise an exception if someone tries to use a CHAMBER-style prmtop

### DIFF
--- a/wrappers/python/simtk/openmm/app/amberprmtopfile.py
+++ b/wrappers/python/simtk/openmm/app/amberprmtopfile.py
@@ -173,6 +173,10 @@ class AmberPrmtopFile(object):
          - ewaldErrorTolerance (float=0.0005) The error tolerance to use if nonbondedMethod is Ewald or PME.
         Returns: the newly created System
         """
+        if self._prmtop.chamber:
+            raise ValueError("CHAMBER-style topology file detected. CHAMBER "
+                             "topologies are not supported -- use the native "
+                             "CHARMM files directly.")
         methodMap = {ff.NoCutoff:'NoCutoff',
                      ff.CutoffNonPeriodic:'CutoffNonPeriodic',
                      ff.CutoffPeriodic:'CutoffPeriodic',

--- a/wrappers/python/simtk/openmm/app/internal/amber_file_parser.py
+++ b/wrappers/python/simtk/openmm/app/internal/amber_file_parser.py
@@ -119,36 +119,38 @@ class PrmtopLoader(object):
         self._raw_data={}
         self._has_nbfix_terms = False
 
-        fIn=open(inFilename)
-        for line in fIn:
-            if line.startswith('%VERSION'):
-                tag, self._prmtopVersion = line.rstrip().split(None, 1)
-            elif line.startswith('%FLAG'):
-                tag, flag = line.rstrip().split(None, 1)
-                self._flags.append(flag)
-                self._raw_data[flag] = []
-            elif line.startswith('%FORMAT'):
-                format = line.rstrip()
-                index0=format.index('(')
-                index1=format.index(')')
-                format = format[index0+1:index1]
-                m = FORMAT_RE_PATTERN.search(format)
-                self._raw_format[self._flags[-1]] = (format, m.group(1), m.group(2), m.group(3), m.group(4))
-            elif self._flags \
-                 and 'TITLE'==self._flags[-1] \
-                 and not self._raw_data['TITLE']:
-                self._raw_data['TITLE'] = line.rstrip()
-            else:
-                flag=self._flags[-1]
-                (format, numItems, itemType,
-                 itemLength, itemPrecision) = self._getFormat(flag)
-                iLength=int(itemLength)
-                line = line.rstrip()
-                for index in range(0, len(line), iLength):
-                    item = line[index:index+iLength]
-                    if item:
-                        self._raw_data[flag].append(item.strip())
-        fIn.close()
+        with open(inFilename, 'r') as fIn:
+            for line in fIn:
+                if line.startswith('%VERSION'):
+                    tag, self._prmtopVersion = line.rstrip().split(None, 1)
+                elif line.startswith('%FLAG'):
+                    tag, flag = line.rstrip().split(None, 1)
+                    self._flags.append(flag)
+                    self._raw_data[flag] = []
+                elif line.startswith('%FORMAT'):
+                    format = line.rstrip()
+                    index0=format.index('(')
+                    index1=format.index(')')
+                    format = format[index0+1:index1]
+                    m = FORMAT_RE_PATTERN.search(format)
+                    self._raw_format[self._flags[-1]] = (format, m.group(1), m.group(2), m.group(3), m.group(4))
+                elif self._flags \
+                     and 'TITLE'==self._flags[-1] \
+                     and not self._raw_data['TITLE']:
+                    self._raw_data['TITLE'] = line.rstrip()
+                else:
+                    flag=self._flags[-1]
+                    (format, numItems, itemType,
+                     itemLength, itemPrecision) = self._getFormat(flag)
+                    iLength=int(itemLength)
+                    line = line.rstrip()
+                    for index in range(0, len(line), iLength):
+                        item = line[index:index+iLength]
+                        if item:
+                            self._raw_data[flag].append(item.strip())
+        # See if this is a CHAMBER-style topology file, which is not supported
+        # for creating Systems
+        self.chamber = 'CTITLE' in self._flags
 
     def _getFormat(self, flag=None):
         if not flag:


### PR DESCRIPTION
This addresses the (very old and very stale) issue #101.  The inpcrd file parsers were already updated to rigorously conform to the file spec in #461, but using CHAMBER-style topology files was still not explicitly caught (which meant, more than likely, that an obscure exception would be thrown or, worse, the CHARMM-specific pieces of the force field would be discarded and the simulation would "run").

There is code in ParmEd to properly parse CHAMBER-style topology files and create an OpenMM `System` from it (correctly).  It also has rigorously correct Fortran format string handling as well as a C-accelerated reading routine, so it should be quite efficient when reading large files.

I also switched the parsing loop to use a context manager -- a bit safer when it comes to properly handling I/O in exceptional cases.