### PR TITLE
Fixed a bug in runForClockTime()

### DIFF
--- a/wrappers/python/simtk/openmm/app/simulation.py
+++ b/wrappers/python/simtk/openmm/app/simulation.py
@@ -135,7 +135,7 @@ class Simulation(object):
         if endStep is None:
             endStep = sys.maxint
         nextReport = [None]*len(self.reporters)
-        while self.currentStep < endStep:
+        while self.currentStep < endStep and (endTime is None or datetime.now() < endTime):
             nextSteps = endStep-self.currentStep
             anyReport = False
             for i, reporter in enumerate(self.reporters):


### PR DESCRIPTION
This fixes #962.  The error occurred when a reporter was getting called very frequently (every 10 or fewer time steps).