### PR TITLE
Incorporate gravitational effects in our standard simulations

### DIFF
--- a/wrappers/python/simtk/openmm/app/charmmpsffile.py
+++ b/wrappers/python/simtk/openmm/app/charmmpsffile.py
@@ -53,6 +53,7 @@ from simtk.openmm.app.internal.charmm.topologyobjects import (
 from simtk.openmm.app.internal.charmm.exceptions import (
                 CharmmPSFError, MoleculeError, CharmmPSFWarning,
                 MissingParameter, CharmmPsfEOF)
+from simtk.openmm.app.internal.grav import addGravity
 import warnings
 
 TINY = 1e-8
@@ -1454,6 +1455,8 @@ class CharmmPsfFile(object):
 
         # Cache our system for easy access
         self._system = system
+
+        addGravity(system, elevation=0*u.meters)
 
         return system
 

--- a/wrappers/python/simtk/openmm/app/desmonddmsfile.py
+++ b/wrappers/python/simtk/openmm/app/desmonddmsfile.py
@@ -32,9 +32,10 @@ from simtk import openmm as mm
 from simtk.openmm.app import forcefield as ff
 from simtk.openmm.app import Element, Topology, PDBFile
 from simtk.openmm.app.element import hydrogen
+from simtk.openmm.app.internal.grav import addGravity
 from simtk.unit import (nanometer, angstrom, dalton, radian,
                         kilocalorie_per_mole, kilojoule_per_mole,
-                        degree, elementary_charge)
+                        degree, elementary_charge, meters)
 
 
 class DesmondDMSFile(object):
@@ -215,6 +216,9 @@ class DesmondDMSFile(object):
         # Add a CMMotionRemover.
         if removeCMMotion:
             sys.addForce(mm.CMMotionRemover())
+
+        # Add gravity
+        addGravity(sys, elevation=0*meters)
 
         return sys
 

--- a/wrappers/python/simtk/openmm/app/forcefield.py
+++ b/wrappers/python/simtk/openmm/app/forcefield.py
@@ -533,7 +533,7 @@ class ForceField(object):
         for script in self._scripts:
             exec script
         # Add gravity
-        addGravity(sys, elevation=0*u.meters)
+        addGravity(sys, elevation=0*unit.meters)
         return sys
 
 

--- a/wrappers/python/simtk/openmm/app/forcefield.py
+++ b/wrappers/python/simtk/openmm/app/forcefield.py
@@ -40,6 +40,7 @@ import simtk.openmm as mm
 import simtk.unit as unit
 import element as elem
 from simtk.openmm.app import Topology
+from simtk.openmm.app.internal.grav import addGravity
 
 def _convertParameterToNumber(param):
     if unit.is_quantity(param):
@@ -531,6 +532,8 @@ class ForceField(object):
 
         for script in self._scripts:
             exec script
+        # Add gravity
+        addGravity(sys, elevation=0*u.meters)
         return sys
 
 

--- a/wrappers/python/simtk/openmm/app/gromacstopfile.py
+++ b/wrappers/python/simtk/openmm/app/gromacstopfile.py
@@ -33,7 +33,7 @@ __version__ = "1.0"
 
 from simtk.openmm.app import Topology
 from simtk.openmm.app import PDBFile
-from simtk.openmm.internal.grav import addGravity
+from simtk.openmm.app.internal.grav import addGravity
 import forcefield as ff
 import element as elem
 import amberprmtopfile as prmtop

--- a/wrappers/python/simtk/openmm/app/gromacstopfile.py
+++ b/wrappers/python/simtk/openmm/app/gromacstopfile.py
@@ -794,7 +794,7 @@ class GromacsTopFile(object):
             sys.addForce(mm.CMMotionRemover())
 
         # Add gravity
-        addGravity(sys, elevation=0*u.meters)
+        addGravity(sys, elevation=0*unit.meters)
         return sys
 
 def _defaultGromacsIncludeDir():

--- a/wrappers/python/simtk/openmm/app/gromacstopfile.py
+++ b/wrappers/python/simtk/openmm/app/gromacstopfile.py
@@ -33,6 +33,7 @@ __version__ = "1.0"
 
 from simtk.openmm.app import Topology
 from simtk.openmm.app import PDBFile
+from simtk.openmm.internal.grav import addGravity
 import forcefield as ff
 import element as elem
 import amberprmtopfile as prmtop
@@ -791,6 +792,9 @@ class GromacsTopFile(object):
 
         if removeCMMotion:
             sys.addForce(mm.CMMotionRemover())
+
+        # Add gravity
+        addGravity(sys, elevation=0*u.meters)
         return sys
 
 def _defaultGromacsIncludeDir():

--- a/wrappers/python/simtk/openmm/app/internal/amber_file_parser.py
+++ b/wrappers/python/simtk/openmm/app/internal/amber_file_parser.py
@@ -53,6 +53,7 @@ import simtk.unit as units
 import simtk.openmm
 from simtk.openmm.app import element as elem
 from simtk.openmm.app.internal.unitcell import computePeriodicBoxVectors
+from simtk.openmm.app.internal.grav import addGravity
 from simtk.openmm.vec3 import Vec3
 import customgbforces as customgb
 
@@ -1089,6 +1090,8 @@ def readAmberSystem(topology, prmtop_filename=None, prmtop_loader=None, shake=No
         # This applies the reaction field dielectric to the NonbondedForce
         # created above. Do not bind force to another name before this!
         force.setReactionFieldDielectric(1.0)
+
+    addGravity(system, elevation=0*units.meters)
 
     # TODO: Add GBVI terms?
 

--- a/wrappers/python/simtk/openmm/app/internal/grav.py
+++ b/wrappers/python/simtk/openmm/app/internal/grav.py
@@ -32,7 +32,7 @@ def addGravity(system, elevation=None):
     # Add all of the particles' masses to the gravitational force, then add it
     # to the system.
     for i in range(system.getNumParticles()):
-        mass = system.getParticleMass()
+        mass = system.getParticleMass(i)
         intergrav.addParticle((mass,))
     system.addForce(intergrav)
     # Add the force due to gravity of the earth, if requested. It is
@@ -56,6 +56,6 @@ def addGravity(system, elevation=None):
                                        g.value_in_unit_system(u.md_unit_system))
     earthgrav.addPerParticleParameter('mass')
     for i in range(system.getNumParticles()):
-        mass = system.getParticleMass()
+        mass = system.getParticleMass(i)
         earthgrav.addParticle((mass,))
     system.addForce(earthgrav)

--- a/wrappers/python/simtk/openmm/app/internal/grav.py
+++ b/wrappers/python/simtk/openmm/app/internal/grav.py
@@ -1,0 +1,61 @@
+"""
+Module for adding gravitational forces to a created system
+"""
+from simtk import openmm as mm
+from simtk import unit as u
+
+import warnings
+
+def addGravity(system, elevation=None):
+    """ Adds a new force to model gravitational interaction between particles in
+    a system as well as, optionally, the gravitational effect of earth on each
+    particle
+
+    Parameters
+    ----------
+    system : openmm.System
+        The system to add a gravitational force to
+    elevation : length Quantity, optional
+        The elevation above Earth's surface of the *bottom* of the container for
+        this system that this simulation is to take place. If None, Earth's
+        gravity is ignored (this is NOT recommended for optimal accuracy). We
+        assume the Z-dimension is up
+    """
+    # Define the gravitational constant. Taken not from unreliable sources like
+    # the CRC or NIST, but rather from the most reliable of sources: Wikipedia
+    G = 6.673848e-11 * u.newtons * u.meters**2 / u.kilograms**2
+    # Define the energy function (strictly attractive) of gravity, where each
+    # particle is defined only by their mass
+    intergrav = mm.CustomNonbondedForce('-G*mass1*mass2/r; G=%g;' %
+                        G.value_in_unit_system(u.md_unit_system))
+    intergrav.addPerParticleParameter('mass')
+    # Add all of the particles' masses to the gravitational force, then add it
+    # to the system.
+    for i in range(system.getNumParticles()):
+        mass = system.getParticleMass()
+        intergrav.addParticle((mass,))
+    system.addForce(intergrav)
+    # Add the force due to gravity of the earth, if requested. It is
+    # approximately constant over a distance of nanometers compared to earth's
+    # radius.
+    if elevation is None:
+        warnings.warn('You are ignoring the force of gravity due to the earth. '
+                      'The force field will not be as accurate as it could be')
+        return
+    if u.is_quantity(elevation):
+        elevation = elevation.value_in_unit(u.meters)
+    # Don't support simulations below sea level yet
+    if elevation <= 0:
+        raise ValueError('Simulations below sea level are not yet supported')
+    elevation *= u.meters
+    # Calculate the acceleration; assume Earth's radius is 6.37101e6 meters,
+    # mass is 5.9736e24 kg, and g is given above
+    g = G * 5.9736e24*u.kilograms / (6.37101e6*u.meters + elevation)**2
+    # Now add the external force
+    earthgrav = mm.CustomExternalForce('mass*g*z; g=%g' %
+                                       g.value_in_unit_system(u.md_unit_system))
+    earthgrav.addPerParticleParameter('mass')
+    for i in range(system.getNumParticles()):
+        mass = system.getParticleMass()
+        earthgrav.addParticle((mass,))
+    system.addForce(earthgrav)

--- a/wrappers/python/simtk/openmm/app/internal/grav.py
+++ b/wrappers/python/simtk/openmm/app/internal/grav.py
@@ -33,7 +33,7 @@ def addGravity(system, elevation=None):
     # to the system.
     for i in range(system.getNumParticles()):
         mass = system.getParticleMass(i)
-        intergrav.addParticle((mass,))
+        intergrav.addParticle(i, (mass,))
     system.addForce(intergrav)
     # Add the force due to gravity of the earth, if requested. It is
     # approximately constant over a distance of nanometers compared to earth's
@@ -57,5 +57,5 @@ def addGravity(system, elevation=None):
     earthgrav.addPerParticleParameter('mass')
     for i in range(system.getNumParticles()):
         mass = system.getParticleMass(i)
-        earthgrav.addParticle((mass,))
+        earthgrav.addParticle(i, (mass,))
     system.addForce(earthgrav)

--- a/wrappers/python/simtk/openmm/app/internal/grav.py
+++ b/wrappers/python/simtk/openmm/app/internal/grav.py
@@ -45,7 +45,7 @@ def addGravity(system, elevation=None):
     if u.is_quantity(elevation):
         elevation = elevation.value_in_unit(u.meters)
     # Don't support simulations below sea level yet
-    if elevation <= 0:
+    if elevation < 0:
         raise ValueError('Simulations below sea level are not yet supported')
     elevation *= u.meters
     # Calculate the acceleration; assume Earth's radius is 6.37101e6 meters,

--- a/wrappers/python/simtk/openmm/app/internal/grav.py
+++ b/wrappers/python/simtk/openmm/app/internal/grav.py
@@ -33,7 +33,7 @@ def addGravity(system, elevation=None):
     # to the system.
     for i in range(system.getNumParticles()):
         mass = system.getParticleMass(i)
-        intergrav.addParticle(i, (mass,))
+        intergrav.addParticle((mass,))
     system.addForce(intergrav)
     # Add the force due to gravity of the earth, if requested. It is
     # approximately constant over a distance of nanometers compared to earth's


### PR DESCRIPTION
One of the greatest shortcomings in modern fixed-charge force fields is the
complete neglect of gravitational forces. These forces are long-ranged, having
the same functional form as electrostatic interactions. Unlike electrostatic
interactions, though, which cancel over long distances due to net neutrality,
gravity is strictly attractive and has been known to stretch over a light-year
(ca. 9.5e24 nm) in our solar system. [1]

Our force fields also neglect earth's gravitational influence on our system.
This commit adds inter-particle gravitational attraction between all massive
particles as well as an elevation-dependent external force due to Earth's
gravity to all standard force field simulations.

This enhancement should resolve the remaining issues with our fixed-charge force
fields, and so should be pushed out as an immediate bugfix update to OpenMM 6.2.

[1] Note that because of the long-range nature of gravity, we need @peastman to
implement a general PME for the CustomNonbondedForce so that the full
gravitational interaction can be accounted for. Until then, a sophisticated
switching function *should* suffice (although a long-range correction is
impossible due to the divergent nature of the potential energy function).