### PR TITLE
Record plugin load failures

### DIFF
--- a/olla/include/openmm/Platform.h
+++ b/olla/include/openmm/Platform.h
@@ -174,7 +174,7 @@ public:
     /**
      * Get any failures caused during the last call to loadPluginsFromDirectory
      */
-    static std::vector<std::string> getLoadFailures();
+    static std::vector<std::string> getPluginLoadFailures();
     /**
      * Get the registered Platform with a particular name.  If no Platform with that name has been
      * registered, this throws an exception.
@@ -205,7 +205,7 @@ public:
      * Load multiple dynamic libraries (DLLs) which contain OpenMM plugins from a single directory.
      * This method loops over every file contained in the specified directory and calls loadPluginLibrary()
      * for each one.  If an error occurs while trying to load a particular file, that file is simply
-     * ignored.
+     * ignored. You can retrieve a list of all such errors by calling getPluginLoadFailures().
      *
      * @param directory    the path to the directory containing libraries to load
      * @return the names of all files which were successfully loaded as libraries
@@ -237,7 +237,7 @@ private:
     std::map<std::string, KernelFactory*> kernelFactories;
     std::map<std::string, std::string> defaultProperties;
     static std::vector<Platform*>& getPlatforms();
-    static std::vector<std::string> loadFailures;
+    static std::vector<std::string> pluginLoadFailures;
 };
 
 

--- a/olla/include/openmm/Platform.h
+++ b/olla/include/openmm/Platform.h
@@ -49,13 +49,13 @@ class KernelFactory;
  * More precisely, a Platform object acts as a registry for a set of KernelFactory
  * objects which together implement the kernels.  The Platform class, in turn, provides a
  * static registry of all available Platform objects.
- * 
+ *
  * To get a Platform object, call
- * 
+ *
  * <pre>
  * Platform& platform Platform::findPlatform(kernelNames);
  * </pre>
- * 
+ *
  * passing in the names of all kernels that will be required for the calculation you plan to perform.  It
  * will return the fastest available Platform which provides implementations of all the specified kernels.
  * You can then call createKernel() to construct particular kernels as needed.
@@ -133,14 +133,14 @@ public:
      * Register a KernelFactory which should be used to create Kernels with a particular name.
      * The Platform takes over ownership of the factory, and will delete it when the Platform itself
      * is deleted.
-     * 
+     *
      * @param name     the kernel name for which the factory should be used
      * @param factory  the factory to use for creating Kernels with the specified name
      */
     void registerKernelFactory(const std::string& name, KernelFactory* factory);
     /**
      * Determine whether this Platforms provides implementations of a set of kernels.
-     * 
+     *
      * @param kernelNames the names of the kernels of interests
      * @return true if this Platform provides implementations of all the kernels in the list,
      * false if there are any which it does not support
@@ -151,9 +151,9 @@ public:
      * the returned Kernels are independent and do not interact with each other.  This means
      * that it is possible to have multiple simulations in progress at one time without them
      * interfering.
-     * 
+     *
      * If no KernelFactory has been registered for the specified name, this will throw an exception.
-     * 
+     *
      * @param name the name of the Kernel to get
      * @param context the context for which to create a Kernel
      * @return a newly created Kernel object
@@ -172,13 +172,17 @@ public:
      */
     static Platform& getPlatform(int index);
     /**
+     * Get any failures caused during the last call to loadPluginsFromDirectory
+     */
+    static std::vector<std::string> getLoadFailures();
+    /**
      * Get the registered Platform with a particular name.  If no Platform with that name has been
      * registered, this throws an exception.
      */
     static Platform& getPlatformByName(const std::string& name);
     /**
      * Find a Platform which can be used to perform a calculation.
-     * 
+     *
      * @param kernelNames the names of all kernels which will be needed for the calculation
      * @return the fastest registered Platform which supports all of the requested kernels.  If no
      * Platform exists which supports all of them, this will throw an exception.
@@ -233,7 +237,9 @@ private:
     std::map<std::string, KernelFactory*> kernelFactories;
     std::map<std::string, std::string> defaultProperties;
     static std::vector<Platform*>& getPlatforms();
+    static std::vector<std::string> loadFailures;
 };
+
 
 } // namespace OpenMM
 

--- a/olla/src/Platform.cpp
+++ b/olla/src/Platform.cpp
@@ -51,6 +51,9 @@
 using namespace OpenMM;
 using namespace std;
 
+std::vector<std::string> Platform::loadFailures;
+
+
 static int registerPlatforms() {
 
     // Register the Platforms built into the main library.  This should eventually be moved elsewhere.
@@ -140,6 +143,10 @@ Platform& Platform::getPlatform(int index) {
     throw OpenMMException("Invalid platform index");
 }
 
+std::vector<std::string> Platform::getLoadFailures() {
+  return loadFailures;
+}
+
 Platform& Platform::getPlatformByName(const string& name) {
     for (int i = 0; i < getNumPlatforms(); i++)
         if (getPlatform(i).getName() == name)
@@ -196,8 +203,9 @@ static void* loadOneLibrary(const string& file) {
     throw OpenMMException("Loading dynamic libraries is not supported on PNaCl");
 #else    
     void *handle = dlopen(file.c_str(), RTLD_LAZY | RTLD_GLOBAL);
-    if (handle == NULL)
+    if (handle == NULL) {
         throw OpenMMException("Error loading library "+file+": "+dlerror());
+    }
     return handle;
 #endif
 }
@@ -261,12 +269,14 @@ vector<string> Platform::loadPluginsFromDirectory(const string& directory) {
     vector<void*> plugins;
 #endif
     vector<string> loadedLibraries;
+    loadFailures.resize(0);
+
     for (unsigned int i = 0; i < files.size(); ++i) {
         try {
             plugins.push_back(loadOneLibrary(directory+dirSeparator+files[i]));
             loadedLibraries.push_back(files[i]);
         } catch (OpenMMException& ex) {
-            // Just ignore it.
+	    loadFailures.push_back(ex.what());
         }
     }
     initializePlugins(plugins);

--- a/olla/src/Platform.cpp
+++ b/olla/src/Platform.cpp
@@ -45,19 +45,13 @@
 #include <cstdlib>
 #endif
 #include <set>
-#include <algorithm>
 
 #include "ReferencePlatform.h"
 
 using namespace OpenMM;
 using namespace std;
 
-std::vector<std::string> Platform::loadFailures;
-
-static bool stringLengthComparator(string i, string j) {
-  return (i.size() < j.size());
-}
-
+std::vector<std::string> Platform::pluginLoadFailures;
 
 static int registerPlatforms() {
 
@@ -148,8 +142,8 @@ Platform& Platform::getPlatform(int index) {
     throw OpenMMException("Invalid platform index");
 }
 
-std::vector<std::string> Platform::getLoadFailures() {
-  return loadFailures;
+std::vector<std::string> Platform::getPluginLoadFailures() {
+  return pluginLoadFailures;
 }
 
 Platform& Platform::getPlatformByName(const string& name) {
@@ -274,15 +268,14 @@ vector<string> Platform::loadPluginsFromDirectory(const string& directory) {
     vector<void*> plugins;
 #endif
     vector<string> loadedLibraries;
-    std::sort (files.begin(), files.end(), stringLengthComparator);
-    loadFailures.resize(0);
+    pluginLoadFailures.resize(0);
 
     for (unsigned int i = 0; i < files.size(); ++i) {
         try {
             plugins.push_back(loadOneLibrary(directory+dirSeparator+files[i]));
             loadedLibraries.push_back(files[i]);
         } catch (OpenMMException& ex) {
-	    loadFailures.push_back(ex.what());
+	    pluginLoadFailures.push_back(ex.what());
         }
     }
     initializePlugins(plugins);

--- a/olla/src/Platform.cpp
+++ b/olla/src/Platform.cpp
@@ -45,6 +45,7 @@
 #include <cstdlib>
 #endif
 #include <set>
+#include <algorithm>
 
 #include "ReferencePlatform.h"
 
@@ -52,6 +53,10 @@ using namespace OpenMM;
 using namespace std;
 
 std::vector<std::string> Platform::loadFailures;
+
+static bool stringLengthComparator(string i, string j) {
+  return (i.size() < j.size());
+}
 
 
 static int registerPlatforms() {
@@ -269,6 +274,7 @@ vector<string> Platform::loadPluginsFromDirectory(const string& directory) {
     vector<void*> plugins;
 #endif
     vector<string> loadedLibraries;
+    std::sort (files.begin(), files.end(), stringLengthComparator);
     loadFailures.resize(0);
 
     for (unsigned int i = 0; i < files.size(); ++i) {

--- a/wrappers/generateWrappers.py
+++ b/wrappers/generateWrappers.py
@@ -68,7 +68,7 @@ class WrapperGenerator:
     
     def __init__(self, inputDirname, output):
         self.skipClasses = ['OpenMM::Vec3', 'OpenMM::XmlSerializer', 'OpenMM::Kernel', 'OpenMM::KernelImpl', 'OpenMM::KernelFactory', 'OpenMM::ContextImpl', 'OpenMM::SerializationNode', 'OpenMM::SerializationProxy']
-        self.skipMethods = ['OpenMM::Context::getState', 'OpenMM::Platform::loadPluginsFromDirectory', 'OpenMM::Context::createCheckpoint', 'OpenMM::Context::loadCheckpoint', 'OpenMM::Context::getMolecules']
+        self.skipMethods = ['OpenMM::Context::getState', 'OpenMM::Platform::loadPluginsFromDirectory', 'OpenMM::Platform::getLoadFailures', 'OpenMM::Context::createCheckpoint', 'OpenMM::Context::loadCheckpoint', 'OpenMM::Context::getMolecules']
         self.hideClasses = ['Kernel', 'KernelImpl', 'KernelFactory', 'ContextImpl', 'SerializationNode', 'SerializationProxy']
         self.nodeByID={}
 
@@ -398,6 +398,7 @@ extern OPENMM_EXPORT void %(name)s_insert(%(name)s* set, %(type)s value);""" % v
    Unlike the C++ versions, the return value is allocated on the heap, and you must delete it yourself. */
 extern OPENMM_EXPORT OpenMM_State* OpenMM_Context_getState(const OpenMM_Context* target, int types, int enforcePeriodicBox);
 extern OPENMM_EXPORT OpenMM_StringArray* OpenMM_Platform_loadPluginsFromDirectory(const char* directory);
+extern OPENMM_EXPORT OpenMM_StringArray* OpenMM_Platform_getLoadFailures();
 extern OPENMM_EXPORT char* OpenMM_XmlSerializer_serializeSystem(const OpenMM_System* system);
 extern OPENMM_EXPORT char* OpenMM_XmlSerializer_serializeState(const OpenMM_State* state);
 extern OPENMM_EXPORT char* OpenMM_XmlSerializer_serializeIntegrator(const OpenMM_Integrator* integrator);
@@ -802,6 +803,10 @@ OPENMM_EXPORT OpenMM_State* OpenMM_Context_getState(const OpenMM_Context* target
 }
 OPENMM_EXPORT OpenMM_StringArray* OpenMM_Platform_loadPluginsFromDirectory(const char* directory) {
     vector<string> result = Platform::loadPluginsFromDirectory(string(directory));
+    return reinterpret_cast<OpenMM_StringArray*>(new vector<string>(result));
+}
+OPENMM_EXPORT OpenMM_StringArray* OpenMM_Platform_getLoadFailures() {
+    vector<string> result = Platform::getLoadFailures();
     return reinterpret_cast<OpenMM_StringArray*>(new vector<string>(result));
 }
 static char* createStringFromStream(stringstream& stream) {
@@ -1312,6 +1317,10 @@ MODULE OpenMM
         subroutine OpenMM_Platform_loadPluginsFromDirectory(directory, result)
             use OpenMM_Types; implicit none
             character(*) directory
+            type(OpenMM_StringArray) result
+        end subroutine
+        subroutine OpenMM_Platform_getLoadFailures(result)
+            use OpenMM_Types; implicit none
             type(OpenMM_StringArray) result
         end subroutine
         subroutine OpenMM_XmlSerializer_serializeSystemToC(system, result, result_length)
@@ -1987,6 +1996,12 @@ OPENMM_EXPORT void openmm_platform_loadpluginsfromdirectory_(const char* directo
 }
 OPENMM_EXPORT void OPENMM_PLATFORM_LOADPLUGINSFROMDIRECTORY(const char* directory, OpenMM_StringArray*& result, int length) {
     result = OpenMM_Platform_loadPluginsFromDirectory(makeString(directory, length).c_str());
+}
+OPENMM_EXPORT void openmm_platform_getloadfailures_(OpenMM_StringArray*& result) {
+    result = OpenMM_Platform_getLoadFailures();
+}
+OPENMM_EXPORT void OPENMM_PLATFORM_GETLOADFAILURES(OpenMM_StringArray*& result) {
+    result = OpenMM_Platform_getLoadFailures();
 }
 OPENMM_EXPORT void openmm_xmlserializer_serializesystemtoc_(OpenMM_System*& system, char*& result, int& result_length) {
     convertStringToChars(OpenMM_XmlSerializer_serializeSystem(system), result, result_length);

--- a/wrappers/generateWrappers.py
+++ b/wrappers/generateWrappers.py
@@ -68,7 +68,7 @@ class WrapperGenerator:
     
     def __init__(self, inputDirname, output):
         self.skipClasses = ['OpenMM::Vec3', 'OpenMM::XmlSerializer', 'OpenMM::Kernel', 'OpenMM::KernelImpl', 'OpenMM::KernelFactory', 'OpenMM::ContextImpl', 'OpenMM::SerializationNode', 'OpenMM::SerializationProxy']
-        self.skipMethods = ['OpenMM::Context::getState', 'OpenMM::Platform::loadPluginsFromDirectory', 'OpenMM::Platform::getLoadFailures', 'OpenMM::Context::createCheckpoint', 'OpenMM::Context::loadCheckpoint', 'OpenMM::Context::getMolecules']
+        self.skipMethods = ['OpenMM::Context::getState', 'OpenMM::Platform::loadPluginsFromDirectory', 'OpenMM::Platform::getPluginLoadFailures', 'OpenMM::Context::createCheckpoint', 'OpenMM::Context::loadCheckpoint', 'OpenMM::Context::getMolecules']
         self.hideClasses = ['Kernel', 'KernelImpl', 'KernelFactory', 'ContextImpl', 'SerializationNode', 'SerializationProxy']
         self.nodeByID={}
 
@@ -398,7 +398,7 @@ extern OPENMM_EXPORT void %(name)s_insert(%(name)s* set, %(type)s value);""" % v
    Unlike the C++ versions, the return value is allocated on the heap, and you must delete it yourself. */
 extern OPENMM_EXPORT OpenMM_State* OpenMM_Context_getState(const OpenMM_Context* target, int types, int enforcePeriodicBox);
 extern OPENMM_EXPORT OpenMM_StringArray* OpenMM_Platform_loadPluginsFromDirectory(const char* directory);
-extern OPENMM_EXPORT OpenMM_StringArray* OpenMM_Platform_getLoadFailures();
+extern OPENMM_EXPORT OpenMM_StringArray* OpenMM_Platform_getPluginLoadFailures();
 extern OPENMM_EXPORT char* OpenMM_XmlSerializer_serializeSystem(const OpenMM_System* system);
 extern OPENMM_EXPORT char* OpenMM_XmlSerializer_serializeState(const OpenMM_State* state);
 extern OPENMM_EXPORT char* OpenMM_XmlSerializer_serializeIntegrator(const OpenMM_Integrator* integrator);
@@ -805,8 +805,8 @@ OPENMM_EXPORT OpenMM_StringArray* OpenMM_Platform_loadPluginsFromDirectory(const
     vector<string> result = Platform::loadPluginsFromDirectory(string(directory));
     return reinterpret_cast<OpenMM_StringArray*>(new vector<string>(result));
 }
-OPENMM_EXPORT OpenMM_StringArray* OpenMM_Platform_getLoadFailures() {
-    vector<string> result = Platform::getLoadFailures();
+OPENMM_EXPORT OpenMM_StringArray* OpenMM_Platform_getPluginLoadFailures() {
+    vector<string> result = Platform::getPluginLoadFailures();
     return reinterpret_cast<OpenMM_StringArray*>(new vector<string>(result));
 }
 static char* createStringFromStream(stringstream& stream) {
@@ -1319,7 +1319,7 @@ MODULE OpenMM
             character(*) directory
             type(OpenMM_StringArray) result
         end subroutine
-        subroutine OpenMM_Platform_getLoadFailures(result)
+        subroutine OpenMM_Platform_getPluginLoadFailures(result)
             use OpenMM_Types; implicit none
             type(OpenMM_StringArray) result
         end subroutine
@@ -1997,11 +1997,11 @@ OPENMM_EXPORT void openmm_platform_loadpluginsfromdirectory_(const char* directo
 OPENMM_EXPORT void OPENMM_PLATFORM_LOADPLUGINSFROMDIRECTORY(const char* directory, OpenMM_StringArray*& result, int length) {
     result = OpenMM_Platform_loadPluginsFromDirectory(makeString(directory, length).c_str());
 }
-OPENMM_EXPORT void openmm_platform_getloadfailures_(OpenMM_StringArray*& result) {
-    result = OpenMM_Platform_getLoadFailures();
+OPENMM_EXPORT void openmm_platform_getpluginloadfailures_(OpenMM_StringArray*& result) {
+    result = OpenMM_Platform_getPluginLoadFailures();
 }
-OPENMM_EXPORT void OPENMM_PLATFORM_GETLOADFAILURES(OpenMM_StringArray*& result) {
-    result = OpenMM_Platform_getLoadFailures();
+OPENMM_EXPORT void OPENMM_PLATFORM_GETPLUGINLOADFAILURES(OpenMM_StringArray*& result) {
+    result = OpenMM_Platform_getPluginLoadFailures();
 }
 OPENMM_EXPORT void openmm_xmlserializer_serializesystemtoc_(OpenMM_System*& system, char*& result, int& result_length) {
     convertStringToChars(OpenMM_XmlSerializer_serializeSystem(system), result, result_length);

--- a/wrappers/python/src/swig_doxygen/swigInputConfig.py
+++ b/wrappers/python/src/swig_doxygen/swigInputConfig.py
@@ -180,7 +180,7 @@ UNITS = {
 ("*", "getParticleMass") : ("unit.amu", ()),
 ("*", "getPlatform") : (None, ()),
 ("*", "getPlatformByName") : (None, ()),
-("*", "getLoadFailures"): (None, ()),
+("*", "getPluginLoadFailures"): (None, ()),
 ("*", "getRandomNumberSeed") : (None, ()),
 ("*", "getReactionFieldDielectric") : (None, ()),
 ("*", "getSoluteDielectric") : (None, ()),

--- a/wrappers/python/src/swig_doxygen/swigInputConfig.py
+++ b/wrappers/python/src/swig_doxygen/swigInputConfig.py
@@ -180,6 +180,7 @@ UNITS = {
 ("*", "getParticleMass") : ("unit.amu", ()),
 ("*", "getPlatform") : (None, ()),
 ("*", "getPlatformByName") : (None, ()),
+("*", "getLoadFailures"): (None, ()),
 ("*", "getRandomNumberSeed") : (None, ()),
 ("*", "getReactionFieldDielectric") : (None, ()),
 ("*", "getSoluteDielectric") : (None, ()),


### PR DESCRIPTION
When debugging installations of the OpenMM OpenCL/CUDA platforms, the general error message is just 'There is no registered platform named CUDA', without any information about how to debug the problem. Usually it's caused by `LD_LIBRARY_PATH` not being set correctly or similar, and the first thing I always do with people is run `ldd` on the `libOpenMMCUDA.so` library, but that's not something they'd think to do themselves without knowledge of the OpenMM plugin architecture and the linker.

This PR adds a new static method to `Platform`, `getLoadFailures`, that returns a vector/tuple of strings containing the errors produced by the last call to `loadPluginsFromDirectory` (which is called from python during the import process).

So, for example, you can do

```
import simtk.openmm as mm
mm.Platform.getLoadFailures()
```
And get something like
```
('Error loading library /home/rmcgibbo/opt/openmm-6.3.dev/lib/plugins/libOpenMMCUDA.so: libcuda.so.1: cannot open shared object file: No such file or directory',)
```

