### PR TITLE
Modified travis logic to only fail if retested tests fail.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ script:
   - sudo make PythonInstall
   - # Run the testInstallation script
   - python -m simtk.testInstallation
-  - # run all of the tests
-  - ctest -j2 -V
+  - # run all of the tests, making sure failures at this stage don't cause travis failures
+  - ctest -j2 -V || true
   - # get a list of all of the failed tests into this stupid ctest format
   - python -c 'fn = "Testing/Temporary/LastTestsFailed.log"; import os; os.path.exists(fn) or exit(0); l = [line.split(":")[0] for line in open(fn)]; triplets = zip(l, l, [","]*len(l)); print "".join(",".join(t) for t in triplets)' > FailedTests.log
   - # rerun all of the failed tests


### PR DESCRIPTION
This modifies the travis logic so that ctests only fail if they fail on retest, rather than triggering a travis failure if they fail the first time.  This was discussed in #850.