### PR TITLE
Add a set of unit tests for unit handling in the core API.

### DIFF
--- a/devtools/forcefield-scripts/processTinkerForceField.py
+++ b/devtools/forcefield-scripts/processTinkerForceField.py
@@ -1017,7 +1017,6 @@ if( isAmoeba ):
     torsionTorsionUnit      = 1.0
     outputString            = """ <AmoebaTorsionTorsionForce >"""
     tinkerXmlFile.write( "%s\n" % (outputString ) )
-    conversion              = 41.84/radian
     torsionTorsions         = forces['tortors']
     for (index, torsionTorsion) in enumerate(torsionTorsions):
        torInfo       = torsionTorsion[0]

--- a/plugins/amoeba/openmmapi/include/openmm/AmoebaAngleForce.h
+++ b/plugins/amoeba/openmmapi/include/openmm/AmoebaAngleForce.h
@@ -127,7 +127,7 @@ public:
      * @param particle1     the index of the first particle connected by the angle
      * @param particle2     the index of the second particle connected by the angle
      * @param particle3     the index of the third particle connected by the angle
-     * @param length        the equilibrium angle, measured in degrees if >2*pi, otherwise interpreted as radians
+     * @param length        the equilibrium angle, measured in degrees
      * @param quadratic k   the quadratic force constant for the angle, measured in kJ/mol/radian^2
      * @return the index of the angle that was added
      */
@@ -152,7 +152,7 @@ public:
      * @param particle1     the index of the first particle connected by the angle
      * @param particle2     the index of the second particle connected by the angle
      * @param particle3     the index of the third particle connected by the angle
-     * @param length        the equilibrium angle, measured in degrees if >2*pi, otherwise interpreted as radians
+     * @param length        the equilibrium angle, measured in degrees
      * @param quadratic k   the quadratic force constant for the angle, measured in kJ/mol/radian^2
      */
     void setAngleParameters(int index, int particle1, int particle2, int particle3, double length, double quadraticK);

--- a/plugins/amoeba/openmmapi/include/openmm/AmoebaAngleForce.h
+++ b/plugins/amoeba/openmmapi/include/openmm/AmoebaAngleForce.h
@@ -140,7 +140,7 @@ public:
      * @param particle1     the index of the first particle connected by the angle
      * @param particle2     the index of the second particle connected by the angle
      * @param particle3     the index of the third particle connected by the angle
-     * @param length        the equilibrium angle, measured in degrees if >2*pi, otherwise interpreted as radians
+     * @param length        the equilibrium angle, measured in degrees
      * @param quadratic k   the quadratic force constant for the angle, measured in kJ/mol/radian^2
      */
     void getAngleParameters(int index, int& particle1, int& particle2, int& particle3, double& length, double& quadraticK) const;

--- a/plugins/amoeba/openmmapi/include/openmm/AmoebaAngleForce.h
+++ b/plugins/amoeba/openmmapi/include/openmm/AmoebaAngleForce.h
@@ -127,7 +127,7 @@ public:
      * @param particle1     the index of the first particle connected by the angle
      * @param particle2     the index of the second particle connected by the angle
      * @param particle3     the index of the third particle connected by the angle
-     * @param length        the angle measured in degrees
+     * @param length        the equilibrium angle, measured in degrees if >2*pi, otherwise interpreted as radians
      * @param quadratic k   the quadratic force constant for the angle, measured in kJ/mol/radian^2
      * @return the index of the angle that was added
      */
@@ -140,7 +140,7 @@ public:
      * @param particle1     the index of the first particle connected by the angle
      * @param particle2     the index of the second particle connected by the angle
      * @param particle3     the index of the third particle connected by the angle
-     * @param length        the equilibrium angle, measured in degress
+     * @param length        the equilibrium angle, measured in degrees if >2*pi, otherwise interpreted as radians
      * @param quadratic k   the quadratic force constant for the angle, measured in kJ/mol/radian^2
      */
     void getAngleParameters(int index, int& particle1, int& particle2, int& particle3, double& length, double& quadraticK) const;
@@ -152,7 +152,7 @@ public:
      * @param particle1     the index of the first particle connected by the angle
      * @param particle2     the index of the second particle connected by the angle
      * @param particle3     the index of the third particle connected by the angle
-     * @param length        the equilibrium angle, measured in degrees
+     * @param length        the equilibrium angle, measured in degrees if >2*pi, otherwise interpreted as radians
      * @param quadratic k   the quadratic force constant for the angle, measured in kJ/mol/radian^2
      */
     void setAngleParameters(int index, int particle1, int particle2, int particle3, double length, double quadraticK);

--- a/plugins/amoeba/openmmapi/include/openmm/AmoebaOutOfPlaneBendForce.h
+++ b/plugins/amoeba/openmmapi/include/openmm/AmoebaOutOfPlaneBendForce.h
@@ -74,7 +74,7 @@ public:
      * 
      * @return global cubicK term
      */
-    double getAmoebaGlobalOutOfPlaneBendCubic(void) const;
+    double getAmoebaGlobalOutOfPlaneBendCubic() const;
 
     /** 
      * Set the global cubic term
@@ -88,7 +88,7 @@ public:
      * 
      * @return global  quartic term
      */
-    double getAmoebaGlobalOutOfPlaneBendQuartic(void) const;
+    double getAmoebaGlobalOutOfPlaneBendQuartic() const;
 
     /** 
      * Set the global pentic term
@@ -102,7 +102,7 @@ public:
      * 
      * @return global penticK term
      */
-    double getAmoebaGlobalOutOfPlaneBendPentic(void) const;
+    double getAmoebaGlobalOutOfPlaneBendPentic() const;
 
     /** 
      * Set the global sextic term
@@ -116,7 +116,7 @@ public:
      * 
      * @return global sexticK term
      */
-    double getAmoebaGlobalOutOfPlaneBendSextic(void) const;
+    double getAmoebaGlobalOutOfPlaneBendSextic() const;
 
     /**
      * Add an out-of-plane bend term to the force field.

--- a/plugins/amoeba/openmmapi/src/AmoebaAngleForce.cpp
+++ b/plugins/amoeba/openmmapi/src/AmoebaAngleForce.cpp
@@ -29,6 +29,7 @@
  * USE OR OTHER DEALINGS IN THE SOFTWARE.                                     *
  * -------------------------------------------------------------------------- */
 
+#include <cmath>
 #include "openmm/Force.h"
 #include "openmm/OpenMMException.h"
 #include "openmm/AmoebaAngleForce.h"
@@ -41,6 +42,7 @@ AmoebaAngleForce::AmoebaAngleForce() {
 }
 
 int AmoebaAngleForce::addAngle(int particle1, int particle2, int particle3,  double length, double quadraticK) {
+    length = length < 2*M_PI ? length * 180.0/M_PI : length;
     angles.push_back(AngleInfo(particle1, particle2, particle3, length, quadraticK));
     return angles.size()-1;
 }
@@ -59,7 +61,7 @@ void AmoebaAngleForce::setAngleParameters(int index, int particle1, int particle
     angles[index].particle1  = particle1;
     angles[index].particle2  = particle2;
     angles[index].particle3  = particle3;
-    angles[index].length     = length;
+    angles[index].length     = length < 2*M_PI ? length * 180.0/M_PI : length;
     angles[index].quadraticK = quadraticK;
 }
 

--- a/plugins/amoeba/openmmapi/src/AmoebaAngleForce.cpp
+++ b/plugins/amoeba/openmmapi/src/AmoebaAngleForce.cpp
@@ -29,8 +29,6 @@
  * USE OR OTHER DEALINGS IN THE SOFTWARE.                                     *
  * -------------------------------------------------------------------------- */
 
-#define _USE_MATH_DEFINES 1 /* Needed for Windows */
-#include <cmath>
 #include "openmm/Force.h"
 #include "openmm/OpenMMException.h"
 #include "openmm/AmoebaAngleForce.h"
@@ -43,7 +41,6 @@ AmoebaAngleForce::AmoebaAngleForce() {
 }
 
 int AmoebaAngleForce::addAngle(int particle1, int particle2, int particle3,  double length, double quadraticK) {
-    length = length < 2*M_PI ? length * 180.0/M_PI : length;
     angles.push_back(AngleInfo(particle1, particle2, particle3, length, quadraticK));
     return angles.size()-1;
 }
@@ -62,7 +59,7 @@ void AmoebaAngleForce::setAngleParameters(int index, int particle1, int particle
     angles[index].particle1  = particle1;
     angles[index].particle2  = particle2;
     angles[index].particle3  = particle3;
-    angles[index].length     = length < 2*M_PI ? length * 180.0/M_PI : length;
+    angles[index].length     = length;
     angles[index].quadraticK = quadraticK;
 }
 

--- a/plugins/amoeba/openmmapi/src/AmoebaAngleForce.cpp
+++ b/plugins/amoeba/openmmapi/src/AmoebaAngleForce.cpp
@@ -29,6 +29,7 @@
  * USE OR OTHER DEALINGS IN THE SOFTWARE.                                     *
  * -------------------------------------------------------------------------- */
 
+#define _USE_MATH_DEFINES 1 /* Needed for Windows */
 #include <cmath>
 #include "openmm/Force.h"
 #include "openmm/OpenMMException.h"

--- a/wrappers/python/src/swig_doxygen/swigInputBuilder.py
+++ b/wrappers/python/src/swig_doxygen/swigInputBuilder.py
@@ -481,7 +481,6 @@ class SwigInputBuilder:
                     sys.stdout.write("%s.%s() returns %s\n" %
                                      (shortClassName, methName, valueUnits[0]))
                     if len(valueUnits[1])>0:
-                        print('IT IS GREATER THAN 1')
                         addText = "%s%sval[%d]=unit.Quantity(val[%d], %s)\n" \
                                  % (addText, INDENT,
                                     index, index,
@@ -492,10 +491,10 @@ class SwigInputBuilder:
                                  % (addText, INDENT, valueUnits[0])
 
                 for vUnit in valueUnits[1]:
-                        if vUnit!=None:
-                            addText = "%s%sval[%s]=unit.Quantity(val[%s], %s)\n" \
+                    if vUnit is not None:
+                        addText = "%s%sval[%s]=unit.Quantity(val[%s], %s)\n" \
                                      % (addText, INDENT, index, index, vUnit)
-                        index+=1
+                    index+=1
 
                 if key in self.configModule.STEAL_OWNERSHIP:
                     for argNum in self.configModule.STEAL_OWNERSHIP[key]:

--- a/wrappers/python/src/swig_doxygen/swigInputBuilder.py
+++ b/wrappers/python/src/swig_doxygen/swigInputBuilder.py
@@ -10,6 +10,7 @@ import getopt
 import re
 import xml.etree.ElementTree as etree
 from distutils.version import LooseVersion
+import copy
 
 try:
     from html.parser import HTMLParser
@@ -19,7 +20,6 @@ except ImportError:
 
 INDENT = "   "
 docTags = {'emphasis':'i', 'bold':'b', 'itemizedlist':'ul', 'listitem':'li', 'preformatted':'pre', 'computeroutput':'tt', 'subscript':'sub'}
-
 
 def striphtmltags(s):
     """Strip a couple html tags used inside docstrings in the C++ source
@@ -477,10 +477,11 @@ class SwigInputBuilder:
                     valueUnits=[None, ()]
 
                 index=0
-                if valueUnits[0]:
+                if valueUnits[0] is not None:
                     sys.stdout.write("%s.%s() returns %s\n" %
                                      (shortClassName, methName, valueUnits[0]))
                     if len(valueUnits[1])>0:
+                        print('IT IS GREATER THAN 1')
                         addText = "%s%sval[%d]=unit.Quantity(val[%d], %s)\n" \
                                  % (addText, INDENT,
                                     index, index,

--- a/wrappers/python/src/swig_doxygen/swigInputBuilder.py
+++ b/wrappers/python/src/swig_doxygen/swigInputBuilder.py
@@ -157,7 +157,7 @@ class SwigInputBuilder:
                  skipAdditionalMethods=[],
                  SWIG_VERSION='3.0.2'):
         self.nodeByID={}
-        self.SWIG_COMPACT_ARGUMENTS = LooseVersion(SWIG_VERSION) < LooseVersion('3.0.6')
+        self.SWIG_COMPACT_ARGUMENTS = LooseVersion(SWIG_VERSION) < LooseVersion('3.0.5')
 
         self.configModule = __import__(os.path.splitext(configFilename)[0])
 

--- a/wrappers/python/src/swig_doxygen/swigInputConfig.py
+++ b/wrappers/python/src/swig_doxygen/swigInputConfig.py
@@ -256,7 +256,9 @@ UNITS = {
 #    void getCovalentMap(int index, CovalentType typeId, std::vector<int>& covalentAtoms )
 #    void getCovalentMaps(int index, std::vector < std::vector<int> >& covalentLists )
 
-("AmoebaMultipoleForce",                 "getMultipoleParameters")                        :  ( None, ()),
+("AmoebaMultipoleForce",                 "getMultipoleParameters")                        :  ( None, ('unit.elementary_charge', 'unit.elementary_charge/unit.nanometer',
+                                                                                                      'unit.elementary_charge/unit.nanometer**2', None, None, None, None, None, None,
+                                                                                                      'unit.nanometer**3')),
 ("AmoebaMultipoleForce",                 "getCovalentMap")                                :  ( None, ()),
 ("AmoebaMultipoleForce",                 "getCovalentMaps")                               :  ( None, ()),
 ("AmoebaMultipoleForce",                 "getScalingDistanceCutoff")                      :  ( 'unit.nanometer', ()),

--- a/wrappers/python/src/swig_doxygen/swigInputConfig.py
+++ b/wrappers/python/src/swig_doxygen/swigInputConfig.py
@@ -378,6 +378,9 @@ UNITS = {
 ("CustomTorsionForce", "getPerTorsionParameterName") : (None, ()),
 ("CustomTorsionForce", "getGlobalParameterName") : (None, ()),
 ("CustomTorsionForce", "getTorsionParameters") : (None, ()),
+("DrudeForce", "getParticleParameters") : (None, (None, None, None, None, None, 'unit.elementary_charge', 'unit.nanometer**3', None, None)),
+("DrudeForce", "getNumScreenedPairs") : (None, ()),
+("DrudeForce", "getScreenedPairParameters") : (None, ()),
 ("GBSAOBCForce", "getParticleParameters")
  : (None, ('unit.elementary_charge',
            'unit.nanometer', None)),

--- a/wrappers/python/src/swig_doxygen/swigInputConfig.py
+++ b/wrappers/python/src/swig_doxygen/swigInputConfig.py
@@ -224,8 +224,8 @@ UNITS = {
 ("AmoebaAngleForce",             "getAmoebaGlobalAngleSextic")            :  ( None,()),
 ("AmoebaAngleForce",             "getAngleParameters")                            :  ( None, (None, None, None, 'unit.radian', 'unit.kilojoule_per_mole/(unit.radian*unit.radian)')),
 
-("AmoebaBondForce",              "getAmoebaGlobalBondCubic")              :  ( None,()),
-("AmoebaBondForce",              "getAmoebaGlobalBondQuartic")            :  ( None,()),
+("AmoebaBondForce",              "getAmoebaGlobalBondCubic")              :  ( '1/unit.nanometer',()),
+("AmoebaBondForce",              "getAmoebaGlobalBondQuartic")            :  ( '1/unit.nanometer**2',()),
 ("AmoebaBondForce",              "getBondParameters")                             :  ( None, (None, None, 'unit.nanometer', 'unit.kilojoule_per_mole/(unit.nanometer*unit.nanometer)')),
 
 ("AmoebaInPlaneAngleForce",      "getAmoebaGlobalInPlaneAngleCubic")      :  ( None,()),

--- a/wrappers/python/src/swig_doxygen/swigInputConfig.py
+++ b/wrappers/python/src/swig_doxygen/swigInputConfig.py
@@ -218,11 +218,11 @@ UNITS = {
 ("AmoebaGeneralizedKirkwoodForce",       "getProbeRadius")                                :  ( 'unit.nanometer', ()),
 ("AmoebaGeneralizedKirkwoodForce",       "getSurfaceAreaFactor")                          :  ( '(unit.nanometer*unit.nanometer)/unit.kilojoule_per_mole',()),
 
-("AmoebaAngleForce",             "getAmoebaGlobalAngleCubic")             :  ( None,()),
-("AmoebaAngleForce",             "getAmoebaGlobalAngleQuartic")           :  ( None,()),
-("AmoebaAngleForce",             "getAmoebaGlobalAnglePentic")            :  ( None,()),
-("AmoebaAngleForce",             "getAmoebaGlobalAngleSextic")            :  ( None,()),
-("AmoebaAngleForce",             "getAngleParameters")                            :  ( None, (None, None, None, 'unit.radian', 'unit.kilojoule_per_mole/(unit.radian*unit.radian)')),
+("AmoebaAngleForce",             "getAmoebaGlobalAngleCubic")             :  ( '1/unit.radian',()),
+("AmoebaAngleForce",             "getAmoebaGlobalAngleQuartic")           :  ( '1/unit.radian**2',()),
+("AmoebaAngleForce",             "getAmoebaGlobalAnglePentic")            :  ( '1/unit.radian**3',()),
+("AmoebaAngleForce",             "getAmoebaGlobalAngleSextic")            :  ( '1/unit.radian**4',()),
+("AmoebaAngleForce",             "getAngleParameters")                            :  ( None, (None, None, None, 'unit.degree', 'unit.kilojoule_per_mole/(unit.radian*unit.radian)')),
 
 ("AmoebaBondForce",              "getAmoebaGlobalBondCubic")              :  ( '1/unit.nanometer',()),
 ("AmoebaBondForce",              "getAmoebaGlobalBondQuartic")            :  ( '1/unit.nanometer**2',()),

--- a/wrappers/python/src/swig_doxygen/swigInputConfig.py
+++ b/wrappers/python/src/swig_doxygen/swigInputConfig.py
@@ -268,10 +268,10 @@ UNITS = {
 ("AmoebaMultipoleForce",                 "getSystemMultipoleMoments")                     :  ( None, ()),
 
 ("AmoebaOutOfPlaneBendForce",            "getNumOutOfPlaneBends")                         :  ( None, ()),
-("AmoebaOutOfPlaneBendForce",            "getAmoebaGlobalOutOfPlaneBendCubic")            :  ( None,()),
-("AmoebaOutOfPlaneBendForce",            "getAmoebaGlobalOutOfPlaneBendQuartic")          :  ( None,()),
-("AmoebaOutOfPlaneBendForce",            "getAmoebaGlobalOutOfPlaneBendPentic")           :  ( None,()),
-("AmoebaOutOfPlaneBendForce",            "getAmoebaGlobalOutOfPlaneBendSextic")           :  ( None,()),
+("AmoebaOutOfPlaneBendForce",            "getAmoebaGlobalOutOfPlaneBendCubic")            :  ( '1/unit.radian',()),
+("AmoebaOutOfPlaneBendForce",            "getAmoebaGlobalOutOfPlaneBendQuartic")          :  ( '1/unit.radian**2',()),
+("AmoebaOutOfPlaneBendForce",            "getAmoebaGlobalOutOfPlaneBendPentic")           :  ( '1/unit.radian**3',()),
+("AmoebaOutOfPlaneBendForce",            "getAmoebaGlobalOutOfPlaneBendSextic")           :  ( '1/unit.radian**4',()),
 ("AmoebaOutOfPlaneBendForce",            "getOutOfPlaneBendParameters")                   :  ( None, (None, None, None, None, 'unit.kilojoule_per_mole')),
 
 ("AmoebaPiTorsionForce",                  "getNumPiTorsions")                              :  ( None, ()),

--- a/wrappers/python/src/swig_doxygen/swigInputConfig.py
+++ b/wrappers/python/src/swig_doxygen/swigInputConfig.py
@@ -216,7 +216,7 @@ UNITS = {
 ("AmoebaGeneralizedKirkwoodForce",       "getDielectricOffset")                           :  ( 'unit.nanometer', ()),
 ("AmoebaGeneralizedKirkwoodForce",       "getIncludeCavityTerm")                          :  ( None,()),
 ("AmoebaGeneralizedKirkwoodForce",       "getProbeRadius")                                :  ( 'unit.nanometer', ()),
-("AmoebaGeneralizedKirkwoodForce",       "getSurfaceAreaFactor")                          :  ( '(unit.nanometer*unit.nanometer)/unit.kilojoule_per_mole',()),
+("AmoebaGeneralizedKirkwoodForce",       "getSurfaceAreaFactor")                          :  ( 'unit.kilojoule_per_mole/(unit.nanometer*unit.nanometer)',()),
 
 ("AmoebaAngleForce",             "getAmoebaGlobalAngleCubic")             :  ( '1/unit.radian',()),
 ("AmoebaAngleForce",             "getAmoebaGlobalAngleQuartic")           :  ( '1/unit.radian**2',()),

--- a/wrappers/python/src/swig_doxygen/swigInputConfig.py
+++ b/wrappers/python/src/swig_doxygen/swigInputConfig.py
@@ -228,10 +228,10 @@ UNITS = {
 ("AmoebaBondForce",              "getAmoebaGlobalBondQuartic")            :  ( '1/unit.nanometer**2',()),
 ("AmoebaBondForce",              "getBondParameters")                             :  ( None, (None, None, 'unit.nanometer', 'unit.kilojoule_per_mole/(unit.nanometer*unit.nanometer)')),
 
-("AmoebaInPlaneAngleForce",      "getAmoebaGlobalInPlaneAngleCubic")      :  ( None,()),
-("AmoebaInPlaneAngleForce",      "getAmoebaGlobalInPlaneAngleQuartic")    :  ( None,()),
-("AmoebaInPlaneAngleForce",      "getAmoebaGlobalInPlaneAnglePentic")     :  ( None,()),
-("AmoebaInPlaneAngleForce",      "getAmoebaGlobalInPlaneAngleSextic")     :  ( None,()),
+("AmoebaInPlaneAngleForce",      "getAmoebaGlobalInPlaneAngleCubic")      :  ( '1/unit.radian',()),
+("AmoebaInPlaneAngleForce",      "getAmoebaGlobalInPlaneAngleQuartic")    :  ( '1/unit.radian**2',()),
+("AmoebaInPlaneAngleForce",      "getAmoebaGlobalInPlaneAnglePentic")     :  ( '1/unit.radian**3',()),
+("AmoebaInPlaneAngleForce",      "getAmoebaGlobalInPlaneAngleSextic")     :  ( '1/unit.radian**4',()),
 ("AmoebaInPlaneAngleForce",      "getAngleParameters")                            :  ( None, (None, None, None, None, 'unit.radian', 'unit.kilojoule_per_mole/(unit.radian*unit.radian)')),
 
 ("AmoebaMultipoleForce",                 "getNumMultipoles")                              :  ( None,()),

--- a/wrappers/python/src/swig_doxygen/swigInputConfig.py
+++ b/wrappers/python/src/swig_doxygen/swigInputConfig.py
@@ -272,7 +272,7 @@ UNITS = {
 ("AmoebaOutOfPlaneBendForce",            "getAmoebaGlobalOutOfPlaneBendQuartic")          :  ( '1/unit.radian**2',()),
 ("AmoebaOutOfPlaneBendForce",            "getAmoebaGlobalOutOfPlaneBendPentic")           :  ( '1/unit.radian**3',()),
 ("AmoebaOutOfPlaneBendForce",            "getAmoebaGlobalOutOfPlaneBendSextic")           :  ( '1/unit.radian**4',()),
-("AmoebaOutOfPlaneBendForce",            "getOutOfPlaneBendParameters")                   :  ( None, (None, None, None, None, 'unit.kilojoule_per_mole')),
+("AmoebaOutOfPlaneBendForce",            "getOutOfPlaneBendParameters")                   :  ( None, (None, None, None, None, 'unit.kilojoule_per_mole/unit.radians**2')),
 
 ("AmoebaPiTorsionForce",                  "getNumPiTorsions")                              :  ( None, ()),
 ("AmoebaPiTorsionForce",                  "getPiTorsionParameters")                        :  ( None, (None, None, None, None, None,  None, 'unit.kilojoule_per_mole')),

--- a/wrappers/python/src/swig_doxygen/swigInputConfig.py
+++ b/wrappers/python/src/swig_doxygen/swigInputConfig.py
@@ -278,7 +278,7 @@ UNITS = {
 ("AmoebaPiTorsionForce",                  "getPiTorsionParameters")                        :  ( None, (None, None, None, None, None,  None, 'unit.kilojoule_per_mole')),
 
 ("AmoebaStretchBendForce",                "getNumStretchBends")                            :  ( None, ()),
-("AmoebaStretchBendForce",                "getStretchBendParameters")                      :  ( None, (None, None, None, 'unit.nanometer', 'unit.nanometer', 'unit.radian', 'unit.kilojoule_per_mole/unit.nanometer/unit.degree', 'unit.kilojoule_per_mole/unit.nanometer/unit.degree')),
+("AmoebaStretchBendForce",                "getStretchBendParameters")                      :  ( None, (None, None, None, 'unit.nanometer', 'unit.nanometer', 'unit.radian', 'unit.kilojoule_per_mole/unit.nanometer/unit.radian', 'unit.kilojoule_per_mole/unit.nanometer/unit.radian')),
 
 ("AmoebaTorsionTorsionForce",             "getNumTorsionTorsions")                         :  ( None, ()),
 ("AmoebaTorsionTorsionForce",             "getNumTorsionTorsionGrids")                     :  ( None, ()),

--- a/wrappers/python/src/swig_doxygen/swig_lib/python/pythoncode.i
+++ b/wrappers/python/src/swig_doxygen/swig_lib/python/pythoncode.i
@@ -2,9 +2,10 @@
 
 try:
     import numpy
-except:
-    pass
+except ImportError:
+    numpy = None
 
+import copy
 import sys
 import math
 RMIN_PER_SIGMA=math.pow(2, 1/6.0)
@@ -223,4 +224,71 @@ class State(_object):
 %pythonappend OpenMM::Context::Context %{
     self._system = args[0]
     self._integrator = args[1]
+%}
+
+%pythonprepend OpenMM::AmoebaAngleForce::addAngle %{
+    try:
+        length = args[3]
+        if isinstance(args, tuple):
+            args = list(args)
+    except (NameError, UnboundLocalError):
+        if unit.is_quantity(length):
+            length = length.value_in_unit(unit.degree)
+    else:
+        if unit.is_quantity(length):
+            args[3] = length.value_in_unit(unit.degree)
+%}
+
+%pythonprepend OpenMM::AmoebaAngleForce::setAngleParameters %{
+    try:
+        length = args[4]
+        if isinstance(args, tuple):
+            args = list(args)
+    except (NameError, UnboundLocalError):
+        if unit.is_quantity(length):
+            length = length.value_in_unit(unit.degree)
+    else:
+        if unit.is_quantity(length):
+            args[4] = length.value_in_unit(unit.degree)
+%}
+
+%pythonprepend OpenMM::AmoebaTorsionTorsionForce::setTorsionTorsionGrid %{
+    def deunitize_grid(grid):
+        if isinstance(grid, tuple):
+            grid = list(grid)
+        for i, row in enumerate(grid):
+            if isinstance(row, tuple):
+                row = list(row)
+                grid[i] = row
+            for i, column in enumerate(row):
+                if isinstance(column, tuple):
+                    column = list(column)
+                    row[i] = column
+                # Data is angle, angle, energy, de/dang1, de/dang2, d^2e/dang1dang2
+                if unit.is_quantity(column[0]):
+                    column[0] = column[0].value_in_unit(unit.degree)
+                if unit.is_quantity(column[1]):
+                    column[1] = column[1].value_in_unit(unit.degree)
+                if unit.is_quantity(column[2]):
+                    column[2] = column[2].value_in_unit(unit.kilojoule_per_mole)
+                if len(column) > 3 and unit.is_quantity(column[3]):
+                    column[3] = column[3].value_in_unit(unit.kilojoule_per_mole/unit.radians)
+                if len(column) > 4 and unit.is_quantity(column[4]):
+                    column[4] = column[4].value_in_unit(unit.kilojoule_per_mole/unit.radians)
+                if len(column) > 5 and unit.is_quantity(column[5]):
+                    column[5] = column[5].value_in_unit(unit.kilojoule_per_mole/unit.radians**2)
+        return grid
+    try:
+        grid = copy.deepcopy(args[1])
+        if isinstance(args, tuple):
+            args = list(args)
+    except (NameError, UnboundLocalError):
+        try:
+            # Support numpy arrays
+            grid = grid.tolist()
+        except AttributeError:
+            grid = copy.deepcopy(grid)
+        grid = deunitize_grid(grid)
+    else:
+        args[1] = deunitize_grid(grid)
 %}

--- a/wrappers/python/tests/TestAPIUnits.py
+++ b/wrappers/python/tests/TestAPIUnits.py
@@ -521,6 +521,71 @@ class TestAPIUnits(unittest.TestCase):
         self.assertEqual(force.getParticleParameters(1)[0][0], 20)
         self.assertEqual(force.getParticleParameters(2)[0][0], 30*4.184)
 
+    def testDrudeForce(self):
+        """ Tests the DrudeForce API features """
+        force = DrudeForce()
+        self.assertFalse(force.usesPeriodicBoundaryConditions())
+        force.addParticle(0, 1, -1, -1, -1, 1, 1, 0, 0)
+        force.addParticle(1, 2, 3, -1, -1, 1*elementary_charge, 1*angstrom**3, 0.5, 0)
+        force.addParticle(2, 3, 4, 5, 6, 1*elementary_charge, 10*angstrom**3, 0.5, 0.5)
+        force.addScreenedPair(0, 1, 0.5)
+        force.addScreenedPair(1, 2, 0.25)
+        force.addScreenedPair(0, 2, 0.125)
+
+        self.assertEqual(force.getNumParticles(), 3)
+        self.assertEqual(force.getNumScreenedPairs(), 3)
+
+        i, j, k, l, m, q, a, an12, an34 = force.getParticleParameters(0)
+
+        self.assertEqual(i, 0)
+        self.assertEqual(j, 1)
+        self.assertEqual(k, -1)
+        self.assertEqual(l, -1)
+        self.assertEqual(m, -1)
+        self.assertEqual(q, 1*elementary_charge)
+        self.assertEqual(a, 1*nanometer**3)
+        self.assertEqual(an12, 0)
+        self.assertEqual(an34, 0)
+
+        i, j, k, l, m, q, a, an12, an34 = force.getParticleParameters(1)
+
+        self.assertEqual(i, 1)
+        self.assertEqual(j, 2)
+        self.assertEqual(k, 3)
+        self.assertEqual(l, -1)
+        self.assertEqual(m, -1)
+        self.assertEqual(q, 1*elementary_charge)
+        self.assertAlmostEqualUnit(a, 1*angstrom**3)
+        self.assertEqual(an12, 0.5)
+        self.assertEqual(an34, 0)
+
+        i, j, k, l, m, q, a, an12, an34 = force.getParticleParameters(2)
+
+        self.assertEqual(i, 2)
+        self.assertEqual(j, 3)
+        self.assertEqual(k, 4)
+        self.assertEqual(l, 5)
+        self.assertEqual(m, 6)
+        self.assertEqual(q, 1*elementary_charge)
+        self.assertAlmostEqualUnit(a, 10*angstrom**3)
+        self.assertEqual(an12, 0.5)
+        self.assertEqual(an34, 0.5)
+
+        i, j, thole = force.getScreenedPairParameters(0)
+        self.assertEqual(i, 0)
+        self.assertEqual(j, 1)
+        self.assertEqual(thole, 0.5)
+
+        i, j, thole = force.getScreenedPairParameters(1)
+        self.assertEqual(i, 1)
+        self.assertEqual(j, 2)
+        self.assertEqual(thole, 0.25)
+
+        i, j, thole = force.getScreenedPairParameters(2)
+        self.assertEqual(i, 0)
+        self.assertEqual(j, 2)
+        self.assertEqual(thole, 0.125)
+
     def testAmoebaBondForce(self):
         """ Tests the AmoebaBondForce API features """
         force1 = AmoebaBondForce()

--- a/wrappers/python/tests/TestAPIUnits.py
+++ b/wrappers/python/tests/TestAPIUnits.py
@@ -636,5 +636,50 @@ class TestAPIUnits(unittest.TestCase):
         self.assertIs(r.unit, nanometer)
         self.assertEqual(s, 0.4)
 
+    def testAmoebaInPlaneAngleForce(self):
+        """ Tests the AmoebaInPlaneAngleForce API features """
+        force = AmoebaInPlaneAngleForce()
+
+        force.setAmoebaGlobalInPlaneAngleCubic(1.0)
+        self.assertEqual(force.getAmoebaGlobalInPlaneAngleCubic(), 1/radian)
+        self.assertEqual(str(force.getAmoebaGlobalInPlaneAngleCubic().unit), '/radian')
+
+        force.setAmoebaGlobalInPlaneAngleQuartic(1.0/degrees**2)
+        self.assertAlmostEqualUnit(force.getAmoebaGlobalInPlaneAngleQuartic(), 1/degrees**2)
+        self.assertEqual(str(force.getAmoebaGlobalInPlaneAngleQuartic().unit), '/(radian**2)')
+
+        force.setAmoebaGlobalInPlaneAnglePentic(1.0/radians**3)
+        self.assertEqual(force.getAmoebaGlobalInPlaneAnglePentic(), 1/radian**3)
+        self.assertEqual(str(force.getAmoebaGlobalInPlaneAnglePentic().unit), '/(radian**3)')
+
+        force.setAmoebaGlobalInPlaneAngleSextic(1.0/radians**4)
+        self.assertEqual(force.getAmoebaGlobalInPlaneAngleSextic(), 1/radian**4)
+        self.assertEqual(str(force.getAmoebaGlobalInPlaneAngleSextic().unit), '/(radian**4)')
+
+        force.addAngle(0, 1, 2, 3, math.pi, 1.0)
+        force.addAngle(1, 2, 3, 4, 180*degrees, 1.0*kilocalories_per_mole/radians**2)
+
+        self.assertEqual(force.getNumAngles(), 2)
+
+        i, j, k, l, t, tk = force.getAngleParameters(0)
+        self.assertEqual(i, 0)
+        self.assertEqual(j, 1)
+        self.assertEqual(k, 2)
+        self.assertEqual(l, 3)
+        self.assertEqual(t, math.pi*radians)
+        self.assertIs(t.unit, radians)
+        self.assertEqual(tk, 1.0*kilojoules_per_mole/radians**2)
+        self.assertIs(tk.unit, kilojoules_per_mole/radians**2)
+
+        i, j, k, l, t, tk = force.getAngleParameters(1)
+        self.assertEqual(i, 1)
+        self.assertEqual(j, 2)
+        self.assertEqual(k, 3)
+        self.assertEqual(l, 4)
+        self.assertEqual(t, 180*degrees)
+        self.assertIs(t.unit, radians)
+        self.assertEqual(tk, 1.0*kilocalorie_per_mole/radians**2)
+        self.assertIs(tk.unit, kilojoules_per_mole/radians**2)
+
 if __name__ == '__main__':
     unittest.main()

--- a/wrappers/python/tests/TestAPIUnits.py
+++ b/wrappers/python/tests/TestAPIUnits.py
@@ -547,6 +547,49 @@ class TestAPIUnits(unittest.TestCase):
 
     def testAmoebaAngleForce(self):
         """ Tests the AmoebaAngleForce API features """
+        force = AmoebaAngleForce()
+        force.setAmoebaGlobalAngleCubic(1.0)
+        force.setAmoebaGlobalAngleQuartic(2.0/radians**2)
+        force.setAmoebaGlobalAnglePentic(3.0/degrees**3)
+        force.setAmoebaGlobalAngleSextic(4.0)
+
+        self.assertEqual(force.getAmoebaGlobalAngleCubic(), 1.0/radians)
+        self.assertEqual(force.getAmoebaGlobalAngleQuartic(), 2.0/radians**2)
+        self.assertAlmostEqualUnit(force.getAmoebaGlobalAnglePentic(), 3.0/degrees**3)
+        self.assertEqual(force.getAmoebaGlobalAngleSextic(), 4.0/radians**4)
+
+        force.addAngle(0, 1, 2, math.pi*radians, 1.5*kilocalories_per_mole/radians**2)
+        force.addAngle(1, 2, 3, 180*degrees, 1.5*kilocalories_per_mole/radians**2)
+        force.addAngle(2, 3, 4, 109.4, 1.5)
+
+        self.assertEqual(force.getNumAngles(), 3)
+
+        i, j, k, t, tk = force.getAngleParameters(0)
+        self.assertEqual(i, 0)
+        self.assertEqual(j, 1)
+        self.assertEqual(k, 2)
+        self.assertAlmostEqualUnit(t, math.pi*radians)
+        self.assertIs(t.unit, degree)
+        self.assertAlmostEqualUnit(tk, 1.5*kilocalories_per_mole/radians**2)
+        self.assertIs(tk.unit, kilojoules_per_mole/radians**2)
+
+        i, j, k, t, tk = force.getAngleParameters(1)
+        self.assertEqual(i, 1)
+        self.assertEqual(j, 2)
+        self.assertEqual(k, 3)
+        self.assertAlmostEqualUnit(t, 180*degrees)
+        self.assertIs(t.unit, degree)
+        self.assertAlmostEqualUnit(tk, 1.5*kilocalories_per_mole/radians**2)
+        self.assertIs(tk.unit, kilojoules_per_mole/radians**2)
+
+        i, j, k, t, tk = force.getAngleParameters(2)
+        self.assertEqual(i, 2)
+        self.assertEqual(j, 3)
+        self.assertEqual(k, 4)
+        self.assertAlmostEqualUnit(t, 109.4*degrees)
+        self.assertIs(t.unit, degree)
+        self.assertAlmostEqualUnit(tk, 1.5*kilojoules_per_mole/radians**2)
+        self.assertIs(tk.unit, kilojoules_per_mole/radians**2)
 
 if __name__ == '__main__':
     unittest.main()

--- a/wrappers/python/tests/TestAPIUnits.py
+++ b/wrappers/python/tests/TestAPIUnits.py
@@ -2,6 +2,7 @@ import unittest
 from simtk.openmm import *
 from simtk.openmm.app import *
 from simtk.unit import *
+import random
 import math
 
 class TestAPIUnits(unittest.TestCase):
@@ -158,6 +159,31 @@ class TestAPIUnits(unittest.TestCase):
         self.assertIs(charge.unit, elementary_charge)
         self.assertIs(sigma.unit, nanometers)
         self.assertIs(epsilon.unit, kilojoules_per_mole)
+
+    def testCmapForce(self):
+        """ Tests the CMAPTorsionForce API features """
+        map1 = [random.random() for i in range(24*24)]
+        map2 = [random.random() for i in range(12*12)] * kilocalories_per_mole
+        force = CMAPTorsionForce()
+        force.addMap(24, map1)
+        force.addMap(12, map2)
+        force.addTorsion(0, 0, 1, 2, 3, 1, 2, 3, 4)
+        force.addTorsion(1, 5, 6, 7, 8, 6, 7, 8, 9)
+        force.addTorsion(0, 10, 11, 12, 13, 11, 12, 13, 14)
+        force.addTorsion(1, 15, 16, 17, 18, 16, 17, 18, 19)
+
+        self.assertEqual(force.getNumTorsions(), 4)
+        self.assertEqual(force.getNumMaps(), 2)
+        self.assertEqual(force.getMapParameters(0)[0], 24)
+        self.assertEqual(force.getMapParameters(1)[0], 12)
+        self.assertIs(force.getMapParameters(0)[1].unit, kilojoules_per_mole)
+        self.assertIs(force.getMapParameters(1)[1].unit, kilojoules_per_mole)
+
+        for x, y in zip(force.getMapParameters(0)[1], map1):
+            self.assertAlmostEqual(x.value_in_unit(kilojoules_per_mole), y)
+
+        for x, y in zip(force.getMapParameters(1)[1], map2):
+            self.assertAlmostEqualUnit(x, y)
 
 if __name__ == '__main__':
     unittest.main()

--- a/wrappers/python/tests/TestAPIUnits.py
+++ b/wrappers/python/tests/TestAPIUnits.py
@@ -517,5 +517,36 @@ class TestAPIUnits(unittest.TestCase):
         self.assertEqual(force.getParticleParameters(1)[0][0], 20)
         self.assertEqual(force.getParticleParameters(2)[0][0], 30*4.184)
 
+    def testAmoebaBondForce(self):
+        """ Tests the AmoebaBondForce API features """
+        force1 = AmoebaBondForce()
+        force2 = AmoebaBondForce()
+        force1.setAmoebaGlobalBondCubic(1.5)
+        force2.setAmoebaGlobalBondCubic(1.5/angstrom)
+        force1.setAmoebaGlobalBondQuartic(1.5)
+        force2.setAmoebaGlobalBondQuartic(1.5/angstrom**2)
+
+        self.assertEqual(force1.getAmoebaGlobalBondCubic(), 1.5/nanometer)
+        self.assertEqual(force2.getAmoebaGlobalBondCubic(), 1.5/angstrom)
+        self.assertEqual(force1.getAmoebaGlobalBondQuartic(), 1.5/nanometer**2)
+        self.assertAlmostEqualUnit(force2.getAmoebaGlobalBondQuartic(), 1.5/angstrom**2)
+
+        force1.addBond(0, 1, 0.15, 10.0)
+        force1.addBond(1, 2, 1.5*angstroms, 10.0*kilocalories_per_mole/angstroms**2)
+
+        self.assertEqual(force1.getNumBonds(), 2)
+        self.assertEqual(force2.getNumBonds(), 0)
+
+        i, j, req, k = force1.getBondParameters(0)
+        self.assertEqual(req, 0.15*nanometers)
+        self.assertEqual(k, 10.0*kilojoules_per_mole/nanometers**2)
+
+        i, j, req, k = force1.getBondParameters(1)
+        self.assertAlmostEqualUnit(req, 1.5*angstroms)
+        self.assertAlmostEqualUnit(k, 10.0*kilocalories_per_mole/angstroms**2)
+
+    def testAmoebaAngleForce(self):
+        """ Tests the AmoebaAngleForce API features """
+
 if __name__ == '__main__':
     unittest.main()

--- a/wrappers/python/tests/TestAPIUnits.py
+++ b/wrappers/python/tests/TestAPIUnits.py
@@ -1041,5 +1041,50 @@ class TestAPIUnits(unittest.TestCase):
         self.assertEqual(damp, 0.5)
         self.assertAlmostEqualUnit(polarity, 1*angstrom**3)
 
+    def testVerletIntegrator(self):
+        """ Tests the VerletIntegrator API features """
+        integrator = VerletIntegrator(1.0)
+        self.assertEqual(integrator.getStepSize(), 1.0*picosecond)
+        self.assertEqual(integrator.getConstraintTolerance(), 1e-5)
+        integrator.setConstraintTolerance(1e-6)
+        self.assertEqual(integrator.getConstraintTolerance(), 1e-6)
+
+        integrator = VerletIntegrator(1.0*femtoseconds)
+        self.assertEqual(integrator.getStepSize(), 1.0*femtoseconds)
+
+    def testVariableVerletIntegrator(self):
+        """ Tests the VariableVerletIntegrator API features """
+        integrator = VariableVerletIntegrator(0.1)
+        self.assertEqual(integrator.getErrorTolerance(), 0.1)
+        integrator.setErrorTolerance(0.01)
+        self.assertEqual(integrator.getErrorTolerance(), 0.01)
+        self.assertEqual(integrator.getConstraintTolerance(), 1e-5)
+        integrator.setConstraintTolerance(1e-6)
+        self.assertEqual(integrator.getConstraintTolerance(), 1e-6)
+
+    def testLangevinIntegrator(self):
+        """ Tests the LangevinIntegrator API features """
+        integrator = LangevinIntegrator(300, 0.1, 1)
+        self.assertEqual(integrator.getTemperature(), 300*kelvin)
+        self.assertEqual(integrator.getFriction(), 0.1/picosecond)
+        self.assertEqual(integrator.getStepSize(), 1*picosecond)
+
+        integrator = LangevinIntegrator(300*kelvin, 0.1/microsecond, 1*femtosecond)
+        self.assertEqual(integrator.getTemperature(), 300*kelvin)
+        self.assertAlmostEqualUnit(integrator.getFriction(), 0.1/microsecond)
+        self.assertEqual(integrator.getStepSize(), 1*femtosecond)
+
+    def testVariableLangevinIntegrator(self):
+        """ Tests the VariableLangevinIntegrator API features """
+        integrator = VariableLangevinIntegrator(300, 0.1, 0.1)
+        self.assertEqual(integrator.getTemperature(), 300*kelvin)
+        self.assertEqual(integrator.getFriction(), 0.1/picosecond)
+        self.assertEqual(integrator.getErrorTolerance(), 0.1)
+
+        integrator = VariableLangevinIntegrator(300*kelvin, 0.1/microsecond, 0.01)
+        self.assertEqual(integrator.getTemperature(), 300*kelvin)
+        self.assertAlmostEqualUnit(integrator.getFriction(), 0.1/microsecond)
+        self.assertEqual(integrator.getErrorTolerance(), 0.01)
+
 if __name__ == '__main__':
     unittest.main()

--- a/wrappers/python/tests/TestAPIUnits.py
+++ b/wrappers/python/tests/TestAPIUnits.py
@@ -1201,5 +1201,16 @@ class TestAPIUnits(unittest.TestCase):
         integrator.setStepSize(0.0005)
         self.assertEqual(integrator.getStepSize(), 0.0005*picosecond)
 
+    def testCustomIntegrator(self):
+        """ Tests the CustomIntegrator API features """
+        integrator = CustomIntegrator(1.0)
+        self.assertEqual(integrator.getStepSize(), 1.0*picosecond)
+        self.assertEqual(integrator.getConstraintTolerance(), 1e-5)
+        integrator.setConstraintTolerance(1e-6)
+        self.assertEqual(integrator.getConstraintTolerance(), 1e-6)
+
+        integrator = CustomIntegrator(1.0*femtoseconds)
+        self.assertEqual(integrator.getStepSize(), 1.0*femtoseconds)
+
 if __name__ == '__main__':
     unittest.main()

--- a/wrappers/python/tests/TestAPIUnits.py
+++ b/wrappers/python/tests/TestAPIUnits.py
@@ -1086,5 +1086,55 @@ class TestAPIUnits(unittest.TestCase):
         self.assertAlmostEqualUnit(integrator.getFriction(), 0.1/microsecond)
         self.assertEqual(integrator.getErrorTolerance(), 0.01)
 
+    def testBrownianIntegrator(self):
+        """ Tests the BrownianIntegrator API features """
+        integrator = BrownianIntegrator(300, 0.1, 1)
+        self.assertEqual(integrator.getTemperature(), 300*kelvin)
+        self.assertEqual(integrator.getFriction(), 0.1/picosecond)
+        self.assertEqual(integrator.getStepSize(), 1*picosecond)
+
+        integrator = BrownianIntegrator(300*kelvin, 0.1/microsecond, 1*femtosecond)
+        self.assertEqual(integrator.getTemperature(), 300*kelvin)
+        self.assertAlmostEqualUnit(integrator.getFriction(), 0.1/microsecond)
+        self.assertEqual(integrator.getStepSize(), 1*femtosecond)
+
+    def testAndersenThermostat(self):
+        """ Tests the AndersenThermostat API features """
+        force = AndersenThermostat(300*kelvin, 1/microsecond)
+        self.assertEqual(force.getDefaultTemperature(), 300*kelvin)
+        self.assertAlmostEqualUnit(force.getDefaultCollisionFrequency(), 1/microsecond)
+
+        force.setDefaultTemperature(298.15)
+        force.setDefaultCollisionFrequency(1)
+        self.assertEqual(force.getDefaultTemperature(), 298.15*kelvin)
+        self.assertAlmostEqualUnit(force.getDefaultCollisionFrequency(), 1/picosecond)
+
+    def testDrudeSCFIntegrator(self):
+        """ Tests the DrudeSCFIntegrator API features """
+        integrator = DrudeSCFIntegrator(0.002)
+        self.assertEqual(integrator.getStepSize(), 0.002*picoseconds)
+        self.assertAlmostEqualUnit(integrator.getMinimizationErrorTolerance(),
+                                   0.1*kilojoule_per_mole/nanometer)
+        integrator.setMinimizationErrorTolerance(1*kilocalorie_per_mole/angstrom)
+        self.assertAlmostEqualUnit(integrator.getMinimizationErrorTolerance(),
+                                   1*kilocalorie_per_mole/angstrom)
+
+    def testDrudeLangevinIntegrator(self):
+        """ Tests the DrudeLangevinIntegrator API features """
+        integrator = DrudeLangevinIntegrator(300*kelvin, 1.0/microsecond,
+                                             100*kelvin, 1/picosecond, 0.1*femtosecond)
+        self.assertEqual(integrator.getTemperature(), 300*kelvin)
+        integrator.setTemperature(298.15)
+        self.assertEqual(integrator.getTemperature(), 298.15*kelvin)
+        self.assertAlmostEqualUnit(integrator.getFriction(), 1/microsecond)
+        integrator.setFriction(1)
+        self.assertEqual(integrator.getFriction(), 1/picosecond)
+        self.assertEqual(integrator.getDrudeTemperature(), 100*kelvin)
+        integrator.setDrudeTemperature(50)
+        self.assertEqual(integrator.getDrudeTemperature(), 50*kelvin)
+        self.assertEqual(integrator.getStepSize(), 0.1*femtosecond)
+        integrator.setStepSize(0.0005)
+        self.assertEqual(integrator.getStepSize(), 0.0005*picosecond)
+
 if __name__ == '__main__':
     unittest.main()

--- a/wrappers/python/tests/TestAPIUnits.py
+++ b/wrappers/python/tests/TestAPIUnits.py
@@ -711,16 +711,16 @@ class TestAPIUnits(unittest.TestCase):
         self.assertEqual(j, 1)
         self.assertEqual(k, 2)
         self.assertEqual(l, 3)
-        self.assertEqual(tk, 1.0*kilojoules_per_mole)
-        self.assertIs(tk.unit, kilojoules_per_mole)
+        self.assertEqual(tk, 1.0*kilojoules_per_mole/radians**2)
+        self.assertIs(tk.unit, kilojoules_per_mole/radians**2)
 
         i, j, k, l, tk = force.getOutOfPlaneBendParameters(1)
         self.assertEqual(i, 1)
         self.assertEqual(j, 2)
         self.assertEqual(k, 3)
         self.assertEqual(l, 4)
-        self.assertEqual(tk, 1.0*kilocalorie_per_mole)
-        self.assertIs(tk.unit, kilojoules_per_mole)
+        self.assertEqual(tk, 1.0*kilocalorie_per_mole/radians**2)
+        self.assertIs(tk.unit, kilojoules_per_mole/radians**2)
 
 if __name__ == '__main__':
     unittest.main()

--- a/wrappers/python/tests/TestAPIUnits.py
+++ b/wrappers/python/tests/TestAPIUnits.py
@@ -681,5 +681,46 @@ class TestAPIUnits(unittest.TestCase):
         self.assertEqual(tk, 1.0*kilocalorie_per_mole/radians**2)
         self.assertIs(tk.unit, kilojoules_per_mole/radians**2)
 
+    def testAmoebaOutOfPlaneBendForce(self):
+        """ Tests the AmoebaOutOfPlaneBendForce API features """
+        force = AmoebaOutOfPlaneBendForce()
+
+        force.setAmoebaGlobalOutOfPlaneBendCubic(1.0)
+        self.assertEqual(force.getAmoebaGlobalOutOfPlaneBendCubic(), 1/radian)
+        self.assertEqual(str(force.getAmoebaGlobalOutOfPlaneBendCubic().unit), '/radian')
+
+        force.setAmoebaGlobalOutOfPlaneBendQuartic(1.0/degrees**2)
+        self.assertAlmostEqualUnit(force.getAmoebaGlobalOutOfPlaneBendQuartic(), 1/degrees**2)
+        self.assertEqual(str(force.getAmoebaGlobalOutOfPlaneBendQuartic().unit), '/(radian**2)')
+
+        force.setAmoebaGlobalOutOfPlaneBendPentic(1.0/radians**3)
+        self.assertEqual(force.getAmoebaGlobalOutOfPlaneBendPentic(), 1/radian**3)
+        self.assertEqual(str(force.getAmoebaGlobalOutOfPlaneBendPentic().unit), '/(radian**3)')
+
+        force.setAmoebaGlobalOutOfPlaneBendSextic(1.0/radians**4)
+        self.assertEqual(force.getAmoebaGlobalOutOfPlaneBendSextic(), 1/radian**4)
+        self.assertEqual(str(force.getAmoebaGlobalOutOfPlaneBendSextic().unit), '/(radian**4)')
+
+        force.addOutOfPlaneBend(0, 1, 2, 3, 1.0)
+        force.addOutOfPlaneBend(1, 2, 3, 4, 1.0*kilocalories_per_mole/radians**2)
+
+        self.assertEqual(force.getNumOutOfPlaneBends(), 2)
+
+        i, j, k, l, tk = force.getOutOfPlaneBendParameters(0)
+        self.assertEqual(i, 0)
+        self.assertEqual(j, 1)
+        self.assertEqual(k, 2)
+        self.assertEqual(l, 3)
+        self.assertEqual(tk, 1.0*kilojoules_per_mole)
+        self.assertIs(tk.unit, kilojoules_per_mole)
+
+        i, j, k, l, tk = force.getOutOfPlaneBendParameters(1)
+        self.assertEqual(i, 1)
+        self.assertEqual(j, 2)
+        self.assertEqual(k, 3)
+        self.assertEqual(l, 4)
+        self.assertEqual(tk, 1.0*kilocalorie_per_mole)
+        self.assertIs(tk.unit, kilojoules_per_mole)
+
 if __name__ == '__main__':
     unittest.main()

--- a/wrappers/python/tests/TestAPIUnits.py
+++ b/wrappers/python/tests/TestAPIUnits.py
@@ -591,5 +591,50 @@ class TestAPIUnits(unittest.TestCase):
         self.assertAlmostEqualUnit(tk, 1.5*kilojoules_per_mole/radians**2)
         self.assertIs(tk.unit, kilojoules_per_mole/radians**2)
 
+    def testGeneralizedKirkwood(self):
+        """ Tests the AmoebaGeneralizedKirkwoodForce API features """
+        force = AmoebaGeneralizedKirkwoodForce()
+
+        self.assertEqual(force.getProbeRadius(), 0.14*nanometer) # default
+        force.setProbeRadius(0.16)
+        self.assertEqual(force.getProbeRadius(), 0.16*nanometer)
+        self.assertIs(force.getProbeRadius().unit, nanometer)
+        force.setProbeRadius(1.4*angstrom)
+        self.assertEqual(force.getProbeRadius(), 1.4*angstrom)
+        self.assertIs(force.getProbeRadius().unit, nanometer)
+
+        self.assertEqual(force.getSoluteDielectric(), 1.0) # default
+        force.setSoluteDielectric(2.0)
+        self.assertEqual(force.getSoluteDielectric(), 2.0)
+
+        self.assertEqual(force.getSolventDielectric(), 78.3) # default
+        force.setSolventDielectric(80)
+        self.assertEqual(force.getSolventDielectric(), 80)
+
+        self.assertEqual(force.getSurfaceAreaFactor(),
+                -170.35173066268223*kilojoule_per_mole/nanometer**2) # default
+        force.setSurfaceAreaFactor(-1.0*kilocalorie_per_mole/angstrom**2)
+        self.assertAlmostEqualUnit(force.getSurfaceAreaFactor(),
+                -1.0*kilocalorie_per_mole/angstrom**2) # default
+
+        force.addParticle(1.0*coulomb, 1.0*angstroms, 0.5)
+        force.addParticle(1.0, 1.0, 0.4)
+
+        self.assertEqual(force.getNumParticles(), 2)
+
+        q, r, s = force.getParticleParameters(0)
+        self.assertAlmostEqualUnit(q, 1.0*coulomb)
+        self.assertIs(q.unit, elementary_charge)
+        self.assertEqual(r, 1.0*angstroms)
+        self.assertIs(r.unit, nanometer)
+        self.assertEqual(s, 0.5)
+
+        q, r, s = force.getParticleParameters(1)
+        self.assertAlmostEqualUnit(q, 1.0*elementary_charge)
+        self.assertIs(q.unit, elementary_charge)
+        self.assertEqual(r, 1.0*nanometer)
+        self.assertIs(r.unit, nanometer)
+        self.assertEqual(s, 0.4)
+
 if __name__ == '__main__':
     unittest.main()

--- a/wrappers/python/tests/TestAPIUnits.py
+++ b/wrappers/python/tests/TestAPIUnits.py
@@ -792,5 +792,19 @@ class TestAPIUnits(unittest.TestCase):
         self.assertEqual(k2, 12*kilocalories_per_mole/angstroms/radians)
         self.assertIs(k2.unit, kilojoules_per_mole/nanometers/radians)
 
+    def testAmoebaTorsionTorsionForce(self):
+        """ Tests the AmoebaTorsionTorsionForce API features """
+        force = AmoebaTorsionTorsionForce()
+
+        grid1 = [[[i, j, random.random(), random.random(), random.random(), random.random()]
+                    for j in range(-180, 180, 24)] for i in range(-180, 180, 24)]
+        kcal = kilocalories_per_mole
+        grid2 = [[[i*degrees, j*degrees, random.random()*kcal,
+                   random.random()*kcal/radians, random.random()*kcal/radians,
+                   random.random()*kcal/radians**2]
+            for j in range(-180, 0, 10)] for i in range(-180, 0, 10)]
+        force.setTorsionTorsionGrid(0, grid1)
+        force.setTorsionTorsionGrid(0, grid2)
+
 if __name__ == '__main__':
     unittest.main()

--- a/wrappers/python/tests/TestAPIUnits.py
+++ b/wrappers/python/tests/TestAPIUnits.py
@@ -722,5 +722,75 @@ class TestAPIUnits(unittest.TestCase):
         self.assertEqual(tk, 1.0*kilocalorie_per_mole/radians**2)
         self.assertIs(tk.unit, kilojoules_per_mole/radians**2)
 
+    def testAmoebaPiTorsionForce(self):
+        """ Tests the AmoebaPiTorsionForce API features """
+        force = AmoebaPiTorsionForce()
+
+        force.addPiTorsion(0, 1, 2, 3, 4, 5, 1.0)
+        force.addPiTorsion(1, 2, 3, 4, 5, 6, 1.0*kilocalories_per_mole)
+
+        self.assertEqual(force.getNumPiTorsions(), 2)
+
+        i, j, k, l, m, n, tk = force.getPiTorsionParameters(0)
+        self.assertEqual(i, 0)
+        self.assertEqual(j, 1)
+        self.assertEqual(k, 2)
+        self.assertEqual(l, 3)
+        self.assertEqual(m, 4)
+        self.assertEqual(n, 5)
+        self.assertEqual(tk, 1.0*kilojoules_per_mole)
+        self.assertIs(tk.unit, kilojoule_per_mole)
+
+        i, j, k, l, m, n, tk = force.getPiTorsionParameters(1)
+        self.assertEqual(i, 1)
+        self.assertEqual(j, 2)
+        self.assertEqual(k, 3)
+        self.assertEqual(l, 4)
+        self.assertEqual(m, 5)
+        self.assertEqual(n, 6)
+        self.assertEqual(tk, 1.0*kilocalories_per_mole)
+        self.assertIs(tk.unit, kilojoule_per_mole)
+
+    def testAmoebaStretchBendForce(self):
+        """ Tests the AmoebaStretchBendForce API features """
+        force = AmoebaStretchBendForce()
+
+        force.addStretchBend(0, 1, 2, 0.10, 0.12, math.pi/2, 10.0, 12.0)
+        force.addStretchBend(1, 2, 3, 1.0*angstroms, 1.2*angstroms, 60*degrees,
+                10.0*kilocalories_per_mole/angstroms/radians,
+                12.0*kilocalories_per_mole/angstroms/radians)
+
+        self.assertEqual(force.getNumStretchBends(), 2)
+
+        i, j, k, r1, r2, t, k1, k2 = force.getStretchBendParameters(0)
+        self.assertEqual(i, 0)
+        self.assertEqual(j, 1)
+        self.assertEqual(k, 2)
+        self.assertEqual(r1, 0.1*nanometers)
+        self.assertIs(r1.unit, nanometers)
+        self.assertEqual(r2, 0.12*nanometers)
+        self.assertIs(r2.unit, nanometers)
+        self.assertEqual(t, math.pi/2*radians)
+        self.assertIs(t.unit, radians)
+        self.assertEqual(k1, 10*kilojoules_per_mole/nanometers/radians)
+        self.assertIs(k1.unit, kilojoules_per_mole/nanometers/radians)
+        self.assertEqual(k2, 12*kilojoules_per_mole/nanometers/radians)
+        self.assertIs(k2.unit, kilojoules_per_mole/nanometers/radians)
+
+        i, j, k, r1, r2, t, k1, k2 = force.getStretchBendParameters(1)
+        self.assertEqual(i, 1)
+        self.assertEqual(j, 2)
+        self.assertEqual(k, 3)
+        self.assertEqual(r1, 1.0*angstroms)
+        self.assertIs(r1.unit, nanometers)
+        self.assertEqual(r2, 1.2*angstroms)
+        self.assertIs(r2.unit, nanometers)
+        self.assertAlmostEqualUnit(t, 60*degrees)
+        self.assertIs(t.unit, radians)
+        self.assertEqual(k1, 10*kilocalories_per_mole/angstroms/radians)
+        self.assertIs(k1.unit, kilojoules_per_mole/nanometers/radians)
+        self.assertEqual(k2, 12*kilocalories_per_mole/angstroms/radians)
+        self.assertIs(k2.unit, kilojoules_per_mole/nanometers/radians)
+
 if __name__ == '__main__':
     unittest.main()

--- a/wrappers/python/tests/TestAPIUnits.py
+++ b/wrappers/python/tests/TestAPIUnits.py
@@ -1,0 +1,163 @@
+import unittest
+from simtk.openmm import *
+from simtk.openmm.app import *
+from simtk.unit import *
+import math
+
+class TestAPIUnits(unittest.TestCase):
+    """Test the Simulation class"""
+
+    def assertAlmostEqualUnit(self, x1, x2):
+        self.assertAlmostEqual(x1._value, x2.value_in_unit(x1.unit))
+
+    def testHarmonicBondForce(self):
+        """ Tests HarmonicBondForce API features """
+        force = HarmonicBondForce()
+        force.addBond(0, 1, 1.0, 1.0)
+        force.addBond(2, 3, 1.0*angstroms,
+                      1.0*kilocalories_per_mole/angstroms**2)
+        i, j, length, K = force.getBondParameters(0)
+        self.assertEqual(force.getNumBonds(), 2)
+        self.assertEqual(i, 0)
+        self.assertEqual(j, 1)
+        self.assertEqual(length, 1.0*nanometers)
+        self.assertEqual(K, 1*kilojoules_per_mole/nanometers**2)
+        self.assertIs(length.unit, nanometers)
+        self.assertIs(K.unit, kilojoules_per_mole/nanometers**2)
+
+        i, j, length, K = force.getBondParameters(1)
+        self.assertEqual(i, 2)
+        self.assertEqual(j, 3)
+        self.assertEqual(length, 1.0*angstroms)
+        self.assertAlmostEqualUnit(K, 1*kilocalories_per_mole/angstroms**2)
+        self.assertIs(length.unit, nanometers)
+        self.assertIs(K.unit, kilojoules_per_mole/nanometers**2)
+
+    def testHarmonicAngleForce(self):
+        """ Tests HarmonicAngleForce API features """
+        force = HarmonicAngleForce()
+        force.addAngle(0, 1, 2, 180*degrees,
+                       1.0*kilocalories_per_mole/radians**2)
+        force.addAngle(1, 2, 3, math.pi/2, 1.0)
+        self.assertEqual(force.getNumAngles(), 2)
+        i, j, k, angle, K = force.getAngleParameters(0)
+        self.assertEqual(i, 0)
+        self.assertEqual(j, 1)
+        self.assertEqual(k, 2)
+        self.assertEqual(angle, 180*degrees)
+        self.assertEqual(K, 1.0*kilocalories_per_mole/radians**2)
+        self.assertIs(angle.unit, radians)
+        self.assertIs(K.unit, kilojoules_per_mole/radians**2)
+
+        i, j, k, angle, K = force.getAngleParameters(1)
+        self.assertEqual(i, 1)
+        self.assertEqual(j, 2)
+        self.assertEqual(k, 3)
+        self.assertEqual(angle, math.pi/2*radians)
+        self.assertEqual(K, 1.0*kilojoules_per_mole/radians**2)
+        self.assertIs(angle.unit, radians)
+        self.assertIs(K.unit, kilojoules_per_mole/radians**2)
+
+    def testPeriodicTorsionForce(self):
+        """ Tests PeriodicTorsionForce API features """
+        force = PeriodicTorsionForce()
+        force.addTorsion(0, 1, 2, 3, 1, math.pi, 1)
+        force.addTorsion(1, 2, 3, 4, 2, 180*degrees, 1*kilocalories_per_mole)
+
+        self.assertEqual(force.getNumTorsions(), 2)
+        i, j, k, l, per, phase, K = force.getTorsionParameters(0)
+        self.assertEqual(i, 0)
+        self.assertEqual(j, 1)
+        self.assertEqual(k, 2)
+        self.assertEqual(l, 3)
+        self.assertEqual(per, 1)
+        self.assertFalse(is_quantity(per))
+        self.assertEqual(phase, math.pi*radians)
+        self.assertEqual(K, 1*kilojoules_per_mole)
+        self.assertIs(phase.unit, radians)
+        self.assertIs(K.unit, kilojoules_per_mole)
+
+        i, j, k, l, per, phase, K = force.getTorsionParameters(1)
+        self.assertEqual(i, 1)
+        self.assertEqual(j, 2)
+        self.assertEqual(k, 3)
+        self.assertEqual(l, 4)
+        self.assertEqual(per, 2)
+        self.assertFalse(is_quantity(per))
+        self.assertEqual(phase, 180*degrees)
+        self.assertEqual(K, 1*kilocalories_per_mole)
+        self.assertIs(phase.unit, radians)
+        self.assertIs(K.unit, kilojoules_per_mole)
+
+    def testRBTorsionForce(self):
+        """ Tests the RBTorsionForce API features """
+        force = RBTorsionForce()
+        force.addTorsion(0, 1, 2, 3, 1, 2, 3, 4, 5, 6)
+        force.addTorsion(1, 2, 3, 4, 1*kilocalories_per_mole,
+                2*kilocalories_per_mole, 3*kilocalories_per_mole,
+                4*kilocalories_per_mole, 5*kilocalories_per_mole,
+                6*kilocalories_per_mole)
+
+        self.assertEqual(force.getNumTorsions(), 2)
+        i, j, k, l, c0, c1, c2, c3, c4, c5 = force.getTorsionParameters(0)
+        self.assertEqual(i, 0)
+        self.assertEqual(j, 1)
+        self.assertEqual(k, 2)
+        self.assertEqual(l, 3)
+        self.assertEqual(c0, 1*kilojoules_per_mole)
+        self.assertEqual(c1, 2*kilojoules_per_mole)
+        self.assertEqual(c2, 3*kilojoules_per_mole)
+        self.assertEqual(c3, 4*kilojoules_per_mole)
+        self.assertEqual(c4, 5*kilojoules_per_mole)
+        self.assertEqual(c5, 6*kilojoules_per_mole)
+        self.assertIs(c0.unit, kilojoules_per_mole)
+        self.assertIs(c1.unit, kilojoules_per_mole)
+        self.assertIs(c2.unit, kilojoules_per_mole)
+        self.assertIs(c3.unit, kilojoules_per_mole)
+        self.assertIs(c4.unit, kilojoules_per_mole)
+        self.assertIs(c5.unit, kilojoules_per_mole)
+
+        i, j, k, l, c0, c1, c2, c3, c4, c5 = force.getTorsionParameters(1)
+        self.assertEqual(i, 1)
+        self.assertEqual(j, 2)
+        self.assertEqual(k, 3)
+        self.assertEqual(l, 4)
+        self.assertAlmostEqualUnit(c0, 1*kilocalories_per_mole)
+        self.assertAlmostEqualUnit(c1, 2*kilocalories_per_mole)
+        self.assertAlmostEqualUnit(c2, 3*kilocalories_per_mole)
+        self.assertAlmostEqualUnit(c3, 4*kilocalories_per_mole)
+        self.assertAlmostEqualUnit(c4, 5*kilocalories_per_mole)
+        self.assertAlmostEqualUnit(c5, 6*kilocalories_per_mole)
+        self.assertIs(c0.unit, kilojoules_per_mole)
+        self.assertIs(c1.unit, kilojoules_per_mole)
+        self.assertIs(c2.unit, kilojoules_per_mole)
+        self.assertIs(c3.unit, kilojoules_per_mole)
+        self.assertIs(c4.unit, kilojoules_per_mole)
+        self.assertIs(c5.unit, kilojoules_per_mole)
+
+    def testNonbondedForce(self):
+        """ Tests the NonbondedForce API features """
+        force = NonbondedForce()
+        force.addParticle(1.0, 1.0, 1.0)
+        force.addParticle(1.0*coulombs, 1.0*angstroms,
+                          1.0*kilocalories_per_mole)
+
+        self.assertEqual(force.getNumParticles(), 2)
+        charge, sigma, epsilon = force.getParticleParameters(0)
+        self.assertEqual(charge, 1.0*elementary_charge)
+        self.assertEqual(sigma, 1.0*nanometers)
+        self.assertEqual(epsilon, 1.0*kilojoules_per_mole)
+        self.assertIs(charge.unit, elementary_charge)
+        self.assertIs(sigma.unit, nanometers)
+        self.assertIs(epsilon.unit, kilojoules_per_mole)
+
+        charge, sigma, epsilon = force.getParticleParameters(1)
+        self.assertEqual(charge, 1.0*coulombs)
+        self.assertEqual(sigma, 1.0*angstroms)
+        self.assertEqual(epsilon, 1.0*kilocalories_per_mole)
+        self.assertIs(charge.unit, elementary_charge)
+        self.assertIs(sigma.unit, nanometers)
+        self.assertIs(epsilon.unit, kilojoules_per_mole)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This is the start of what I promised in #1031 

So far it just has the basic classes, but I still want to add:

- [x] `CMAPForce`
- [x] custom forces
- [x] integrators
- [x] Amoeba forces