### PR TITLE
Have travis build and push openmm-dev conda package after success

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,10 +39,10 @@ script:
 after_success:
   # Get libraries necessary for building docs and pushing
   # them to S3
-  - sudo apt-get install python-sphinx python-yaml
-  - sudo pip install sphinxcontrib-bibtex boto
-  - make DoxygenApiDocs
-  - make sphinxhtml
+  - sudo apt-get install -qq python-sphinx python-yaml
+  - sudo pip install --quiet sphinxcontrib-bibtex boto
+  - make --quiet DoxygenApiDocs
+  - make --quiet sphinxhtml
   - python devtools/ci/push-docs-to-s3.py
   # Build conda dev package and push to binstar
   - source devtools/ci/install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ env:
     # encrypted AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY to push docs to s3
     - secure: "VVKz+yOMbKsskR+PfU1HfKBWdGYYrmIXNWQz4nqXCjtg2MRCQmjDulFZaPVDvsBzis9BUhnzAQrBYUrAtN8bZSTYRg7ADFVGdPFicg3Sv0owcghTQwokIvbw3G+HDz/WAnFmqEhqm3t5pNVWNinyHpMM3zYZOVKagyj53cwAM0M="
     - secure: "W2iPU6ooMujfzJNw9ElaEB8Go1rlNFJ5zEldr3FaH7SDRwqtqNOEp9CegCeG/hHtjg1j8TMyytQtvW+OaMKFIbq7Qqu7nIfwIFTV45vBHW6uwT/jAq/J3EgZ8K7JGyysVVHk86D8jT+xu90YVH5Tx/w97luxHOQGfSK8alhCszw="
+    # encrypted BINSTAR_TOKEN for push of dev package to binstar
+    - secure: Qz3pEYXXFnNQ/WK+15ad4cdbLJvzgCIZRwKD9fLiS3CDO2ldAQWxzaz8RQOwqbFtZUWu7lQpr+GukNJz5p0w18QEto+BxLYG9aW5mjoc+F2vCjyWFjkwnJ/Z/3uBKTcr5x9Y7HKaPGivaJ4BNACifjt7cCpeVJzV6u2+bBgSoHc=
 
 before_install:
   - sudo apt-get update -qq
@@ -41,3 +43,12 @@ after_success:
   - make DoxygenApiDocs
   - make sphinxhtml
   - python devtools/ci/push-docs-to-s3.py
+  # Build conda dev package and push to binstar
+  - source tools/ci/install.sh
+  - export PYTHONUNBUFFERED=true
+  - export CC="clang++"
+  - source deactivate
+  - conda install --yes conda-build
+  - # Build the conda package, testing build before packaging.
+  - conda build devtools/conda-recipe
+  - source devtools/ci/after_success.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,9 @@ after_success:
   - conda install --yes conda-build jinja2
   # Clean up old build.
   - make clean
-  - find -iname '*cmake*' -not -name CMakeLists.txt -exec rm -rf {} \+
+  - rm -rf CMakeFiles
+  - rm -rf CMakeCache.txt
+  - rm -rf cmake_install.cmake
   # Build the conda package, testing build before packaging.
   - conda build devtools/conda-recipe
   - source devtools/ci/after_success.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,9 @@ after_success:
   - export CC="clang++"
   - source deactivate
   - conda install --yes conda-build
-  - # Build the conda package, testing build before packaging.
+  # Clean up old build.
+  - make clean
+  - find -iname '*cmake*' -not -name CMakeLists.txt -exec rm -rf {} \+
+  # Build the conda package, testing build before packaging.
   - conda build devtools/conda-recipe
   - source devtools/ci/after_success.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ script:
   - # run the python tests too
   - cd python/tests
   - nosetests -vv --processes=-1 --process-timeout=200
+  - cd ../..
 
 after_success:
   # Get libraries necessary for building docs and pushing

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,8 @@ script:
   - sudo make PythonInstall
   - # Run the testInstallation script
   - python -m simtk.testInstallation
-  - # run all of the tests
-  - ctest -j2 -V
+  - # run all of the tests, catching tests that fail the first time to give them a second try
+  - ctest -j2 -V || true
   - # get a list of all of the failed tests into this stupid ctest format
   - python -c 'fn = "Testing/Temporary/LastTestsFailed.log"; import os; os.path.exists(fn) or exit(0); l = [line.split(":")[0] for line in open(fn)]; triplets = zip(l, l, [","]*len(l)); print "".join(",".join(t) for t in triplets)' > FailedTests.log
   - # rerun all of the failed tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ after_success:
   - export PYTHONUNBUFFERED=true
   - export CC="clang++"
   - source deactivate
-  - conda install --yes conda-build
+  - conda install --yes conda-build jinja2
   # Clean up old build.
   - make clean
   - find -iname '*cmake*' -not -name CMakeLists.txt -exec rm -rf {} \+

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,12 +49,12 @@ after_success:
   - export PYTHONUNBUFFERED=true
   - export CC="clang++"
   - source deactivate
-  - conda install --yes conda-build jinja2
+  - conda install --yes --quiet conda-build jinja2
   # Clean up old build.
   - make clean
   - rm -rf CMakeFiles
   - rm -rf CMakeCache.txt
   - rm -rf cmake_install.cmake
   # Build the conda package, testing build before packaging.
-  - conda build devtools/conda-recipe
+  - conda build --quiet devtools/conda-recipe
   - source devtools/ci/after_success.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ after_success:
   - make sphinxhtml
   - python devtools/ci/push-docs-to-s3.py
   # Build conda dev package and push to binstar
-  - source tools/ci/install.sh
+  - source devtools/ci/install.sh
   - export PYTHONUNBUFFERED=true
   - export CC="clang++"
   - source deactivate

--- a/devtools/ci/after_success.sh
+++ b/devtools/ci/after_success.sh
@@ -11,7 +11,7 @@ fi
 
 
 if [[ "2.7 3.3" =~ "$python" ]]; then
-    conda install --yes binstar
+    conda install --yes binstar jinja2
     binstar -t $BINSTAR_TOKEN upload --force -u omnia -p openmm-dev $HOME/miniconda/conda-bld/linux-64/openmm-dev-*
 fi
 

--- a/devtools/ci/after_success.sh
+++ b/devtools/ci/after_success.sh
@@ -11,7 +11,7 @@ fi
 
 
 if [[ "2.7 3.3" =~ "$python" ]]; then
-    conda install --yes binstar jinja2
+    conda install --yes --quiet binstar jinja2
     binstar -t $BINSTAR_TOKEN upload --force -u omnia -p openmm-dev $HOME/miniconda/conda-bld/linux-64/openmm-dev-*
 fi
 

--- a/devtools/ci/install.sh
+++ b/devtools/ci/install.sh
@@ -2,20 +2,20 @@
 sudo apt-get update -qq
 sudo apt-get install -qq libpcre3 libpcre3-dev gromacs
 sudo apt-get install -qq swig doxygen llvm-3.3
-sudo apt-get install -qq libgl1-mesa-dev opencl-headers fglrx=2:8.960-0ubuntu1 # for opencl support
+#sudo apt-get install -qq libgl1-mesa-dev opencl-headers fglrx=2:8.960-0ubuntu1 # for opencl support
 export ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer-3.3
 
 # New requirements.
 sudo apt-get install -qq -y g++ gfortran csh
 sudo apt-get install -qq -y g++-multilib gcc-multilib
-wget http://repo.continuum.io/miniconda/Miniconda-3.0.5-Linux-x86_64.sh
-bash Miniconda-3.0.5-Linux-x86_64.sh -b
+wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh
+bash Miniconda-latest-Linux-x86_64.sh -b
 PIP_ARGS="-U"
 
 export PATH=$HOME/miniconda/bin:$PATH
 
 conda update --yes conda
 conda config --add channels http://conda.binstar.org/omnia
-conda create --yes -n ${python} python=${python} --file tools/ci/requirements-conda.txt
+conda create --yes -n ${python} python=${python} --file devtools/ci/requirements-conda.txt
 source activate $python
 $HOME/miniconda/envs/${python}/bin/pip install $PIP_ARGS nose-exclude

--- a/devtools/ci/install.sh
+++ b/devtools/ci/install.sh
@@ -14,7 +14,7 @@ PIP_ARGS="-U"
 
 export PATH=$HOME/miniconda/bin:$PATH
 
-conda update --yes conda
+conda update --yes --quiet conda
 conda config --add channels http://conda.binstar.org/omnia
 conda create --yes -n ${python} python=${python} --file devtools/ci/requirements-conda.txt
 source activate $python

--- a/devtools/conda-recipe/build.sh
+++ b/devtools/conda-recipe/build.sh
@@ -30,8 +30,8 @@ cp -r $RECIPE_DIR/../.. .
 mkdir build
 cd build
 cmake .. $CMAKE_FLAGS
-make -j4
-make install
+make --quiet -j4
+make --quiet install
 
 # Run C tests.
 # Exclude OpenCL tests because @peastman suspects mesa on travis implementation is broken.

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 package:
-  name: openmm
+  name: openmm-dev
   version: !!str dev
 
 requirements:


### PR DESCRIPTION
Attempting to address #816.

Since people were unhappy with the old approach of building the conda package, installing it, then testing it, we now try to build the `openmm-dev` conda package and push to binstar only after travis success.