### PR TITLE
Added missing Windows imports

### DIFF
--- a/platforms/cuda/src/CudaParameterSet.cpp
+++ b/platforms/cuda/src/CudaParameterSet.cpp
@@ -191,8 +191,8 @@ string CudaParameterSet::getParameterSuffix(int index, const std::string& extraS
  * Define template instantiations for float and double versions of getParameterValues() and setParameterValues().
  */
 namespace OpenMM {
-template void CudaParameterSet::getParameterValues<float>(vector<vector<float> >& values);
-template void CudaParameterSet::setParameterValues<float>(const vector<vector<float> >& values);
-template void CudaParameterSet::getParameterValues<double>(vector<vector<double> >& values);
-template void CudaParameterSet::setParameterValues<double>(const vector<vector<double> >& values);
+template OPENMM_EXPORT_CUDA void CudaParameterSet::getParameterValues<float>(vector<vector<float> >& values);
+template OPENMM_EXPORT_CUDA void CudaParameterSet::setParameterValues<float>(const vector<vector<float> >& values);
+template OPENMM_EXPORT_CUDA void CudaParameterSet::getParameterValues<double>(vector<vector<double> >& values);
+template OPENMM_EXPORT_CUDA void CudaParameterSet::setParameterValues<double>(const vector<vector<double> >& values);
 }

--- a/platforms/opencl/src/OpenCLParameterSet.cpp
+++ b/platforms/opencl/src/OpenCLParameterSet.cpp
@@ -198,8 +198,8 @@ string OpenCLParameterSet::getParameterSuffix(int index, const std::string& extr
  * Define template instantiations for float and double versions of getParameterValues() and setParameterValues().
  */
 namespace OpenMM {
-template void OpenCLParameterSet::getParameterValues<float>(vector<vector<float> >& values) const;
-template void OpenCLParameterSet::setParameterValues<float>(const vector<vector<float> >& values);
-template void OpenCLParameterSet::getParameterValues<double>(vector<vector<double> >& values) const;
-template void OpenCLParameterSet::setParameterValues<double>(const vector<vector<double> >& values);
+template OPENMM_EXPORT_OPENCL void OpenCLParameterSet::getParameterValues<float>(vector<vector<float> >& values) const;
+template OPENMM_EXPORT_OPENCL void OpenCLParameterSet::setParameterValues<float>(const vector<vector<float> >& values);
+template OPENMM_EXPORT_OPENCL void OpenCLParameterSet::getParameterValues<double>(vector<vector<double> >& values) const;
+template OPENMM_EXPORT_OPENCL void OpenCLParameterSet::setParameterValues<double>(const vector<vector<double> >& values);
 }


### PR DESCRIPTION
This caused a link error on Windows if you tried to compile a plugin that used CudaParameterSet or OpenCLParameterSet.