### PR TITLE
Check whether atom number is out of range in 'Add bonds' section

### DIFF
--- a/wrappers/python/simtk/openmm/app/amberprmtopfile.py
+++ b/wrappers/python/simtk/openmm/app/amberprmtopfile.py
@@ -134,7 +134,8 @@ class AmberPrmtopFile(object):
 
         atoms = list(top.atoms())
         for bond in prmtop.getBondsWithH():
-            top.addBond(atoms[bond[0]], atoms[bond[1]])
+	        if bond[0] < len(list(top.atoms())):
+				top.addBond(atoms[bond[0]], atoms[bond[1]])
         for bond in prmtop.getBondsNoH():
             top.addBond(atoms[bond[0]], atoms[bond[1]])
 


### PR DESCRIPTION
When attempting to load a water-stripped Amber .prmtop file, ''' top.addBond(atoms[bond[0]], atoms[bond[1]])''' aborts with an 'index out of range' error.

This concerns .prmtop files that are edited with the rdparm tool of Amber12 and earlier. I have to check whether this is different in Amber14.

Reason: Stripping of water molecules does not remove the corresponding BondsWithH entries in the .prmtop file. Thus the error when atoms[bond[0]] and atoms[bond[1]] are encountered that belong to the stripped water molecules.

One solution that has worked for me so far is to skip those entries when adding bonds to top.