### PR TITLE
Fixes the TestCudaLocalEnergyMinimizer

### DIFF
--- a/platforms/cuda/tests/TestCudaLocalEnergyMinimizer.cpp
+++ b/platforms/cuda/tests/TestCudaLocalEnergyMinimizer.cpp
@@ -80,7 +80,7 @@ void testLargeSystem() {
     const int numMolecules = 25;
     const int numParticles = numMolecules*2;
     const double cutoff = 2.0;
-    const double boxSize = 4.0;
+    const double boxSize = 5.0;
     const double tolerance = 5;
     System system;
     system.setDefaultPeriodicBoxVectors(Vec3(boxSize, 0, 0), Vec3(0, boxSize, 0), Vec3(0, 0, boxSize));
@@ -137,7 +137,7 @@ void testVirtualSites() {
     const int numMolecules = 25;
     const int numParticles = numMolecules*3;
     const double cutoff = 2.0;
-    const double boxSize = 4.0;
+    const double boxSize = 5.0;
     const double tolerance = 5;
     System system;
     system.setDefaultPeriodicBoxVectors(Vec3(boxSize, 0, 0), Vec3(0, boxSize, 0), Vec3(0, 0, boxSize));


### PR DESCRIPTION
Not sure why.  Is there a nonbonded "skin" of some sort when building the
pairlist?