### PR TITLE
Fixed errors executing force field scripts on Python 3

### DIFF
--- a/wrappers/python/simtk/openmm/app/forcefield.py
+++ b/wrappers/python/simtk/openmm/app/forcefield.py
@@ -530,7 +530,7 @@ class ForceField(object):
         # Execute scripts found in the XML files.
 
         for script in self._scripts:
-            exec script
+            exec(script, locals())
         return sys
 
 


### PR DESCRIPTION
There was a change in behavior between Python 2 and 3 that caused some scripts embedded in force field XML files to stop working: in particular, the one used for the CHARMM polarizable force field.  This change fixes the problem.  See https://simtk.org/forums/viewtopic.php?f=161&t=5888 for more details.