### PR TITLE
Fixes vs2013 warnings 4251, 4267 in lepton.

### DIFF
--- a/libraries/lepton/include/lepton/windowsIncludes.h
+++ b/libraries/lepton/include/lepton/windowsIncludes.h
@@ -25,14 +25,14 @@
 #ifdef _MSC_VER
     // We don't want to hear about how sprintf is "unsafe".
     #pragma warning(disable:4996)
+    // Keep MS VC++ quiet about lack of dll export of private members.
+    #pragma warning(disable:4251)
     #if defined(LEPTON_BUILDING_SHARED_LIBRARY)
         #define LEPTON_EXPORT __declspec(dllexport)
-        // Keep MS VC++ quiet about lack of dll export of private members.
-        #pragma warning(disable:4251)
     #elif defined(LEPTON_BUILDING_STATIC_LIBRARY) || defined(LEPTON_USE_STATIC_LIBRARIES)
-		#define LEPTON_EXPORT
+        #define LEPTON_EXPORT
     #else
-		#define LEPTON_EXPORT __declspec(dllimport)   // i.e., a client of a shared library
+        #define LEPTON_EXPORT __declspec(dllimport)   // i.e., a client of a shared library
     #endif
 #else
     #define LEPTON_EXPORT // Linux, Mac

--- a/libraries/lepton/src/CompiledExpression.cpp
+++ b/libraries/lepton/src/CompiledExpression.cpp
@@ -121,7 +121,7 @@ void CompiledExpression::compileExpression(const ExpressionTreeNode& node, vecto
                 arguments[stepIndex] = args;
         }
     }
-    temps.push_back(make_pair(node, workspace.size()));
+    temps.push_back(make_pair(node, (int) workspace.size()));
     workspace.push_back(0.0);
 }
 


### PR DESCRIPTION
The pragma to ignore 4251 already existed in windowsIncludes.h, and it works
when compiling lepton itself. However, when clients use lepton, they get this
warning. I think this is why @sherm1 put the define as shown here:
https://github.com/simbody/simbody/blob/master/SimTKcommon/include/SimTKcommon/internal/common.h#L168
 (whether or not the shared library is being built or used).