### PR TITLE
Fixed bug in reference CustomCompoundBondForce

### DIFF
--- a/platforms/cuda/tests/TestCudaCustomCompoundBondForce.cpp
+++ b/platforms/cuda/tests/TestCudaCustomCompoundBondForce.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2012 Stanford University and the Authors.           *
+ * Portions copyright (c) 2012-2015 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -152,21 +152,21 @@ void testPositionDependence() {
     custom->addGlobalParameter("scale1", 0.3);
     custom->addGlobalParameter("scale2", 0.2);
     vector<int> particles(2);
-    particles[0] = 0;
-    particles[1] = 1;
+    particles[0] = 1;
+    particles[1] = 0;
     vector<double> parameters;
     custom->addBond(particles, parameters);
     customSystem.addForce(custom);
     vector<Vec3> positions(2);
-    positions[0] = Vec3(0.5, 1, 0);
-    positions[1] = Vec3(1.5, 1, 0);
+    positions[0] = Vec3(1.5, 1, 0);
+    positions[1] = Vec3(0.5, 1, 0);
     VerletIntegrator integrator(0.01);
     Context context(customSystem, integrator, platform);
     context.setPositions(positions);
     State state = context.getState(State::Forces | State::Energy);
     ASSERT_EQUAL_TOL(0.3*1.0+0.2*0.5+2*1, state.getPotentialEnergy(), 1e-5);
-    ASSERT_EQUAL_VEC(Vec3(0.3-0.2, 0, 0), state.getForces()[0], 1e-5);
-    ASSERT_EQUAL_VEC(Vec3(-0.3, -2, 0), state.getForces()[1], 1e-5);
+    ASSERT_EQUAL_VEC(Vec3(-0.3, -2, 0), state.getForces()[0], 1e-5);
+    ASSERT_EQUAL_VEC(Vec3(0.3-0.2, 0, 0), state.getForces()[1], 1e-5);
 }
 
 void testParallelComputation() {

--- a/platforms/opencl/tests/TestOpenCLCustomCompoundBondForce.cpp
+++ b/platforms/opencl/tests/TestOpenCLCustomCompoundBondForce.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2012 Stanford University and the Authors.           *
+ * Portions copyright (c) 2012-2015 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -152,21 +152,21 @@ void testPositionDependence() {
     custom->addGlobalParameter("scale1", 0.3);
     custom->addGlobalParameter("scale2", 0.2);
     vector<int> particles(2);
-    particles[0] = 0;
-    particles[1] = 1;
+    particles[0] = 1;
+    particles[1] = 0;
     vector<double> parameters;
     custom->addBond(particles, parameters);
     customSystem.addForce(custom);
     vector<Vec3> positions(2);
-    positions[0] = Vec3(0.5, 1, 0);
-    positions[1] = Vec3(1.5, 1, 0);
+    positions[0] = Vec3(1.5, 1, 0);
+    positions[1] = Vec3(0.5, 1, 0);
     VerletIntegrator integrator(0.01);
     Context context(customSystem, integrator, platform);
     context.setPositions(positions);
     State state = context.getState(State::Forces | State::Energy);
     ASSERT_EQUAL_TOL(0.3*1.0+0.2*0.5+2*1, state.getPotentialEnergy(), 1e-5);
-    ASSERT_EQUAL_VEC(Vec3(0.3-0.2, 0, 0), state.getForces()[0], 1e-5);
-    ASSERT_EQUAL_VEC(Vec3(-0.3, -2, 0), state.getForces()[1], 1e-5);
+    ASSERT_EQUAL_VEC(Vec3(-0.3, -2, 0), state.getForces()[0], 1e-5);
+    ASSERT_EQUAL_VEC(Vec3(0.3-0.2, 0, 0), state.getForces()[1], 1e-5);
 }
 
 void testParallelComputation() {

--- a/platforms/reference/src/SimTKReference/ReferenceCustomCompoundBondIxn.cpp
+++ b/platforms/reference/src/SimTKReference/ReferenceCustomCompoundBondIxn.cpp
@@ -1,5 +1,5 @@
 
-/* Portions copyright (c) 2009-2010 Stanford University and Simbios.
+/* Portions copyright (c) 2009-2015 Stanford University and Simbios.
  * Contributors: Peter Eastman
  *
  * Permission is hereby granted, free of charge, to any person obtaining
@@ -127,7 +127,7 @@ void ReferenceCustomCompoundBondIxn::calculateOneIxn(int bond, vector<RealVec>& 
     const vector<int>& atoms = bondAtoms[bond];
     for (int i = 0; i < (int) particleTerms.size(); i++) {
         const ParticleTermInfo& term = particleTerms[i];
-        variables[term.name] = atomCoordinates[term.atom][term.component];
+        variables[term.name] = atomCoordinates[atoms[term.atom]][term.component];
     }
     for (int i = 0; i < (int) distanceTerms.size(); i++) {
         const DistanceTermInfo& term = distanceTerms[i];

--- a/platforms/reference/tests/TestReferenceCustomCompoundBondForce.cpp
+++ b/platforms/reference/tests/TestReferenceCustomCompoundBondForce.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2012 Stanford University and the Authors.           *
+ * Portions copyright (c) 2012-2015 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -153,21 +153,21 @@ void testPositionDependence() {
     custom->addGlobalParameter("scale1", 0.3);
     custom->addGlobalParameter("scale2", 0.2);
     vector<int> particles(2);
-    particles[0] = 0;
-    particles[1] = 1;
+    particles[0] = 1;
+    particles[1] = 0;
     vector<double> parameters;
     custom->addBond(particles, parameters);
     customSystem.addForce(custom);
     vector<Vec3> positions(2);
-    positions[0] = Vec3(0.5, 1, 0);
-    positions[1] = Vec3(1.5, 1, 0);
+    positions[0] = Vec3(1.5, 1, 0);
+    positions[1] = Vec3(0.5, 1, 0);
     VerletIntegrator integrator(0.01);
     Context context(customSystem, integrator, platform);
     context.setPositions(positions);
     State state = context.getState(State::Forces | State::Energy);
     ASSERT_EQUAL_TOL(0.3*1.0+0.2*0.5+2*1, state.getPotentialEnergy(), 1e-5);
-    ASSERT_EQUAL_VEC(Vec3(0.3-0.2, 0, 0), state.getForces()[0], 1e-5);
-    ASSERT_EQUAL_VEC(Vec3(-0.3, -2, 0), state.getForces()[1], 1e-5);
+    ASSERT_EQUAL_VEC(Vec3(-0.3, -2, 0), state.getForces()[0], 1e-5);
+    ASSERT_EQUAL_VEC(Vec3(0.3-0.2, 0, 0), state.getForces()[1], 1e-5);
 }
 
 void testContinuous2DFunction() {


### PR DESCRIPTION
This bug affected CustomCompoundBondForce in the Reference and CPU platforms.  It occurred when the energy expression explicitly depended on the x, y, and z coordinates of an atom.  The coordinates of the wrong atom were being used for those variables.