### PR TITLE
PdbStructure handles byte streams correctly in Python 3

### DIFF
--- a/wrappers/python/simtk/openmm/app/internal/pdbstructure.py
+++ b/wrappers/python/simtk/openmm/app/internal/pdbstructure.py
@@ -150,6 +150,8 @@ class PdbStructure(object):
         self._reset_residue_numbers()
         # Read one line at a time
         for pdb_line in input_stream:
+            if not isinstance(pdb_line, str):
+                pdb_line = pdb_line.decode('utf-8')
             # Look for atoms
             if (pdb_line.find("ATOM  ") == 0) or (pdb_line.find("HETATM") == 0):
                 self._add_atom(Atom(pdb_line, self))

--- a/wrappers/python/tests/TestPdbFile.py
+++ b/wrappers/python/tests/TestPdbFile.py
@@ -60,6 +60,12 @@ class TestPdbFile(unittest.TestCase):
             self.assertEqual(atom1.name, atom2.name)
             self.assertEqual(atom1.residue.name, atom2.residue.name)
 
+    def test_BinaryStream(self):
+        """Test reading a stream that was opened in binary mode."""
+        pdb = PDBFile(open('systems/triclinic.pdb', 'rb'))
+        self.assertEqual(len(pdb.positions), 8)
+
+
     def assertVecAlmostEqual(self, p1, p2, tol=1e-7):
         unit = p1.unit
         p1 = p1.value_in_unit(unit)


### PR DESCRIPTION
This is the fix for https://github.com/pandegroup/pdbfixer/issues/81.