### PR TITLE
Generalize Amoeba Stretch-Bend term

### DIFF
--- a/plugins/amoeba/openmmapi/include/openmm/AmoebaStretchBendForce.h
+++ b/plugins/amoeba/openmmapi/include/openmm/AmoebaStretchBendForce.h
@@ -76,7 +76,7 @@ public:
      * @return the index of the stretch-bend that was added
      */
     int addStretchBend(int particle1, int particle2, int particle3, double lengthAB,  double lengthCB, double angle,
-                       double k1, double k2=-1.0);
+                       double k1, double k2);
 
     /**
      * Get the force field parameters for a stretch-bend term.
@@ -108,7 +108,7 @@ public:
      * @param k2            the force constant of the product of bond bc and angle a-b-c (optional, default is the same as k1)
      */
     void setStretchBendParameters(int index, int particle1, int particle2, int particle3, 
-                                  double lengthAB,  double lengthCB, double angle, double k1, double k2=-1.0 );
+                                  double lengthAB,  double lengthCB, double angle, double k1, double k2);
     /**
      * Update the per-stretch-bend term parameters in a Context to match those stored in this Force object.  This method provides
      * an efficient method to update certain parameters in an existing Context without needing to reinitialize it.

--- a/plugins/amoeba/openmmapi/include/openmm/AmoebaStretchBendForce.h
+++ b/plugins/amoeba/openmmapi/include/openmm/AmoebaStretchBendForce.h
@@ -95,6 +95,24 @@ public:
                                   double& lengthCB, double& angle, double& k1, double& k2) const;
 
     /**
+     * Get the force field parameters for a stretch-bend term, provided for
+     * backwards-compatibility. Since the two force constants may be different,
+     * you are recommended to call the other version of getStretchBendParameters
+     * with both a k1 and k2
+     * 
+     * @param index         the index of the stretch-bend for which to get parameters
+     * @param particle1     the index of the first particle connected by the stretch-bend
+     * @param particle2     the index of the second particle connected by the stretch-bend
+     * @param particle3     the index of the third particle connected by the stretch-bend
+     * @param lengthAB      the equilibrium length of the stretch-bend in bond ab [particle1, particle2], measured in nm
+     * @param lengthCB      the equilibrium length of the stretch-bend in bond cb [particle3, particle2], measured in nm
+     * @param angle         the equilibrium angle in radians
+     * @param k1            the force constant
+     */
+    void getStretchBendParameters(int index, int& particle1, int& particle2, int& particle3, double& lengthAB,
+                                  double& lengthCB, double& angle, double& k1) const;
+
+    /**
      * Set the force field parameters for a stretch-bend term.
      * 
      * @param index         the index of the stretch-bend for which to set parameters

--- a/plugins/amoeba/openmmapi/include/openmm/AmoebaStretchBendForce.h
+++ b/plugins/amoeba/openmmapi/include/openmm/AmoebaStretchBendForce.h
@@ -95,24 +95,6 @@ public:
                                   double& lengthCB, double& angle, double& k1, double& k2) const;
 
     /**
-     * Get the force field parameters for a stretch-bend term, provided for
-     * backwards-compatibility. Since the two force constants may be different,
-     * you are recommended to call the other version of getStretchBendParameters
-     * with both a k1 and k2
-     * 
-     * @param index         the index of the stretch-bend for which to get parameters
-     * @param particle1     the index of the first particle connected by the stretch-bend
-     * @param particle2     the index of the second particle connected by the stretch-bend
-     * @param particle3     the index of the third particle connected by the stretch-bend
-     * @param lengthAB      the equilibrium length of the stretch-bend in bond ab [particle1, particle2], measured in nm
-     * @param lengthCB      the equilibrium length of the stretch-bend in bond cb [particle3, particle2], measured in nm
-     * @param angle         the equilibrium angle in radians
-     * @param k1            the force constant
-     */
-    void getStretchBendParameters(int index, int& particle1, int& particle2, int& particle3, double& lengthAB,
-                                  double& lengthCB, double& angle, double& k1) const;
-
-    /**
      * Set the force field parameters for a stretch-bend term.
      * 
      * @param index         the index of the stretch-bend for which to set parameters

--- a/plugins/amoeba/openmmapi/include/openmm/AmoebaStretchBendForce.h
+++ b/plugins/amoeba/openmmapi/include/openmm/AmoebaStretchBendForce.h
@@ -71,11 +71,12 @@ public:
      * @param lengthAB      the equilibrium length of the stretch-bend in bond ab [particle1, particle2], measured in nm
      * @param lengthCB      the equilibrium length of the stretch-bend in bond cb [particle3, particle2], measured in nm
      * @param angle         the equilibrium angle in radians
-     * @param k             the force constant for the stretch-bend
+     * @param k1            the force constant of the product of bond ab and angle a-b-c
+     * @param k2            the force constant of the product of bond bc and angle a-b-c (optional, default is the same as k1)
      * @return the index of the stretch-bend that was added
      */
     int addStretchBend(int particle1, int particle2, int particle3, double lengthAB,  double lengthCB, double angle,
-                       double k );
+                       double k1, double k2=-1.0);
 
     /**
      * Get the force field parameters for a stretch-bend term.
@@ -87,10 +88,11 @@ public:
      * @param lengthAB      the equilibrium length of the stretch-bend in bond ab [particle1, particle2], measured in nm
      * @param lengthCB      the equilibrium length of the stretch-bend in bond cb [particle3, particle2], measured in nm
      * @param angle         the equilibrium angle in radians
-     * @param k             the force constant for the stretch-bend
+     * @param k1            the force constant of the product of bond ab and angle a-b-c
+     * @param k2            the force constant of the product of bond bc and angle a-b-c
      */
-    void getStretchBendParameters(int index, int& particle1, int& particle2, int& particle3,
-                                  double& lengthAB, double& lengthCB, double& angle, double& k ) const;
+    void getStretchBendParameters(int index, int& particle1, int& particle2, int& particle3, double& lengthAB,
+                                  double& lengthCB, double& angle, double& k1, double& k2) const;
 
     /**
      * Set the force field parameters for a stretch-bend term.
@@ -102,10 +104,11 @@ public:
      * @param lengthAB      the equilibrium length of the stretch-bend in bond ab [particle1, particle2], measured in nm
      * @param lengthCB      the equilibrium length of the stretch-bend in bond cb [particle3, particle2], measured in nm
      * @param angle         the equilibrium angle in radians
-     * @param k             the force constant for the stretch-bend
+     * @param k1            the force constant of the product of bond ab and angle a-b-c
+     * @param k2            the force constant of the product of bond bc and angle a-b-c (optional, default is the same as k1)
      */
     void setStretchBendParameters(int index, int particle1, int particle2, int particle3, 
-                                  double lengthAB,  double lengthCB, double angle, double k );
+                                  double lengthAB,  double lengthCB, double angle, double k1, double k2=-1.0 );
     /**
      * Update the per-stretch-bend term parameters in a Context to match those stored in this Force object.  This method provides
      * an efficient method to update certain parameters in an existing Context without needing to reinitialize it.
@@ -139,16 +142,15 @@ private:
 class AmoebaStretchBendForce::StretchBendInfo {
 public:
     int particle1, particle2, particle3;
-    double lengthAB, lengthCB, angle, k;
+    double lengthAB, lengthCB, angle, k1, k2;
     StretchBendInfo() {
         particle1 = particle2  = particle3 = -1;
-        lengthAB  = lengthCB   = angle     = k   = 0.0;
+        lengthAB  = lengthCB   = angle     = k1 = k2 = 0.0;
     }
     StretchBendInfo(int particle1, int particle2, int particle3, 
-                    double lengthAB,  double lengthCB, double angle, double k ) :
+                    double lengthAB,  double lengthCB, double angle, double k1, double k2 ) :
                     particle1(particle1), particle2(particle2), particle3(particle3), 
-                    lengthAB(lengthAB), lengthCB(lengthCB), angle(angle), k(k) {
-     
+                    lengthAB(lengthAB), lengthCB(lengthCB), angle(angle), k1(k1), k2(k2) {
     }
 };
 

--- a/plugins/amoeba/openmmapi/src/AmoebaStretchBendForce.cpp
+++ b/plugins/amoeba/openmmapi/src/AmoebaStretchBendForce.cpp
@@ -41,7 +41,6 @@ AmoebaStretchBendForce::AmoebaStretchBendForce() {
 
 int AmoebaStretchBendForce::addStretchBend(int particle1, int particle2, int particle3,
                                            double lengthAB,  double lengthCB, double angle, double k1, double k2) {
-    if (k2 == -1.0) k2 = k1;
     stretchBends.push_back(StretchBendInfo(particle1, particle2, particle3, lengthAB,  lengthCB, angle, k1, k2));
     return stretchBends.size()-1;
 }
@@ -67,10 +66,7 @@ void AmoebaStretchBendForce::setStretchBendParameters(int index, int particle1, 
     stretchBends[index].lengthCB   = lengthCB;
     stretchBends[index].angle      = angle;
     stretchBends[index].k1         = k1;
-    if (k2 == -1.0)
-        stretchBends[index].k2     = k1;
-    else
-        stretchBends[index].k2     = k2;
+    stretchBends[index].k2         = k2;
 }
 
 ForceImpl* AmoebaStretchBendForce::createImpl() const {

--- a/plugins/amoeba/openmmapi/src/AmoebaStretchBendForce.cpp
+++ b/plugins/amoeba/openmmapi/src/AmoebaStretchBendForce.cpp
@@ -41,7 +41,7 @@ AmoebaStretchBendForce::AmoebaStretchBendForce() {
 
 int AmoebaStretchBendForce::addStretchBend(int particle1, int particle2, int particle3,
                                            double lengthAB,  double lengthCB, double angle, double k1, double k2) {
-    if (k2 == -1.0) k2 = k1
+    if (k2 == -1.0) k2 = k1;
     stretchBends.push_back(StretchBendInfo(particle1, particle2, particle3, lengthAB,  lengthCB, angle, k1, k2));
     return stretchBends.size()-1;
 }

--- a/plugins/amoeba/openmmapi/src/AmoebaStretchBendForce.cpp
+++ b/plugins/amoeba/openmmapi/src/AmoebaStretchBendForce.cpp
@@ -40,31 +40,37 @@ AmoebaStretchBendForce::AmoebaStretchBendForce() {
 }
 
 int AmoebaStretchBendForce::addStretchBend(int particle1, int particle2, int particle3,
-                                           double lengthAB,  double lengthCB, double angle, double k) {
-    stretchBends.push_back(StretchBendInfo(particle1, particle2, particle3, lengthAB,  lengthCB, angle, k));
+                                           double lengthAB,  double lengthCB, double angle, double k1, double k2) {
+    if (k2 == -1.0) k2 = k1
+    stretchBends.push_back(StretchBendInfo(particle1, particle2, particle3, lengthAB,  lengthCB, angle, k1, k2));
     return stretchBends.size()-1;
 }
 
 void AmoebaStretchBendForce::getStretchBendParameters(int index, int& particle1, int& particle2, int& particle3,
-                                                      double& lengthAB, double& lengthCB, double& angle, double& k ) const {
+                                                      double& lengthAB, double& lengthCB, double& angle, double& k1, double& k2 ) const {
     particle1       = stretchBends[index].particle1;
     particle2       = stretchBends[index].particle2;
     particle3       = stretchBends[index].particle3;
     lengthAB        = stretchBends[index].lengthAB;
     lengthCB        = stretchBends[index].lengthCB;
     angle           = stretchBends[index].angle;
-    k               = stretchBends[index].k;
+    k1              = stretchBends[index].k1;
+    k2              = stretchBends[index].k2;
 }
 
-void AmoebaStretchBendForce::setStretchBendParameters(int index, int particle1, int particle2, int particle3, 
-                                                      double lengthAB,  double lengthCB, double angle, double k) {
+void AmoebaStretchBendForce::setStretchBendParameters(int index, int particle1, int particle2, int particle3,
+                                                      double lengthAB,  double lengthCB, double angle, double k1, double k2) {
     stretchBends[index].particle1  = particle1;
     stretchBends[index].particle2  = particle2;
     stretchBends[index].particle3  = particle3;
     stretchBends[index].lengthAB   = lengthAB;
     stretchBends[index].lengthCB   = lengthCB;
     stretchBends[index].angle      = angle;
-    stretchBends[index].k          = k;
+    stretchBends[index].k1         = k1;
+    if (k2 == -1.0)
+        stretchBends[index].k2     = k1;
+    else
+        stretchBends[index].k2     = k2;
 }
 
 ForceImpl* AmoebaStretchBendForce::createImpl() const {

--- a/plugins/amoeba/platforms/cuda/src/AmoebaCudaKernels.cpp
+++ b/plugins/amoeba/platforms/cuda/src/AmoebaCudaKernels.cpp
@@ -483,7 +483,7 @@ private:
 };
 
 CudaCalcAmoebaStretchBendForceKernel::CudaCalcAmoebaStretchBendForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system) :
-                   CalcAmoebaStretchBendForceKernel(name, platform), cu(cu), system(system), params(NULL) {
+                   CalcAmoebaStretchBendForceKernel(name, platform), cu(cu), system(system), params1(NULL), params2(NULL) {
 }
 
 CudaCalcAmoebaStretchBendForceKernel::~CudaCalcAmoebaStretchBendForceKernel() {
@@ -539,14 +539,17 @@ void CudaCalcAmoebaStretchBendForceKernel::copyParametersToContext(ContextImpl& 
     
     // Record the per-stretch-bend parameters.
     
-    vector<float4> paramVector(numStretchBends);
+    vector<float3> paramVector(numStretchBends);
+    vector<float2> paramVector1(numStretchBends);
     for (int i = 0; i < numStretchBends; i++) {
         int atom1, atom2, atom3;
-        double lengthAB, lengthCB, angle, k;
-        force.getStretchBendParameters(startIndex+i, atom1, atom2, atom3, lengthAB, lengthCB, angle, k);
-        paramVector[i] = make_float4((float) lengthAB, (float) lengthCB, (float) angle, (float) k);
+        double lengthAB, lengthCB, angle, k1, k2;
+        force.getStretchBendParameters(startIndex+i, atom1, atom2, atom3, lengthAB, lengthCB, angle, k1, k2);
+        paramVector[i] = make_float3((float) lengthAB, (float) lengthCB, (float) angle);
+        paramVector1[i] = make_flaot2((float) k1, (float) k2);
     }
-    params->upload(paramVector);
+    params1->upload(paramVector);
+    params2->upload(paramVector1);
     
     // Mark that the current reordering may be invalid.
     

--- a/plugins/amoeba/platforms/cuda/src/AmoebaCudaKernels.cpp
+++ b/plugins/amoeba/platforms/cuda/src/AmoebaCudaKernels.cpp
@@ -546,7 +546,7 @@ void CudaCalcAmoebaStretchBendForceKernel::copyParametersToContext(ContextImpl& 
         double lengthAB, lengthCB, angle, k1, k2;
         force.getStretchBendParameters(startIndex+i, atom1, atom2, atom3, lengthAB, lengthCB, angle, k1, k2);
         paramVector[i] = make_float3((float) lengthAB, (float) lengthCB, (float) angle);
-        paramVector1[i] = make_flaot2((float) k1, (float) k2);
+        paramVector1[i] = make_float2((float) k1, (float) k2);
     }
     params1->upload(paramVector);
     params2->upload(paramVector1);

--- a/plugins/amoeba/platforms/cuda/src/AmoebaCudaKernels.h
+++ b/plugins/amoeba/platforms/cuda/src/AmoebaCudaKernels.h
@@ -229,7 +229,8 @@ private:
     int numStretchBends;
     CudaContext& cu;
     const System& system;
-    CudaArray* params;
+    CudaArray* params1; // Equilibrium values
+    CudaArray* params2; // force constants
 };
 
 /**

--- a/plugins/amoeba/platforms/cuda/src/kernels/amoebaStretchBendForce.cu
+++ b/plugins/amoeba/platforms/cuda/src/kernels/amoebaStretchBendForce.cu
@@ -64,6 +64,6 @@ real ddrdzic = termc * zcb;
 
 energy += dt*drkk;
 
-real3 force1 = make_real3(-frc1*dt*ddrdxia+ddtdxia*drkk, -frc1*dt*ddrdyia+ddtdyia*drkk, -frc1*dt*ddrdzia+ddtdzia*drkk);
-real3 force3 = make_real3(-frc2*dt*ddrdxic+ddtdxic*drkk, -frc2*dt*ddrdyic+ddtdyic*drkk, -frc2*dt*ddrdzic+ddtdzic*drkk);
+real3 force1 = make_real3(-frc1*dt*ddrdxia-ddtdxia*drkk, -frc1*dt*ddrdyia-ddtdyia*drkk, -frc1*dt*ddrdzia-ddtdzia*drkk);
+real3 force3 = make_real3(-frc2*dt*ddrdxic-ddtdxic*drkk, -frc2*dt*ddrdyic-ddtdyic*drkk, -frc2*dt*ddrdzic-ddtdzic*drkk);
 real3 force2 = make_real3(-force1.x-force3.x, -force1.y-force3.y, -force1.z-force3.z);

--- a/plugins/amoeba/platforms/cuda/tests/TestCudaAmoebaStretchBendForce.cpp
+++ b/plugins/amoeba/platforms/cuda/tests/TestCudaAmoebaStretchBendForce.cpp
@@ -276,7 +276,7 @@ void testOneStretchBend( FILE* log ) {
     //double kStretchBend     = 0.750491578E-01;
     double kStretchBend     = 1.0;
 
-    amoebaStretchBendForce->addStretchBend(0, 1, 2, abLength, cbLength, angleStretchBend, kStretchBend );
+    amoebaStretchBendForce->addStretchBend(0, 1, 2, abLength, cbLength, angleStretchBend, kStretchBend, kStretchBend );
 
     system.addForce(amoebaStretchBendForce);
     Context context(system, integrator, Platform::getPlatformByName( "CUDA"));
@@ -292,7 +292,7 @@ void testOneStretchBend( FILE* log ) {
     
     // Try changing the stretch-bend parameters and make sure it's still correct.
     
-    amoebaStretchBendForce->setStretchBendParameters(0, 0, 1, 2, 1.1*abLength, 1.2*cbLength, 1.3*angleStretchBend, 1.4*kStretchBend);
+    amoebaStretchBendForce->setStretchBendParameters(0, 0, 1, 2, 1.1*abLength, 1.2*cbLength, 1.3*angleStretchBend, 1.4*kStretchBend, 1.4*kStretchBend);
     bool exceptionThrown = false;
     try {
         // This should throw an exception.

--- a/plugins/amoeba/platforms/cuda/tests/TestCudaAmoebaStretchBendForce.cpp
+++ b/plugins/amoeba/platforms/cuda/tests/TestCudaAmoebaStretchBendForce.cpp
@@ -82,14 +82,14 @@ static void computeAmoebaStretchBendForce(int bondIndex,  std::vector<Vec3>& pos
                                           std::vector<Vec3>& forces, double* energy, FILE* log ) {
 
     int particle1, particle2, particle3;
-    double abBondLength, cbBondLength, angleStretchBend, kStretchBend;
+    double abBondLength, cbBondLength, angleStretchBend, kStretchBend, k2StretchBend;
 
-    amoebaStretchBendForce.getStretchBendParameters(bondIndex, particle1, particle2, particle3, abBondLength, cbBondLength, angleStretchBend, kStretchBend);
+    amoebaStretchBendForce.getStretchBendParameters(bondIndex, particle1, particle2, particle3, abBondLength, cbBondLength, angleStretchBend, kStretchBend, k2StretchBend);
     angleStretchBend *= RADIAN;
 #ifdef AMOEBA_DEBUG
     if( log ){
-        (void) fprintf( log, "computeAmoebaStretchBendForce: bond %d [%d %d %d] ab=%10.3e cb=%10.3e angle=%10.3e k=%10.3e\n", 
-                             bondIndex, particle1, particle2, particle3, abBondLength, cbBondLength, angleStretchBend, kStretchBend );
+        (void) fprintf( log, "computeAmoebaStretchBendForce: bond %d [%d %d %d] ab=%10.3e cb=%10.3e angle=%10.3e k1=%10.3e k2=%10.3e\n",
+                             bondIndex, particle1, particle2, particle3, abBondLength, cbBondLength, angleStretchBend, kStretchBend, k2StretchBend );
         (void) fflush( log );
     }
 #endif
@@ -128,9 +128,11 @@ static void computeAmoebaStretchBendForce(int bondIndex,  std::vector<Vec3>& pos
     double angle;
     if( cosine >= 1.0 ){
        angle = 0.0;
-    } else if( cosine <= -1.0 ){
+    }
+    else if( cosine <= -1.0 ){
        angle = PI_M;
-    } else {
+    }
+    else {
        angle = RADIAN*acos(cosine);
     }
  
@@ -146,12 +148,13 @@ static void computeAmoebaStretchBendForce(int bondIndex,  std::vector<Vec3>& pos
        deltaR[CBxP][ii] *= termC;
     }
  
-    double dr    = rAB - abBondLength + rCB - cbBondLength;
+    double dr1   = rAB - abBondLength;
+    double dr2   = rCB - cbBondLength;
  
     termA        = 1.0/rAB;
     termC        = 1.0/rCB;
  
-    double term  = kStretchBend;
+    double drkk = dr1 * kStretchBend + dr2 * k2StretchBend;
  
     // ---------------------------------------------------------------------------------------
  
@@ -163,8 +166,8 @@ static void computeAmoebaStretchBendForce(int bondIndex,  std::vector<Vec3>& pos
     double subForce[LastAtomIndex][3];
     double dt = angle - angleStretchBend;
     for( int jj = 0; jj < 3; jj++ ){
-        subForce[A][jj] = term*(dt*termA*deltaR[AB][jj] + dr*deltaR[ABxP][jj] );
-        subForce[C][jj] = term*(dt*termC*deltaR[CB][jj] + dr*deltaR[CBxP][jj] );
+        subForce[A][jj] = kStretchBend*dt*termA*deltaR[AB][jj] + drkk*deltaR[ABxP][jj];
+        subForce[C][jj] = k2StretchBend*dt*termC*deltaR[CB][jj] + drkk*deltaR[CBxP][jj];
         subForce[B][jj] = -( subForce[A][jj] + subForce[C][jj] );
     }
  
@@ -184,8 +187,7 @@ static void computeAmoebaStretchBendForce(int bondIndex,  std::vector<Vec3>& pos
     forces[particle3][1]       -= subForce[2][1];
     forces[particle3][2]       -= subForce[2][2];
 
-    *energy                    += term*dt*dr;
-
+    *energy                    += dt*drkk;
 #ifdef AMOEBA_DEBUG
     if( log ){
         (void) fprintf( log, "computeAmoebaStretchBendForce: angle=%10.3e dt=%10.3e dr=%10.3e\n", angle, dt, dr ); 

--- a/plugins/amoeba/platforms/reference/src/AmoebaReferenceKernels.cpp
+++ b/plugins/amoeba/platforms/reference/src/AmoebaReferenceKernels.cpp
@@ -346,7 +346,7 @@ void ReferenceCalcAmoebaStretchBendForceKernel::copyParametersToContext(ContextI
         lengthCBParameters[i] = (RealOpenMM) lengthCB;
         angleParameters[i] = (RealOpenMM) angle;
         k1Parameters[i] = (RealOpenMM) k1;
-        k1Parameters[i] = (RealOpenMM) k2;
+        k2Parameters[i] = (RealOpenMM) k2;
     }
 }
 

--- a/plugins/amoeba/platforms/reference/src/AmoebaReferenceKernels.cpp
+++ b/plugins/amoeba/platforms/reference/src/AmoebaReferenceKernels.cpp
@@ -307,15 +307,16 @@ void ReferenceCalcAmoebaStretchBendForceKernel::initialize(const System& system,
     numStretchBends = force.getNumStretchBends();
     for ( int ii = 0; ii < numStretchBends; ii++) {
         int particle1Index, particle2Index, particle3Index;
-        double lengthAB, lengthCB, angle, k;
-        force.getStretchBendParameters(ii, particle1Index, particle2Index, particle3Index, lengthAB, lengthCB, angle, k);
+        double lengthAB, lengthCB, angle, k1, k2;
+        force.getStretchBendParameters(ii, particle1Index, particle2Index, particle3Index, lengthAB, lengthCB, angle, k1, k2);
         particle1.push_back( particle1Index ); 
         particle2.push_back( particle2Index ); 
         particle3.push_back( particle3Index ); 
         lengthABParameters.push_back( static_cast<RealOpenMM>(lengthAB) );
         lengthCBParameters.push_back( static_cast<RealOpenMM>(lengthCB) );
         angleParameters.push_back(    static_cast<RealOpenMM>(angle) );
-        kParameters.push_back(        static_cast<RealOpenMM>(k) );
+        k1Parameters.push_back(       static_cast<RealOpenMM>(k1) );
+        k2Parameters.push_back(       static_cast<RealOpenMM>(k2) );
     }
 }
 
@@ -324,7 +325,8 @@ double ReferenceCalcAmoebaStretchBendForceKernel::execute(ContextImpl& context, 
     vector<RealVec>& forceData = extractForces(context);
     AmoebaReferenceStretchBendForce amoebaReferenceStretchBendForce;
     RealOpenMM energy      = amoebaReferenceStretchBendForce.calculateForceAndEnergy( numStretchBends, posData, particle1, particle2, particle3,
-                                                                                      lengthABParameters, lengthCBParameters, angleParameters, kParameters, forceData );
+                                                                                      lengthABParameters, lengthCBParameters, angleParameters, k1Parameters,
+                                                                                      k2Parameters, forceData );
     return static_cast<double>(energy);
 }
 
@@ -336,14 +338,15 @@ void ReferenceCalcAmoebaStretchBendForceKernel::copyParametersToContext(ContextI
 
     for (int i = 0; i < numStretchBends; ++i) {
         int particle1Index, particle2Index, particle3Index;
-        double lengthAB, lengthCB, angle, k;
-        force.getStretchBendParameters(i, particle1Index, particle2Index, particle3Index, lengthAB, lengthCB, angle, k);
+        double lengthAB, lengthCB, angle, k1, k2;
+        force.getStretchBendParameters(i, particle1Index, particle2Index, particle3Index, lengthAB, lengthCB, angle, k1, k2);
         if (particle1Index != particle1[i] || particle2Index != particle2[i] || particle3Index != particle3[i])
             throw OpenMMException("updateParametersInContext: The set of particles in a stretch-bend has changed");
         lengthABParameters[i] = (RealOpenMM) lengthAB;
         lengthCBParameters[i] = (RealOpenMM) lengthCB;
         angleParameters[i] = (RealOpenMM) angle;
-        kParameters[i] = (RealOpenMM) k;
+        k1Parameters[i] = (RealOpenMM) k1;
+        k1Parameters[i] = (RealOpenMM) k2;
     }
 }
 

--- a/plugins/amoeba/platforms/reference/src/AmoebaReferenceKernels.h
+++ b/plugins/amoeba/platforms/reference/src/AmoebaReferenceKernels.h
@@ -248,7 +248,8 @@ private:
     std::vector<RealOpenMM> lengthABParameters;
     std::vector<RealOpenMM> lengthCBParameters;
     std::vector<RealOpenMM> angleParameters;
-    std::vector<RealOpenMM> kParameters;
+    std::vector<RealOpenMM> k1Parameters;
+    std::vector<RealOpenMM> k2Parameters;
     const System& system;
 };
 

--- a/plugins/amoeba/platforms/reference/src/SimTKReference/AmoebaReferenceStretchBendForce.cpp
+++ b/plugins/amoeba/platforms/reference/src/SimTKReference/AmoebaReferenceStretchBendForce.cpp
@@ -53,7 +53,7 @@ RealOpenMM AmoebaReferenceStretchBendForce::calculateStretchBendIxn( const RealV
                                                                      const RealVec& positionAtomC,
                                                                      RealOpenMM lengthAB,      RealOpenMM lengthCB,
                                                                      RealOpenMM idealAngle,    RealOpenMM kParameter,
-                                                                     RealVec* forces ) const {
+                                                                     RealOpenMM k2Parameter, RealVec* forces ) const {
 
    // ---------------------------------------------------------------------------------------
 
@@ -112,7 +112,9 @@ RealOpenMM AmoebaReferenceStretchBendForce::calculateStretchBendIxn( const RealV
        deltaR[CBxP][ii] *= termC;
     }
  
-    RealOpenMM dr    = rAB - lengthAB + rCB - lengthCB;
+    RealOpenMM dr1   = rAB - lengthAB;
+    RealOpenMM dr2   = rCB - lengthCB;
+    RealOpenMM drkk  = dr1*k1Parameter + dr2*k2Parameter;
     termA            = one/rAB;
     termC            = one/rCB;
  
@@ -129,8 +131,8 @@ RealOpenMM AmoebaReferenceStretchBendForce::calculateStretchBendIxn( const RealV
     }
     RealOpenMM dt = angle - idealAngle*RADIAN;
     for( int jj = 0; jj < 3; jj++ ){
-       subForce[A][jj] = kParameter*(dt*termA*deltaR[AB][jj] + dr*deltaR[ABxP][jj] );
-       subForce[C][jj] = kParameter*(dt*termC*deltaR[CB][jj] + dr*deltaR[CBxP][jj] );
+       subForce[A][jj] = k1Parameter*dt*termA*deltaR[AB][jj] + drkk*deltaR[ABxP][jj];
+       subForce[C][jj] = k2Parameter*dt*termC*deltaR[CB][jj] + drkk*deltaR[CBxP][jj];
        subForce[B][jj] = -( subForce[A][jj] + subForce[C][jj] );
     }
  
@@ -144,7 +146,7 @@ RealOpenMM AmoebaReferenceStretchBendForce::calculateStretchBendIxn( const RealV
  
     // ---------------------------------------------------------------------------------------
  
-    return (kParameter*dt*dr);
+    return dt*drkk;
 }
 
 RealOpenMM AmoebaReferenceStretchBendForce::calculateForceAndEnergy( int numStretchBends, vector<RealVec>& posData,

--- a/plugins/amoeba/platforms/reference/src/SimTKReference/AmoebaReferenceStretchBendForce.cpp
+++ b/plugins/amoeba/platforms/reference/src/SimTKReference/AmoebaReferenceStretchBendForce.cpp
@@ -171,7 +171,7 @@ RealOpenMM AmoebaReferenceStretchBendForce::calculateForceAndEnergy( int numStre
         RealOpenMM angleK2      = k2Quadratic[ii];
         RealVec forces[3];
         energy                 += calculateStretchBendIxn( posData[particle1Index], posData[particle2Index], posData[particle3Index],
-                                                           abLength, cbLength, idealAngle, angleK1, anglek2, forces );
+                                                           abLength, cbLength, idealAngle, angleK1, angleK2, forces );
         // accumulate forces
     
         for( int jj = 0; jj < 3; jj++ ){

--- a/plugins/amoeba/platforms/reference/src/SimTKReference/AmoebaReferenceStretchBendForce.cpp
+++ b/plugins/amoeba/platforms/reference/src/SimTKReference/AmoebaReferenceStretchBendForce.cpp
@@ -52,7 +52,7 @@ using OpenMM::RealVec;
 RealOpenMM AmoebaReferenceStretchBendForce::calculateStretchBendIxn( const RealVec& positionAtomA, const RealVec& positionAtomB,
                                                                      const RealVec& positionAtomC,
                                                                      RealOpenMM lengthAB,      RealOpenMM lengthCB,
-                                                                     RealOpenMM idealAngle,    RealOpenMM kParameter,
+                                                                     RealOpenMM idealAngle,    RealOpenMM k1Parameter,
                                                                      RealOpenMM k2Parameter, RealVec* forces ) const {
 
    // ---------------------------------------------------------------------------------------
@@ -156,7 +156,8 @@ RealOpenMM AmoebaReferenceStretchBendForce::calculateForceAndEnergy( int numStre
                                                                        const std::vector<RealOpenMM>& lengthABParameters,
                                                                        const std::vector<RealOpenMM>& lengthCBParameters,
                                                                        const std::vector<RealOpenMM>&  angle,
-                                                                       const std::vector<RealOpenMM>&  kQuadratic,
+                                                                       const std::vector<RealOpenMM>&  k1Quadratic,
+                                                                       const std::vector<RealOpenMM>&  k2Quadratic,
                                                                        vector<RealVec>& forceData) const {
     RealOpenMM energy      = 0.0; 
     for (unsigned int ii = 0; ii < static_cast<unsigned int>(numStretchBends); ii++) {
@@ -166,10 +167,11 @@ RealOpenMM AmoebaReferenceStretchBendForce::calculateForceAndEnergy( int numStre
         RealOpenMM abLength     = lengthABParameters[ii];
         RealOpenMM cbLength     = lengthCBParameters[ii];
         RealOpenMM idealAngle   = angle[ii];
-        RealOpenMM angleK       = kQuadratic[ii];
+        RealOpenMM angleK1      = k1Quadratic[ii];
+        RealOpenMM angleK2      = k2Quadratic[ii];
         RealVec forces[3];
         energy                 += calculateStretchBendIxn( posData[particle1Index], posData[particle2Index], posData[particle3Index],
-                                                           abLength, cbLength, idealAngle, angleK, forces );
+                                                           abLength, cbLength, idealAngle, angleK1, anglek2, forces );
         // accumulate forces
     
         for( int jj = 0; jj < 3; jj++ ){

--- a/plugins/amoeba/platforms/reference/src/SimTKReference/AmoebaReferenceStretchBendForce.h
+++ b/plugins/amoeba/platforms/reference/src/SimTKReference/AmoebaReferenceStretchBendForce.h
@@ -94,7 +94,8 @@ private:
        @param lengthAB                ideal AB bondlength
        @param lengthCB                ideal CB bondlength
        @param idealAngle              ideal angle
-       @param kParameter              k
+       @param k1Parameter             k for distance A-B * angle A-B-C
+       @param k2Parameter             k for distance B-C * angle A-B-C
        @param forces                  force vector
     
        @return energy
@@ -104,8 +105,8 @@ private:
     RealOpenMM calculateStretchBendIxn( const OpenMM::RealVec& positionAtomA, const OpenMM::RealVec& positionAtomB,
                                         const OpenMM::RealVec& positionAtomC,
                                         RealOpenMM lengthAB,      RealOpenMM lengthCB,
-                                        RealOpenMM idealAngle,    RealOpenMM kParameter,
-                                        OpenMM::RealVec* forces ) const;
+                                        RealOpenMM idealAngle,    RealOpenMM k1Parameter,
+                                        RealOpenMM k2Parameter,   OpenMM::RealVec* forces ) const;
  
 };
 

--- a/plugins/amoeba/platforms/reference/src/SimTKReference/AmoebaReferenceStretchBendForce.h
+++ b/plugins/amoeba/platforms/reference/src/SimTKReference/AmoebaReferenceStretchBendForce.h
@@ -77,7 +77,8 @@ public:
                                         const std::vector<RealOpenMM>& lengthABParameters,
                                         const std::vector<RealOpenMM>& lengthCBParameters,
                                         const std::vector<RealOpenMM>&  angle,
-                                        const std::vector<RealOpenMM>&  kQuadratic,
+                                        const std::vector<RealOpenMM>&  k1Quadratic,
+                                        const std::vector<RealOpenMM>&  k2Quadratic,
                                         std::vector<OpenMM::RealVec>& forceData ) const;
 
 

--- a/plugins/amoeba/platforms/reference/tests/TestReferenceAmoebaStretchBendForce.cpp
+++ b/plugins/amoeba/platforms/reference/tests/TestReferenceAmoebaStretchBendForce.cpp
@@ -83,14 +83,14 @@ static void computeAmoebaStretchBendForce(int bondIndex,  std::vector<Vec3>& pos
                                           std::vector<Vec3>& forces, double* energy, FILE* log ) {
 
     int particle1, particle2, particle3;
-    double abBondLength, cbBondLength, angleStretchBend, kStretchBend;
+    double abBondLength, cbBondLength, angleStretchBend, kStretchBend, k2StretchBend;
 
-    amoebaStretchBendForce.getStretchBendParameters(bondIndex, particle1, particle2, particle3, abBondLength, cbBondLength, angleStretchBend, kStretchBend);
+    amoebaStretchBendForce.getStretchBendParameters(bondIndex, particle1, particle2, particle3, abBondLength, cbBondLength, angleStretchBend, kStretchBend, k2StretchBend);
     angleStretchBend *= RADIAN;
 #ifdef AMOEBA_DEBUG
     if( log ){
-        (void) fprintf( log, "computeAmoebaStretchBendForce: bond %d [%d %d %d] ab=%10.3e cb=%10.3e angle=%10.3e k=%10.3e\n", 
-                             bondIndex, particle1, particle2, particle3, abBondLength, cbBondLength, angleStretchBend, kStretchBend );
+        (void) fprintf( log, "computeAmoebaStretchBendForce: bond %d [%d %d %d] ab=%10.3e cb=%10.3e angle=%10.3e k1=%10.3e k2=%10.3e\n",
+                             bondIndex, particle1, particle2, particle3, abBondLength, cbBondLength, angleStretchBend, kStretchBend, k2StretchBend );
         (void) fflush( log );
     }
 #endif
@@ -149,12 +149,13 @@ static void computeAmoebaStretchBendForce(int bondIndex,  std::vector<Vec3>& pos
        deltaR[CBxP][ii] *= termC;
     }
  
-    double dr    = rAB - abBondLength + rCB - cbBondLength;
+    double dr1   = rAB - abBondLength;
+    double dr2   = rCB - cbBondLength;
  
     termA        = 1.0/rAB;
     termC        = 1.0/rCB;
  
-    double term  = kStretchBend;
+    double drkk = dr1 * kStretchBend + dr2 * k2StretchBend;
  
     // ---------------------------------------------------------------------------------------
  
@@ -166,8 +167,8 @@ static void computeAmoebaStretchBendForce(int bondIndex,  std::vector<Vec3>& pos
     double subForce[LastAtomIndex][3];
     double dt = angle - angleStretchBend;
     for( int jj = 0; jj < 3; jj++ ){
-        subForce[A][jj] = term*(dt*termA*deltaR[AB][jj] + dr*deltaR[ABxP][jj] );
-        subForce[C][jj] = term*(dt*termC*deltaR[CB][jj] + dr*deltaR[CBxP][jj] );
+        subForce[A][jj] = kStretchBend*dt*termA*deltaR[AB][jj] + drkk*deltaR[ABxP][jj];
+        subForce[C][jj] = k2StretchBend*dt*termC*deltaR[CB][jj] + drkk*deltaR[CBxP][jj];
         subForce[B][jj] = -( subForce[A][jj] + subForce[C][jj] );
     }
  
@@ -187,7 +188,7 @@ static void computeAmoebaStretchBendForce(int bondIndex,  std::vector<Vec3>& pos
     forces[particle3][1]       -= subForce[2][1];
     forces[particle3][2]       -= subForce[2][2];
 
-    *energy                    += term*dt*dr;
+    *energy                    += dt*drkk;
 #ifdef AMOEBA_DEBUG
     if( log ){
         (void) fprintf( log, "computeAmoebaStretchBendForce: angle=%10.3e dt=%10.3e dr=%10.3e\n", angle, dt, dr ); 

--- a/plugins/amoeba/platforms/reference/tests/TestReferenceAmoebaStretchBendForce.cpp
+++ b/plugins/amoeba/platforms/reference/tests/TestReferenceAmoebaStretchBendForce.cpp
@@ -275,7 +275,7 @@ void testOneStretchBend( FILE* log ) {
     //double kStretchBend     = 0.750491578E-01;
     double kStretchBend     = 1.0;
 
-    amoebaStretchBendForce->addStretchBend(0, 1, 2, abLength, cbLength, angleStretchBend, kStretchBend );
+    amoebaStretchBendForce->addStretchBend(0, 1, 2, abLength, cbLength, angleStretchBend, kStretchBend, kStretchBend );
 
     system.addForce(amoebaStretchBendForce);
     ASSERT(!amoebaStretchBendForce->usesPeriodicBoundaryConditions());
@@ -293,7 +293,7 @@ void testOneStretchBend( FILE* log ) {
     
     // Try changing the stretch-bend parameters and make sure it's still correct.
     
-    amoebaStretchBendForce->setStretchBendParameters(0, 0, 1, 2, 1.1*abLength, 1.2*cbLength, 1.3*angleStretchBend, 1.4*kStretchBend);
+    amoebaStretchBendForce->setStretchBendParameters(0, 0, 1, 2, 1.1*abLength, 1.2*cbLength, 1.3*angleStretchBend, 1.4*kStretchBend, 1.4*kStretchBend);
     bool exceptionThrown = false;
     try {
         // This should throw an exception.

--- a/plugins/amoeba/serialization/src/AmoebaStretchBendForceProxy.cpp
+++ b/plugins/amoeba/serialization/src/AmoebaStretchBendForceProxy.cpp
@@ -47,9 +47,9 @@ void AmoebaStretchBendForceProxy::serialize(const void* object, SerializationNod
     SerializationNode& bonds = node.createChildNode("StretchBendAngles");
     for (unsigned int ii = 0; ii < static_cast<unsigned int>(force.getNumStretchBends()); ii++) {
         int particle1, particle2, particle3;
-        double distanceAB, distanceCB, angle, k;
-        force.getStretchBendParameters(ii, particle1, particle2, particle3, distanceAB, distanceCB, angle, k);
-        bonds.createChildNode("StretchBendAngle").setIntProperty("p1", particle1).setIntProperty("p2", particle2).setIntProperty("p3", particle3).setDoubleProperty("dAB", distanceAB).setDoubleProperty("dCB", distanceCB).setDoubleProperty("angle", angle).setDoubleProperty("k", k);
+        double distanceAB, distanceCB, angle, k1, k2;
+        force.getStretchBendParameters(ii, particle1, particle2, particle3, distanceAB, distanceCB, angle, k1, k2);
+        bonds.createChildNode("StretchBendAngle").setIntProperty("p1", particle1).setIntProperty("p2", particle2).setIntProperty("p3", particle3).setDoubleProperty("dAB", distanceAB).setDoubleProperty("dCB", distanceCB).setDoubleProperty("angle", angle).setDoubleProperty("k1", k1).setDoubleProperty("k2", k2);
     }
 
 }
@@ -62,7 +62,7 @@ void* AmoebaStretchBendForceProxy::deserialize(const SerializationNode& node) co
         const SerializationNode& bonds = node.getChildNode("StretchBendAngles");
         for ( unsigned int ii = 0; ii < (int) bonds.getChildren().size(); ii++) {
             const SerializationNode& bond = bonds.getChildren()[ii];
-            force->addStretchBend(bond.getIntProperty("p1"), bond.getIntProperty("p2"), bond.getIntProperty("p3"),  bond.getDoubleProperty("dAB"), bond.getDoubleProperty("dCB"), bond.getDoubleProperty("angle"), bond.getDoubleProperty("k"));
+            force->addStretchBend(bond.getIntProperty("p1"), bond.getIntProperty("p2"), bond.getIntProperty("p3"),  bond.getDoubleProperty("dAB"), bond.getDoubleProperty("dCB"), bond.getDoubleProperty("angle"), bond.getDoubleProperty("k1"), bond.getDoubleProperty("k2"));
 
         }
     }

--- a/plugins/amoeba/serialization/tests/TestSerializeAmoebaStretchBendForce.cpp
+++ b/plugins/amoeba/serialization/tests/TestSerializeAmoebaStretchBendForce.cpp
@@ -64,10 +64,10 @@ void testSerialization() {
         double dAB1, dAB2;
         double dCB1, dCB2;
         double angle1, angle2;
-        double k1, k2;
+        double k11, k12, k21, k22;
 
-        force1.getStretchBendParameters(ii, p11, p12, p13, dAB1, dCB1, angle1, k1);
-        force2.getStretchBendParameters(ii, p21, p22, p23, dAB2, dCB2, angle2, k2);
+        force1.getStretchBendParameters(ii, p11, p12, p13, dAB1, dCB1, angle1, k11, k12);
+        force2.getStretchBendParameters(ii, p21, p22, p23, dAB2, dCB2, angle2, k21, k22);
 
         ASSERT_EQUAL(p11, p21);
         ASSERT_EQUAL(p12, p22);
@@ -75,7 +75,8 @@ void testSerialization() {
         ASSERT_EQUAL(dAB1, dAB2);
         ASSERT_EQUAL(dCB1, dCB2);
         ASSERT_EQUAL(angle1, angle2);
-        ASSERT_EQUAL(k1, k2);
+        ASSERT_EQUAL(k11, k21);
+        ASSERT_EQUAL(k12, k22);
     }
 }
 

--- a/plugins/amoeba/serialization/tests/TestSerializeAmoebaStretchBendForce.cpp
+++ b/plugins/amoeba/serialization/tests/TestSerializeAmoebaStretchBendForce.cpp
@@ -45,9 +45,9 @@ void testSerialization() {
     // Create a Force.
 
     AmoebaStretchBendForce force1;
-    force1.addStretchBend(0, 1, 3, 1.0, 1.2, 150.1, 83.2);
-    force1.addStretchBend(2, 4, 4, 1.1, 2.2, 180.1, 89.2);
-    force1.addStretchBend(5, 0, 1, 3.1, 8.2, 140.1, 98.2);
+    force1.addStretchBend(0, 1, 3, 1.0, 1.2, 150.1, 83.2, 100.);
+    force1.addStretchBend(2, 4, 4, 1.1, 2.2, 180.1, 89.2, 100.);
+    force1.addStretchBend(5, 0, 1, 3.1, 8.2, 140.1, 98.2, 100.);
 
     // Serialize and then deserialize it.
 

--- a/wrappers/python/simtk/openmm/app/forcefield.py
+++ b/wrappers/python/simtk/openmm/app/forcefield.py
@@ -3086,7 +3086,7 @@ class AmoebaStretchBendGenerator:
                        raise ValueError(outputString)
 
                     else:
-                        force.addStretchBend(angle[0], angle[1], angle[2], bondAB, bondCB, angleDict['idealAngle']/radian, self.k1[i])
+                        force.addStretchBend(angle[0], angle[1], angle[2], bondAB, bondCB, angleDict['idealAngle']/radian, self.k1[i], self.k2[i])
 
                     break
 

--- a/wrappers/python/src/swig_doxygen/swigInputConfig.py
+++ b/wrappers/python/src/swig_doxygen/swigInputConfig.py
@@ -277,7 +277,7 @@ UNITS = {
 ("AmoebaPiTorsionForce",                  "getPiTorsionParameters")                        :  ( None, (None, None, None, None, None,  None, 'unit.kilojoule_per_mole')),
 
 ("AmoebaStretchBendForce",                "getNumStretchBends")                            :  ( None, ()),
-("AmoebaStretchBendForce",                "getStretchBendParameters")                      :  ( None, (None, None, None, 'unit.nanometer', 'unit.nanometer', 'unit.radian', 'unit.kilojoule_per_mole/unit.nanometer/unit.degree')),
+("AmoebaStretchBendForce",                "getStretchBendParameters")                      :  ( None, (None, None, None, 'unit.nanometer', 'unit.nanometer', 'unit.radian', 'unit.kilojoule_per_mole/unit.nanometer/unit.degree', 'unit.kilojoule_per_mole/unit.nanometer/unit.degree')),
 
 ("AmoebaTorsionTorsionForce",             "getNumTorsionTorsions")                         :  ( None, ()),
 ("AmoebaTorsionTorsionForce",             "getNumTorsionTorsionGrids")                     :  ( None, ()),


### PR DESCRIPTION
This should address #800.  All of the tests have been updated and continue to pass (including the CUDA test on my machine).  Also, the *old* versions of the test (without the updated energy expression using separate force constants) passed as well, showing that the energies and forces have not *changed* as a result of this PR.

A few notes:

- I tried to maintain as much backwards-compatibility as possible. So the `addStretchBend` and `setStretchBendParameters` functions were supplied with default values for k2 of -1 that results in k1 being used for k2.  However, `getStretchBendParameters` doesn't work this way, and overloading is not an option thanks to the C wrapper generator. This could be worked around if maintaining this backwards-compatibility is important, but it would be clumsy and I would vote against it.
- I have not added any tests with different k's.
- I didn't touch the Python layer at all.  Hopefully, the default argument should keep the app layer working the same way it always has, but that's not fully tested.  This will also necessitate changes to the tinker-to-openmm XML force field writing tool in the pyopenmm repository.  This might be a good time to move it over here, as @jchodera has frequently pushed for.  But since it's *not* here, I'm leaving this be.

I'd like a code review/discussion before this is merged, though.  And if @jayponder has a test case he can either provide or run this PR through, that would be great as well (although it was pretty easy to figure out what changes to make simply by comparing the OMM and Tinker codes...)