### PR TITLE
stripUnits behavior with bytes

### DIFF
--- a/wrappers/python/src/swig_doxygen/swig_lib/python/pythoncode.i
+++ b/wrappers/python/src/swig_doxygen/swig_lib/python/pythoncode.i
@@ -275,7 +275,6 @@ def stripUnits(args):
             arg = dict(zip(newKeys, newValues))
         elif not isinstance(arg, _string_types):
             try:
-                iter(arg)
                 # Reclusively strip units from all quantities
                 arg=stripUnits(arg)
             except TypeError:

--- a/wrappers/python/src/swig_doxygen/swig_lib/python/pythoncode.i
+++ b/wrappers/python/src/swig_doxygen/swig_lib/python/pythoncode.i
@@ -9,6 +9,10 @@ import sys
 import math
 RMIN_PER_SIGMA=math.pow(2, 1/6.0)
 RVDW_PER_SIGMA=math.pow(2, 1/6.0)/2.0
+if sys.version_info[0] == 2:
+    _string_types = (basestring,)
+else:
+    _string_types = (bytes, str)
 
 import simtk.unit as unit
 from simtk.openmm.vec3 import Vec3
@@ -19,7 +23,7 @@ class State(_object):
      current state of a simulation at a point
      in time.  You create it by calling
      getState() on a Context.
-     
+
      When a State is created, you specify what
      information should be stored in it.  This
      saves time and memory by only copying in
@@ -103,7 +107,7 @@ class State(_object):
 
         returnValue = unit.Quantity(returnValue, unit.nanometers)
         return returnValue
-    
+
     def getPeriodicBoxVolume(self):
         """Get the volume of the periodic box."""
         a = self._periodicBoxVectorsList[0]
@@ -215,28 +219,9 @@ class State(_object):
         return self._paramMap
 
 
-# Strings can cause trouble
-# as can any container that has infinite levels of containment
-def _is_string(x):
-    # step 1) String is always a container
-    # and its contents are themselves containers.
-    try:
-        first_item = iter(x).next()
-        inner_item = iter(first_item).next()
-        if first_item == inner_item:
-            return True
-        else:
-            return False
-    except TypeError:
-        return False
-    except StopIteration:
-        return False
-    except ValueError:
-        return False
-
 def stripUnits(args):
     """
-    getState(self, quantity) 
+    getState(self, quantity)
           -> value with *no* units
 
     Examples
@@ -282,13 +267,13 @@ def stripUnits(args):
             if arg.unit.is_compatible(unit.bar):
                 arg = arg / unit.bar
             else:
-                arg=arg.value_in_unit_system(unit.md_unit_system)                
+                arg = arg.value_in_unit_system(unit.md_unit_system)
             # JDC: End workaround.
         elif isinstance(arg, dict):
             newKeys = stripUnits(arg.keys())
             newValues = stripUnits(arg.values())
             arg = dict(zip(newKeys, newValues))
-        elif not _is_string(arg):
+        elif not isinstance(arg, _string_types):
             try:
                 iter(arg)
                 # Reclusively strip units from all quantities


### PR DESCRIPTION
Current behavior:
```
In [4]: sys.version_info
Out[4]: sys.version_info(major=3, minor=4, micro=2, releaselevel='final', serial=0)

In [5]: simtk.openmm.stripUnits(b'Hello World')
Out[5]: (72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100)
```