### PR TITLE
Look in cuda dir for opencl headers

### DIFF
--- a/cmake_modules/FindOpenCL.cmake
+++ b/cmake_modules/FindOpenCL.cmake
@@ -33,6 +33,7 @@ find_path(OPENCL_INCLUDE_DIR
         "/usr/local/cuda"
         "/usr/local/streamsdk"
         "/usr"
+        "${CUDA_TOOLKIT_ROOT_DIR}"
     PATH_SUFFIXES "include"
 )
 


### PR DESCRIPTION
Useful when cuda is not installed in the default location.