### PR TITLE
Eliminate scipy RuntimeWarning when reading NetCDF restart files

### DIFF
--- a/wrappers/python/simtk/openmm/app/internal/amber_file_parser.py
+++ b/wrappers/python/simtk/openmm/app/internal/amber_file_parser.py
@@ -1363,6 +1363,7 @@ class AmberNetcdfRestart(object):
             if 'velocities' in ncfile.variables:
                 vels = ncfile.variables['velocities']
                 self.velocities = np.array(vels[:]) * vels.scale_factor
+                del vels # Get rid of reference to variable to avoid warnings
             if ('cell_lengths' in ncfile.variables and
                 'cell_angles' in ncfile.variables):
                 self.boxVectors = np.zeros((3,3), np.float32)
@@ -1372,6 +1373,7 @@ class AmberNetcdfRestart(object):
                         units.degrees)
                 self.boxVectors = computePeriodicBoxVectors(leng[0], leng[1],
                         leng[2], angl[0], angl[1], angl[2])
+                del leng, angl # Avoid warnings
             if 'time' in ncfile.variables:
                 self.time = ncfile.variables['time'].getValue()
         finally:


### PR DESCRIPTION
Due to a bug that was uncovered in mdtraj with scipy's NetCDF implementation
regarding mmapping, scipy started issuing the following warning if any NetCDF
variable objects had references remaining after closing the file:

/.../lib/python2.7/site-packages/scipy/io/netcdf.py:287:
RuntimeWarning: Cannot close a netcdf_file opened with mmap=True, when
netcdf_variables or arrays referring to its data still exist. All data arrays
obtained from such files refer directly to data on disk, and must be copied
before the file can be cleanly closed. (See netcdf_file docstring for more
information on mmap.)

We were already copying data to avoid segfaults on some scipy versions, but
there were still references to variables that went out of scope shortly after
the NetCDF file was closed.  Simply deleting these references gets rid of the
warning.