### PR TITLE
Fix SWIG 3 support for the Python wrappers.

### DIFF
--- a/wrappers/python/src/swig_doxygen/swig_lib/python/features.i
+++ b/wrappers/python/src/swig_doxygen/swig_lib/python/features.i
@@ -6,3 +6,12 @@
 %include pythonprepend.i
 %include pythonappend.i
 %include typemaps.i
+/* SWIG 3.x resolved a bug in which all wrapped C++ functions took *args as its
+ * default argument list. OpenMM then exploited this bug by doing stuff like
+ * passing args to stripUnits (and all added code assumed that the arguments
+ * were in an "args" list). So in order to restore this arguably buggy behavior
+ * from SWIG 2, enable the "compactdefaultargs" feature globally.
+ *
+ * See https://github.com/swig/swig/issues/387
+ */
+%feature("compactdefaultargs");


### PR DESCRIPTION
See swig/swig#387 for a discussion.  It would actually be nice to *not* set the
"compactdefaultargs" feature globally, since that would allow us to actually see
the real API at the Python level the same as you would see by looking at the C++
header files. But this is the only way to support both SWIG 2 and SWIG 3 easily
and avoid a lot of retooling for the SWIG input code generator.