### PR TITLE
Fix clang3.6 tautological-undefined-compare warning.

### DIFF
--- a/libraries/lepton/src/ExpressionTreeNode.cpp
+++ b/libraries/lepton/src/ExpressionTreeNode.cpp
@@ -59,7 +59,7 @@ ExpressionTreeNode::ExpressionTreeNode(Operation* operation) : operation(operati
         throw Exception("wrong number of arguments to function: "+operation->getName());
 }
 
-ExpressionTreeNode::ExpressionTreeNode(const ExpressionTreeNode& node) : operation(&node.getOperation() == NULL ? NULL : node.getOperation().clone()), children(node.getChildren()) {
+ExpressionTreeNode::ExpressionTreeNode(const ExpressionTreeNode& node) : operation(node.getOperation().clone()), children(node.getChildren()) {
 }
 
 ExpressionTreeNode::ExpressionTreeNode() : operation(NULL) {

--- a/libraries/lepton/src/ParsedExpression.cpp
+++ b/libraries/lepton/src/ParsedExpression.cpp
@@ -46,8 +46,6 @@ ParsedExpression::ParsedExpression(const ExpressionTreeNode& rootNode) : rootNod
 }
 
 const ExpressionTreeNode& ParsedExpression::getRootNode() const {
-    if (&rootNode.getOperation() == NULL)
-        throw Exception("Illegal call to an initialized ParsedExpression");
     return rootNode;
 }
 


### PR DESCRIPTION
The warnings were:

```
/Users/chris/nmblprojects/psim/pgait/opensim/opensim-core/Vendors/lepton/src/ExpressionTreeNode.cpp:62:85:
warning:
      reference cannot be bound to dereferenced null pointer in well-defined
      C++ code;
      comparison may be assumed to always evaluate to false
      [-Wtautological-undefined-compare]
    ...ExpressionTreeNode& node) : operation(&node.getOperation() == NULL ? NULL : nod...
                                              ^~~~~~~~~~~~~~~~~~~    ~~~~
/Users/chris/nmblprojects/psim/pgait/opensim/opensim-core/Vendors/lepton/include/lepton/ExpressionTreeNode.h:93:22: note:
        'getOperation' returns a reference
    const Operation& getOperation() const;
                     ^
```

```
/Users/chris/nmblprojects/psim/pgait/opensim/opensim-core/Vendors/lepton/src/ParsedExpression.cpp:49:10:
warning:
      reference cannot be bound to dereferenced null pointer in well-defined
      C++ code;
      comparison may be assumed to always evaluate to false
      [-Wtautological-undefined-compare]
    if (&rootNode.getOperation() == NULL)
         ^~~~~~~~~~~~~~~~~~~~~~~    ~~~~
/Users/chris/nmblprojects/psim/pgait/opensim/opensim-core/Vendors/lepton/include/lepton/ExpressionTreeNode.h:93:22: note:
        'getOperation' returns a reference
    const Operation& getOperation() const;
                     ^
```