### PR TITLE
Disable AVX CPU NonbondedForce on Clang 3.6.0 due to compiler bugs

### DIFF
--- a/platforms/cpu/src/CpuNonbondedForceVec8.cpp
+++ b/platforms/cpu/src/CpuNonbondedForceVec8.cpp
@@ -37,6 +37,12 @@ using namespace OpenMM;
     #undef __AVX__
 #endif
 
+#if defined (__clang__) && (__clang_major__==3) && (__clang_minor__==6)
+  // Workaround for a compiler bug in Clang 3.6.0
+  #undef __AVX__
+#endif
+
+
 #ifndef __AVX__
 bool isVec8Supported() {
     return false;


### PR DESCRIPTION
I tested clang 3.5.0 and the [nightly build](http://llvm.org/apt/) of clang 3.7.0 (in development), and they both work.

@peastman: should we be doing these compiler checks (this code is adjacent to a similar msvc check that disables AVX) in CMake, or here?