### PR TITLE
Fixing multiple bugs in dcdfile / dcdreporter.

### DIFF
--- a/wrappers/python/simtk/openmm/app/dcdfile.py
+++ b/wrappers/python/simtk/openmm/app/dcdfile.py
@@ -37,6 +37,8 @@ import time
 import struct
 import math
 from simtk.unit import picoseconds, nanometers, angstroms, is_quantity, norm
+from simtk.openmm import Vec3
+from simtk.openmm.app.internal.unitcell import computeLengthsAndAngles
 
 class DCDFile(object):
     """DCDFile provides methods for creating DCD files.

--- a/wrappers/python/simtk/openmm/app/dcdfile.py
+++ b/wrappers/python/simtk/openmm/app/dcdfile.py
@@ -121,9 +121,9 @@ class DCDFile(object):
                     unitCellDimensions = unitCellDimensions.value_in_unit(nanometers)
                 boxVectors = (Vec3(unitCellDimensions[0], 0, 0), Vec3(0, unitCellDimensions[1], 0), Vec3(0, 0, unitCellDimensions[2]))*nanometers
             (a_length, b_length, c_length, alpha, beta, gamma) = computeLengthsAndAngles(boxVectors)
-            a_length = a_length / 10.  # computeLengthsAndAngles returns unitless nanometers, but need angstroms here.
-            b_length = b_length / 10.  # computeLengthsAndAngles returns unitless nanometers, but need angstroms here.
-            c_length = c_length / 10.  # computeLengthsAndAngles returns unitless nanometers, but need angstroms here.
+            a_length = a_length * 10.  # computeLengthsAndAngles returns unitless nanometers, but need angstroms here.
+            b_length = b_length * 10.  # computeLengthsAndAngles returns unitless nanometers, but need angstroms here.
+            c_length = c_length * 10.  # computeLengthsAndAngles returns unitless nanometers, but need angstroms here.
             angle1 = math.sin(math.pi/2-gamma)
             angle2 = math.sin(math.pi/2-beta)
             angle3 = math.sin(math.pi/2-alpha)

--- a/wrappers/python/simtk/openmm/app/dcdfile.py
+++ b/wrappers/python/simtk/openmm/app/dcdfile.py
@@ -122,7 +122,7 @@ class DCDFile(object):
                 boxVectors = (Vec3(unitCellDimensions[0], 0, 0), Vec3(0, unitCellDimensions[1], 0), Vec3(0, 0, unitCellDimensions[2]))*nanometers
             (a_length, b_length, c_length, alpha, beta, gamma) = computeLengthsAndAngles(boxVectors)
             a_length = a_length / 10.  # computeLengthsAndAngles returns unitless nanometers, but need angstroms here.
-            b_length = b_length / 10.  # computeLengthsAndAngles returns unitless nanometers, but need angstroms here..value_in_unit(angstroms)
+            b_length = b_length / 10.  # computeLengthsAndAngles returns unitless nanometers, but need angstroms here.
             c_length = c_length / 10.  # computeLengthsAndAngles returns unitless nanometers, but need angstroms here.
             angle1 = math.sin(math.pi/2-gamma)
             angle2 = math.sin(math.pi/2-beta)

--- a/wrappers/python/simtk/openmm/app/dcdfile.py
+++ b/wrappers/python/simtk/openmm/app/dcdfile.py
@@ -121,9 +121,9 @@ class DCDFile(object):
                     unitCellDimensions = unitCellDimensions.value_in_unit(nanometers)
                 boxVectors = (Vec3(unitCellDimensions[0], 0, 0), Vec3(0, unitCellDimensions[1], 0), Vec3(0, 0, unitCellDimensions[2]))*nanometers
             (a_length, b_length, c_length, alpha, beta, gamma) = computeLengthsAndAngles(boxVectors)
-            a_length = a_length.value_in_unit(angstroms)
-            b_length = b_length.value_in_unit(angstroms)
-            c_length = c_length.value_in_unit(angstroms)
+            a_length = a_length / 10.  # computeLengthsAndAngles returns unitless nanometers, but need angstroms here.
+            b_length = b_length / 10.  # computeLengthsAndAngles returns unitless nanometers, but need angstroms here..value_in_unit(angstroms)
+            c_length = c_length / 10.  # computeLengthsAndAngles returns unitless nanometers, but need angstroms here.
             angle1 = math.sin(math.pi/2-gamma)
             angle2 = math.sin(math.pi/2-beta)
             angle3 = math.sin(math.pi/2-alpha)

--- a/wrappers/python/simtk/openmm/app/dcdfile.py
+++ b/wrappers/python/simtk/openmm/app/dcdfile.py
@@ -112,8 +112,8 @@ class DCDFile(object):
         file.seek(0, os.SEEK_END)
         boxVectors = self._topology.getPeriodicBoxVectors()
         if boxVectors is not None:
-            if getPeriodicBoxVectors is not None:
-                boxVectors = getPeriodicBoxVectors
+            if periodicBoxVectors is not None:
+                boxVectors = periodicBoxVectors
             elif unitCellDimensions is not None:
                 if is_quantity(unitCellDimensions):
                     unitCellDimensions = unitCellDimensions.value_in_unit(nanometers)

--- a/wrappers/python/tests/TestAmberPrmtopFile.py
+++ b/wrappers/python/tests/TestAmberPrmtopFile.py
@@ -1,4 +1,6 @@
 import unittest
+import os
+import tempfile
 from validateConstraints import *
 from simtk.openmm.app import *
 from simtk.openmm import *
@@ -291,8 +293,10 @@ class TestAmberPrmtopFile(unittest.TestCase):
         simulation.context.setPositions(inpcrd.positions)
         simulation.context.setPeriodicBoxVectors(*inpcrd.boxVectors)
 
-        simulation.reporters.append(DCDReporter('output.dcd', 1))  # This is an explicit test for the bugs in issue #850
+        fname = tempfile.mktemp(suffix='.dcd')
+        simulation.reporters.append(DCDReporter(fname, 1))  # This is an explicit test for the bugs in issue #850
         simulation.step(5)
+        os.remove(fname)
         
 
 if __name__ == '__main__':


### PR DESCRIPTION
Here is the driver code:

```
from simtk.openmm.app import *
from simtk.openmm import *
from simtk.unit import *
from sys import stdout


temperature = 50*kelvin

prmtop = AmberPrmtopFile('CO.prmtop')
inpcrd = AmberInpcrdFile('CO.inpcrd')
system = prmtop.createSystem(nonbondedMethod=PME, nonbondedCutoff=1*nanometer, constraints=HBonds)
system.addForce(MonteCarloBarostat(1.0 * atmospheres, temperature, 1))

integrator = LangevinIntegrator(temperature, 1/picosecond, 0.0001*picoseconds)
simulation = Simulation(prmtop.topology, system, integrator)
simulation.context.setPositions(inpcrd.positions)
simulation.context.setPeriodicBoxVectors(*inpcrd.boxVectors)


simulation.reporters.append(PDBReporter('output.pdb', 1))
simulation.reporters.append(DCDReporter('output.dcd', 1))
simulation.reporters.append(StateDataReporter(stdout, 1, step=True, potentialEnergy=True, temperature=True, density=True))
simulation.step(10000)
```

Here is the first bug, which is already fixed in this PR:

```
/home/kyleb/opt/lib/python2.7/site-packages/simtk/openmm/app/simulation.pyc in step(self, steps)
    125                 for reporter, next in zip(self.reporters, nextReport):
    126                     if next[0] == nextSteps:
--> 127                         reporter.report(self, state)
    128 

/home/kyleb/opt/lib/python2.7/site-packages/simtk/openmm/app/dcdreporter.pyc in report(self, simulation, state)
     75             self._dcd = DCDFile(self._out, simulation.topology, simulation.integrator.getStepSize(), 0, self._reportInterval)
     76         a,b,c = state.getPeriodicBoxVectors()
---> 77         self._dcd.writeModel(state.getPositions(), mm.Vec3(a[0].value_in_unit(nanometer), b[1].value_in_unit(nanometer), c[2].value_in_unit(nanometer))*nanometer)
     78 
     79     def __del__(self):

/home/kyleb/opt/lib/python2.7/site-packages/simtk/openmm/app/dcdfile.pyc in writeModel(self, positions, unitCellDimensions, periodicBoxVectors)
    113         boxVectors = self._topology.getPeriodicBoxVectors()
    114         if boxVectors is not None:
--> 115             if getPeriodicBoxVectors is not None:
    116                 boxVectors = getPeriodicBoxVectors
    117             elif unitCellDimensions is not None:

NameError: global name 'getPeriodicBoxVectors' is not defined
```

Now I'm hitting a second bug, which I'm looking into:

```
----> 1 simulation.step(10000)

/home/kyleb/opt/lib/python2.7/site-packages/simtk/openmm/app/simulation.pyc in step(self, steps)
    125                 for reporter, next in zip(self.reporters, nextReport):
    126                     if next[0] == nextSteps:
--> 127                         reporter.report(self, state)
    128 

/home/kyleb/opt/lib/python2.7/site-packages/simtk/openmm/app/dcdreporter.pyc in report(self, simulation, state)
     75             self._dcd = DCDFile(self._out, simulation.topology, simulation.integrator.getStepSize(), 0, self._reportInterval)
     76         a,b,c = state.getPeriodicBoxVectors()
---> 77         self._dcd.writeModel(state.getPositions(), mm.Vec3(a[0].value_in_unit(nanometer), b[1].value_in_unit(nanometer), c[2].value_in_unit(nanometer))*nanometer)
     78 
     79     def __del__(self):

/home/kyleb/opt/lib/python2.7/site-packages/simtk/openmm/app/dcdfile.pyc in writeModel(self, positions, unitCellDimensions, periodicBoxVectors)
    118                 if is_quantity(unitCellDimensions):
    119                     unitCellDimensions = unitCellDimensions.value_in_unit(nanometers)
--> 120                 boxVectors = (Vec3(unitCellDimensions[0], 0, 0), Vec3(0, unitCellDimensions[1], 0), Vec3(0, 0, unitCellDimensions[2]))*nanometers
    121             (a_length, b_length, c_length, alpha, beta, gamma) = computeLengthsAndAngles(boxVectors)
    122             a_length = a_length.value_in_unit(angstroms)

NameError: global name 'Vec3' is not defined
```