### PR TITLE
Clang 3.6 Broken?

### DIFF
--- a/openmmapi/include/openmm/internal/vectorize8.h
+++ b/openmmapi/include/openmm/internal/vectorize8.h
@@ -63,6 +63,14 @@ public:
     void store(float* v) const {
         _mm256_storeu_ps(v, val);
     }
+    void print() const {
+      float low[4];
+      float high[4];
+      lowerVec().store(low);
+      upperVec().store(high);
+      printf("%.5f %.5f %.5f %.5f %.5f %.5f %.5f %.5f\n", low[0], low[1], low[2], low[3],
+	     high[0], high[1], high[2], high[3]);
+    }
     fvec8 operator+(const fvec8& other) const {
         return _mm256_add_ps(val, other);
     }

--- a/platforms/cpu/src/CpuNonbondedForceVec8.cpp
+++ b/platforms/cpu/src/CpuNonbondedForceVec8.cpp
@@ -27,6 +27,7 @@
 #include "openmm/OpenMMException.h"
 #include "openmm/internal/hardware.h"
 #include <algorithm>
+#include <cstdio>
 
 using namespace std;
 using namespace OpenMM;
@@ -338,7 +339,7 @@ void CpuNonbondedForceVec8::calculateBlockEwaldIxnImpl(int blockIndex, float* fo
             continue; // No interactions to compute.
         
         // Compute the interactions.
-        
+
         fvec8 inverseR = rsqrt(r2);
         fvec8 r = r2*inverseR;
         fvec8 energy, dEdR;
@@ -364,7 +365,7 @@ void CpuNonbondedForceVec8::calculateBlockEwaldIxnImpl(int blockIndex, float* fo
             dEdR = 0.0f;
         }
         fvec8 chargeProd = blockAtomCharge*posq[4*atom+3];
-        dEdR += chargeProd*inverseR*ewaldScaleFunction(r);
+        dEdR += chargeProd*inverseR*ewaldScaleFunction(sqrt(r2));
         dEdR *= inverseR*inverseR;
 
         // Accumulate energies.
@@ -452,6 +453,19 @@ fvec8 CpuNonbondedForceVec8::ewaldScaleFunction(const fvec8& x) {
     fvec8 coeff1 = 1.0f-coeff2;
     ivec4 indexLower = index.lowerVec();
     ivec4 indexUpper = index.upperVec();
+
+    int lowerIndex[4] = {0,0,0,0};
+    int upperIndex[4] = {0,0,0,0};
+
+    printf("ewaldDXInv: %f\n", ewaldDXInv);
+    printf("x\n ");  x.print();
+    printf("x1\n ");x1.print();
+    
+    indexLower.store(lowerIndex);
+    indexUpper.store(upperIndex);
+    printf("indexLower: %d %d %d %d\n", lowerIndex[0], lowerIndex[1], lowerIndex[2], lowerIndex[3]);
+    printf("indexUpper: %d %d %d %d\n", upperIndex[0], upperIndex[1], upperIndex[2], upperIndex[3]);
+    
     fvec4 t1(&ewaldScaleTable[indexLower[0]]);
     fvec4 t2(&ewaldScaleTable[indexLower[1]]);
     fvec4 t3(&ewaldScaleTable[indexLower[2]]);


### PR DESCRIPTION
When compiling with clang 3.6 in debug mode, `TestCpuEwald` segfaults. (Can anyone else try this and confirm. In release mode, I get a test failure). The segfault is in `CpuNonbondedForceVec8::ewaldScaleFunction`.

I put in some print statements, and they don't make any sense. I'm pretty sure that clang is generating incorrect code.

Here's the printout.
```
$ make -j4 TestCpuEwald && ./TestCpuEwald
[  0%] Built target ApiWrappers
[ 94%] Built target OpenMM
[100%] Built target OpenMMCPU
[100%] Built target TestCpuEwald
ewaldDXInv: 1706.666626
x
 0.25269 0.38468 0.00000 0.44406 -0.00000 0.00000 -0.00000 0.00000
x1
 431.26358 656.52563 0.00000 757.85608 1.00000 -nan 1.00000 -nan
indexLower: 431 656 0 757
indexUpper: 0 0 -2139939872 32508
```

Note that the arithmatic here is just `x1 = x*1706.666626`. The first 4 lanes in the vector are correct, but the last 4 contain garbage.

Also, it looks like other people have found bugs in the AVX implementation in clang 3.6 https://llvm.org/bugs/show_bug.cgi?id=23441