### PR TITLE
Variable step size integrators were scaling the step size incorrectly

### DIFF
--- a/platforms/cuda/src/kernels/langevin.cu
+++ b/platforms/cuda/src/kernels/langevin.cu
@@ -90,7 +90,7 @@ extern "C" __global__ void selectLangevinStepSize(int numAtoms, int paddedNumAto
     while (index < numAtoms) {
         mixed3 f = make_mixed3(scale*force[index], scale*force[index+paddedNumAtoms], scale*force[index+paddedNumAtoms*2]);
         mixed invMass = velm[index].w;
-        err += (f.x*f.x + f.y*f.y + f.z*f.z)*invMass;
+        err += (f.x*f.x + f.y*f.y + f.z*f.z)*invMass*invMass;
         index += blockDim.x*gridDim.x;
     }
     error[threadIdx.x] = err;

--- a/platforms/cuda/src/kernels/verlet.cu
+++ b/platforms/cuda/src/kernels/verlet.cu
@@ -89,7 +89,7 @@ extern "C" __global__ void selectVerletStepSize(int numAtoms, int paddedNumAtoms
     for (int index = threadIdx.x; index < numAtoms; index += blockDim.x*gridDim.x) {
         mixed3 f = make_mixed3(scale*force[index], scale*force[index+paddedNumAtoms], scale*force[index+paddedNumAtoms*2]);
         mixed invMass = velm[index].w;
-        err += (f.x*f.x + f.y*f.y + f.z*f.z)*invMass;
+        err += (f.x*f.x + f.y*f.y + f.z*f.z)*invMass*invMass;
     }
     error[threadIdx.x] = err;
     __syncthreads();

--- a/platforms/opencl/src/kernels/langevin.cl
+++ b/platforms/opencl/src/kernels/langevin.cl
@@ -81,7 +81,7 @@ __kernel void selectLangevinStepSize(mixed maxStepSize, mixed errorTol, mixed ta
     while (index < NUM_ATOMS) {
         real4 f = force[index];
         mixed invMass = velm[index].w;
-        err += (f.x*f.x + f.y*f.y + f.z*f.z)*invMass;
+        err += (f.x*f.x + f.y*f.y + f.z*f.z)*invMass*invMass;
         index += get_global_size(0);
     }
     error[get_local_id(0)] = err;

--- a/platforms/opencl/src/kernels/verlet.cl
+++ b/platforms/opencl/src/kernels/verlet.cl
@@ -85,7 +85,7 @@ __kernel void selectVerletStepSize(int numAtoms, mixed maxStepSize, mixed errorT
     while (index < numAtoms) {
         real4 f = force[index];
         mixed invMass = velm[index].w;
-        err += (f.x*f.x + f.y*f.y + f.z*f.z)*invMass;
+        err += (f.x*f.x + f.y*f.y + f.z*f.z)*invMass*invMass;
         index += get_global_size(0);
     }
     error[get_local_id(0)] = err;


### PR DESCRIPTION
The effect of this bug is a bit subtle.  It was still choosing the step size to reduce error, and lowering the error tolerance still affected the step size in the correct way.  But the contribution of each atom to the error was scale by sqrt(mass).  As a result, the step size was always set slightly smaller than it should have been.

This was only in the CUDA and OpenCL platforms.  The Reference and CPU platforms calculated it correctly (that is, following the equations in the manual).