### PR TITLE
add RPMDMonteCarloBarostat header to OpenMM.h

### DIFF
--- a/openmmapi/include/OpenMM.h
+++ b/openmmapi/include/OpenMM.h
@@ -57,6 +57,7 @@
 #include "openmm/MonteCarloAnisotropicBarostat.h"
 #include "openmm/MonteCarloBarostat.h"
 #include "openmm/MonteCarloMembraneBarostat.h"
+#include "openmm/RPMDMonteCarloBarostat.h"
 #include "openmm/NonbondedForce.h"
 #include "openmm/Context.h"
 #include "openmm/OpenMMException.h"


### PR DESCRIPTION
Trying to compile the [mbpol plugin](https://github.com/paesanilab/mbpol_openmm_plugin) with OpenMM 6.3, I noticed that the `RPMDMonteCarloBarostat` header is not included in `OpenMM.h`.
However, it is added in the `swig` headers, so when compiling the Python wrapper for the plugin, it fails with the error:

    MBPolPluginWrapper.cpp:18178:42: error: ‘RPMDMonteCarloBarostat’ is not a member of ‘OpenMM’

Adding this fixes the compilation issue on my machine, so I wonder if this issue is more general.

I thought I tested compilation on the 6.3 beta release, but I guess I overlooked something in the configuration.