### PR TITLE
Implemented cloning of objects by serialization

### DIFF
--- a/serialization/include/openmm/serialization/XmlSerializer.h
+++ b/serialization/include/openmm/serialization/XmlSerializer.h
@@ -74,6 +74,18 @@ public:
     static T* deserialize(std::istream& stream) {
         return reinterpret_cast<T*>(deserializeStream(stream));
     }
+    /**
+     * Clone an object by first serializing it, then deserializing it again.  This method constructs the
+     * new object directly from the SerializationNodes without first converting them to XML.  This means
+     * it is faster and uses less memory than making separate calls to serialize() and deserialize().
+     */
+    template <class T>
+    static T* clone(const T& object) {
+        const SerializationProxy& proxy = SerializationProxy::getProxy(typeid(object));
+        SerializationNode node;
+        proxy.serialize(&object, node);
+        return reinterpret_cast<T*>(proxy.deserialize(node));
+    }
 private:
     class StreamReader;
     static void serialize(const SerializationNode& node, std::ostream& stream);

--- a/wrappers/python/src/swig_doxygen/swig_lib/python/extend.i
+++ b/wrappers/python/src/swig_doxygen/swig_lib/python/extend.i
@@ -272,10 +272,15 @@ Parameters:
     def __setstate__(self, serializationString):
         system = XmlSerializer.deserializeSystem(serializationString)
         self.this = system.this
+    def __deepcopy__(self, memo):
+        return self.__copy__()
     def getForces(self):
         """Get the list of Forces in this System"""
         return [self.getForce(i) for i in range(self.getNumForces())]
   %}
+  OpenMM::System* __copy__() {
+      return OpenMM::XmlSerializer::clone<OpenMM::System>(*self);
+  }
 }
 
 %extend OpenMM::XmlSerializer {
@@ -444,14 +449,12 @@ Parameters:
 
 %extend OpenMM::Force {
   %pythoncode %{
-    def __copy__(self):
-        copy = self.__class__.__new__(self.__class__)
-        copy.__init__(self)
-        return copy
-
     def __deepcopy__(self, memo):
         return self.__copy__()
   %}
+  OpenMM::Force* __copy__() {
+      return OpenMM::XmlSerializer::clone<OpenMM::Force>(*self);
+  }
 }
 
 %extend OpenMM::Integrator {
@@ -463,5 +466,11 @@ Parameters:
     def __setstate__(self, serializationString):
         system = XmlSerializer.deserialize(serializationString)
         self.this = system.this
+
+    def __deepcopy__(self, memo):
+        return self.__copy__()
   %}
+  OpenMM::Integrator* __copy__() {
+      return OpenMM::XmlSerializer::clone<OpenMM::Integrator>(*self);
+  }
 }


### PR DESCRIPTION
Implements #542.  For Python, just call copy() or deepcopy() as usual.  For C++, call XmlSerializer::clone().