### PR TITLE
Compiling on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -530,4 +530,11 @@ IF(BUILD_TESTING)
 ENDIF(BUILD_TESTING)
 ADD_SUBDIRECTORY(examples)
 
+
+get_property(dirs DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES)
+foreach(dir ${dirs})
+  message(STATUS "dir='${dir}'")
+endforeach()
+
+
 ENDIF(NOT cmv EQUAL "2.4") # This whole file...

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -530,11 +530,4 @@ IF(BUILD_TESTING)
 ENDIF(BUILD_TESTING)
 ADD_SUBDIRECTORY(examples)
 
-
-get_property(dirs DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES)
-foreach(dir ${dirs})
-  message(STATUS "dir='${dir}'")
-endforeach()
-
-
 ENDIF(NOT cmv EQUAL "2.4") # This whole file...

--- a/cmake_modules/FindOpenCL.cmake
+++ b/cmake_modules/FindOpenCL.cmake
@@ -33,6 +33,7 @@ find_path(OPENCL_INCLUDE_DIR
         "/usr/local/cuda"
         "/usr/local/streamsdk"
         "/usr"
+        "C:/Program Files (x86)/AMD APP SDK/3.0-0-Beta"
         "${CUDA_TOOLKIT_ROOT_DIR}"
     PATH_SUFFIXES "include"
 )

--- a/cmake_modules/FindOpenCL.cmake
+++ b/cmake_modules/FindOpenCL.cmake
@@ -33,7 +33,6 @@ find_path(OPENCL_INCLUDE_DIR
         "/usr/local/cuda"
         "/usr/local/streamsdk"
         "/usr"
-        "C:/Program Files (x86)/AMD APP SDK/3.0-0-Beta"
         "${CUDA_TOOLKIT_ROOT_DIR}"
     PATH_SUFFIXES "include"
 )
@@ -80,7 +79,6 @@ find_library(OPENCL_LIBRARY
         "/usr/local/cuda"
         "/usr/local/streamsdk"
         "/usr"
-        "C:/Program Files (x86)/AMD APP SDK/3.0-0-Beta"
         "${CUDA_TOOLKIT_ROOT_DIR}"
     PATH_SUFFIXES ${path_suffixes} "lib"
 )

--- a/cmake_modules/FindOpenCL.cmake
+++ b/cmake_modules/FindOpenCL.cmake
@@ -80,6 +80,8 @@ find_library(OPENCL_LIBRARY
         "/usr/local/cuda"
         "/usr/local/streamsdk"
         "/usr"
+        "C:/Program Files (x86)/AMD APP SDK/3.0-0-Beta"
+        "${CUDA_TOOLKIT_ROOT_DIR}"
     PATH_SUFFIXES ${path_suffixes} "lib"
 )
 

--- a/libraries/pthreads/include/pthread.h
+++ b/libraries/pthreads/include/pthread.h
@@ -54,9 +54,12 @@
 #include <sys/timeb.h>
 #include <process.h>
 
+#ifndef ETIMEDOUT
 #define ETIMEDOUT	110
+#endif
+#ifndef ENOTSUP
 #define ENOTSUP		134
-
+#endif
 
 #define PTHREAD_CANCEL_DISABLE 0
 #define PTHREAD_CANCEL_ENABLE 0x01


### PR DESCRIPTION
1. Compiling with x64 VS2010 compilers, I got an error with two `#defines` already having been defined in `pthreads.h`.
2. Extend #948 to search for other usual suspects paths for OpenCL. This isn't strictly necessary, but it smooths things out a little.