### PR TITLE
Check for nan positions was being done incorrectly

### DIFF
--- a/platforms/cpu/src/CpuKernels.cpp
+++ b/platforms/cpu/src/CpuKernels.cpp
@@ -169,8 +169,8 @@ public:
         
         // Check for invalid positions.
         
-        for (int i = 4*start; i < 4*end; i++)
-            if (posq[i] != posq[i])
+        for (int i = 4*start; i < 4*end; i += 4)
+            if (posq[i] != posq[i] || posq[i+1] != posq[i+1] || posq[i+2] != posq[i+2])
                 positionsValid = false;
 
         // Clear the forces.


### PR DESCRIPTION
In addition to checking the positions, it was also checking if the particle charges were nan.  That was generally harmless, except if the system didn't contain a NonbondedForce.  In that case, they would never have been set and could easily be nan.  This was causing TestCpuCustomNonbondedForce to fail.