### PR TITLE
Omit internal directories from API docs

### DIFF
--- a/docs-source/DoxyfileC++.in
+++ b/docs-source/DoxyfileC++.in
@@ -92,6 +92,7 @@ EXCLUDE_SYMLINKS       = NO
 EXCLUDE_PATTERNS       = */tests/* \
                          */openmmapi/src/* \
                          */.svn/* \
+                         */internal/* \
                          */olla/include/openmm/kernels.h \
                          */DrudeKernels.h \
                          */RpmdKernels.h \


### PR DESCRIPTION
This is a cleanup to the C++ API docs.  They were including lots of internal classes that weren't meant to be part of the public API.