### PR TITLE
WIP: Nicer swig wrappers

### DIFF
--- a/wrappers/python/CMakeLists.txt
+++ b/wrappers/python/CMakeLists.txt
@@ -163,7 +163,6 @@ set(SWIG_INPUT_FILES2
     "${SWIG_OPENMM_DIR}/swig_lib/python/header.i"
     "${SWIG_OPENMM_DIR}/swig_lib/python/pythoncode.i"
     "${SWIG_OPENMM_DIR}/swig_lib/python/typemaps.i"
-    "${SWIG_OPENMM_DIR}/swig_lib/python/pythonprepend_all.i"
 )
 
 # Create input files for swig

--- a/wrappers/python/CMakeLists.txt
+++ b/wrappers/python/CMakeLists.txt
@@ -176,7 +176,7 @@ add_custom_command(
         -o OpenMMSwigHeaders.i
         -a swig_lib/python/pythonprepend.i
         -z swig_lib/python/pythonappend.i
-	-v "${SWIG_VERSION}"
+        -v "${SWIG_VERSION}"
     WORKING_DIRECTORY "${SWIG_OPENMM_DIR}"
     DEPENDS
         "${SWIG_OPENMM_DIR}/swigInputConfig.py"

--- a/wrappers/python/CMakeLists.txt
+++ b/wrappers/python/CMakeLists.txt
@@ -176,6 +176,7 @@ add_custom_command(
         -o OpenMMSwigHeaders.i
         -a swig_lib/python/pythonprepend.i
         -z swig_lib/python/pythonappend.i
+	-v "${SWIG_VERSION}"
     WORKING_DIRECTORY "${SWIG_OPENMM_DIR}"
     DEPENDS
         "${SWIG_OPENMM_DIR}/swigInputConfig.py"

--- a/wrappers/python/src/swig_doxygen/swig_lib/python/features.i
+++ b/wrappers/python/src/swig_doxygen/swig_lib/python/features.i
@@ -2,16 +2,7 @@
 %include exceptions.i
 %include extend.i
 %include header.i
-%include pythonprepend_all.i
 %include pythonprepend.i
 %include pythonappend.i
 %include typemaps.i
-/* SWIG 3.x resolved a bug in which all wrapped C++ functions took *args as its
- * default argument list. OpenMM then exploited this bug by doing stuff like
- * passing args to stripUnits (and all added code assumed that the arguments
- * were in an "args" list). So in order to restore this arguably buggy behavior
- * from SWIG 2, enable the "compactdefaultargs" feature globally.
- *
- * See https://github.com/swig/swig/issues/387
- */
-%feature("compactdefaultargs");
+

--- a/wrappers/python/src/swig_doxygen/swig_lib/python/pythoncode.i
+++ b/wrappers/python/src/swig_doxygen/swig_lib/python/pythoncode.i
@@ -219,68 +219,30 @@ class State(_object):
         return self._paramMap
 
 
-def stripUnits(args):
+def _stripUnit(arg):
+    """Remove units from a quantity and convert to OpenMM unit system,
+    suitable for use in C++ layer.
     """
-    getState(self, quantity)
-          -> value with *no* units
-
-    Examples
-    >>> import simtk
-
-    >>> x = 5
-    >>> print x
-    5
-
-    >>> x = stripUnits((5*simtk.unit.nanometer,))
-    >>> x
-    (5,)
-
-    >>> arg1 = 5*simtk.unit.angstrom
-    >>> x = stripUnits((arg1,))
-    >>> x
-    (0.5,)
-
-    >>> arg1 = 5
-    >>> x = stripUnits((arg1,))
-    >>> x
-    (5,)
-
-    >>> arg1 = (1*simtk.unit.angstrom, 5*simtk.unit.angstrom)
-    >>> x = stripUnits((arg1,))
-    >>> x
-    ((0.10000000000000001, 0.5),)
-
-    >>> arg1 = (1*simtk.unit.angstrom,
-    ...         5*simtk.unit.kilojoule_per_mole,
-    ...         1*simtk.unit.kilocalorie_per_mole)
-    >>> y = stripUnits((arg1,))
-    >>> y
-    ((0.10000000000000001, 5, 4.1840000000000002),)
-
-    """
-    newArgList=[]
-    for arg in args:
-        if 'numpy' in sys.modules and isinstance(arg, numpy.ndarray):
-           arg = arg.tolist()
-        elif unit.is_quantity(arg):
-            # JDC: Ugly workaround for OpenMM using 'bar' for fundamental pressure unit.
-            if arg.unit.is_compatible(unit.bar):
-                arg = arg / unit.bar
-            else:
-                arg = arg.value_in_unit_system(unit.md_unit_system)
-            # JDC: End workaround.
-        elif isinstance(arg, dict):
-            newKeys = stripUnits(arg.keys())
-            newValues = stripUnits(arg.values())
-            arg = dict(zip(newKeys, newValues))
-        elif not isinstance(arg, _string_types):
-            try:
-                # Reclusively strip units from all quantities
-                arg=stripUnits(arg)
-            except TypeError:
-                pass
-        newArgList.append(arg)
-    return tuple(newArgList)
+    if 'numpy' in sys.modules and isinstance(arg, numpy.ndarray):
+        arg = arg.tolist()
+    elif unit.is_quantity(arg):
+        # JDC: Ugly workaround for OpenMM using 'bar' for fundamental pressure unit.
+        if arg.unit.is_compatible(unit.bar):
+            arg = arg / unit.bar
+        else:
+            arg = arg.value_in_unit_system(unit.md_unit_system)
+        # JDC: End workaround.
+    elif isinstance(arg, dict):
+        newKeys = stripUnits(arg.keys())
+        newValues = stripUnits(arg.values())
+        arg = dict(zip(newKeys, newValues))
+    elif not isinstance(arg, _string_types):
+        try:
+            # Reclusively strip units from all quantities
+            arg = stripUnits(arg)
+        except TypeError:
+            pass
+    return arg
 %}
 
 %pythonappend OpenMM::Context::Context %{

--- a/wrappers/python/src/swig_doxygen/swig_lib/python/pythoncode.i
+++ b/wrappers/python/src/swig_doxygen/swig_lib/python/pythoncode.i
@@ -233,13 +233,13 @@ def _stripUnit(arg):
             arg = arg.value_in_unit_system(unit.md_unit_system)
         # JDC: End workaround.
     elif isinstance(arg, dict):
-        newKeys = stripUnits(arg.keys())
-        newValues = stripUnits(arg.values())
+        newKeys = [_stripUnit(k) for k in arg.keys()]
+        newValues = [_stripUnit(v) for v in arg.values()]
         arg = dict(zip(newKeys, newValues))
     elif not isinstance(arg, _string_types):
         try:
             # Reclusively strip units from all quantities
-            arg = stripUnits(arg)
+            arg = [_stripUnit(a) for a in arg]
         except TypeError:
             pass
     return arg

--- a/wrappers/python/src/swig_doxygen/swig_lib/python/pythonprepend_all.i
+++ b/wrappers/python/src/swig_doxygen/swig_lib/python/pythonprepend_all.i
@@ -1,5 +1,0 @@
-%pythonprepend %{
-try: args=stripUnits(args)
-except UnboundLocalError: pass
-%}
-


### PR DESCRIPTION
Re #882, #879, this now generates nicer swig wrappers that have the proper function signatures when using a sufficiently new version of swig (definitely 3.0.6, not 3.0.2, not sure exactly where in between).

Previously, all of the python wrappers formally had a signature like `openmm.LangevinIntegrator.setTemperature(self, *args)`. Using new swig, with this PR the signature is `LangevinIntegrator.setTemperature(self, temp)`. This allows you to use keyword arguments for example, for most methods.

Still some bugs to be worked out, I suspect. Try it out and let me know if it works for you.