### PR TITLE
Add PDBxReporter class

### DIFF
--- a/wrappers/python/simtk/openmm/app/__init__.py
+++ b/wrappers/python/simtk/openmm/app/__init__.py
@@ -1,6 +1,8 @@
 """
 OpenMM Application
 """
+from __future__ import absolute_import
+
 __docformat__ = "epytext en"
 
 __author__ = "Peter Eastman"
@@ -10,26 +12,26 @@ __license__ = "MIT"
 __maintainer__ = "Peter Eastman"
 __email__ = "peastman@stanford.edu"
 
-from topology import Topology, Chain, Residue, Atom
-from pdbfile import PDBFile
-from pdbxfile import PDBxFile
-from forcefield import ForceField
-from simulation import Simulation
-from pdbreporter import PDBReporter
-from amberprmtopfile import AmberPrmtopFile, HCT, OBC1, OBC2, GBn, GBn2
-from amberinpcrdfile import AmberInpcrdFile
-from dcdfile import DCDFile
-from gromacsgrofile import GromacsGroFile
-from gromacstopfile import GromacsTopFile
-from dcdreporter import DCDReporter
-from modeller import Modeller
-from statedatareporter import StateDataReporter
-from element import Element
-from desmonddmsfile import DesmondDMSFile
-from checkpointreporter import CheckpointReporter
-from charmmcrdfiles import CharmmCrdFile, CharmmRstFile
-from charmmparameterset import CharmmParameterSet
-from charmmpsffile import CharmmPsfFile, CharmmPSFWarning
+from .topology import Topology, Chain, Residue, Atom
+from .pdbfile import PDBFile
+from .pdbxfile import PDBxFile
+from .forcefield import ForceField
+from .simulation import Simulation
+from .pdbreporter import PDBReporter, PDBxReporter
+from .amberprmtopfile import AmberPrmtopFile, HCT, OBC1, OBC2, GBn, GBn2
+from .amberinpcrdfile import AmberInpcrdFile
+from .dcdfile import DCDFile
+from .gromacsgrofile import GromacsGroFile
+from .gromacstopfile import GromacsTopFile
+from .dcdreporter import DCDReporter
+from .modeller import Modeller
+from .statedatareporter import StateDataReporter
+from .element import Element
+from .desmonddmsfile import DesmondDMSFile
+from .checkpointreporter import CheckpointReporter
+from .charmmcrdfiles import CharmmCrdFile, CharmmRstFile
+from .charmmparameterset import CharmmParameterSet
+from .charmmpsffile import CharmmPsfFile, CharmmPSFWarning
 
 # Enumerated values
 

--- a/wrappers/python/simtk/openmm/app/pdbreporter.py
+++ b/wrappers/python/simtk/openmm/app/pdbreporter.py
@@ -91,18 +91,6 @@ class PDBxReporter(PDBReporter):
     To use it, create a PDBxReporter, then add it to the Simulation's list of reporters.
     """
 
-    def describeNextReport(self, simulation):
-        """Get information about the next report this object will generate.
-
-        Parameters:
-         - simulation (Simulation) The Simulation to generate a report for
-        Returns: A five element tuple.  The first element is the number of steps until the
-        next report.  The remaining elements specify whether that report will require
-        positions, velocities, forces, and energies respectively.
-        """
-        steps = self._reportInterval - simulation.currentStep%self._reportInterval
-        return (steps, True, False, False, False)
-
     def report(self, simulation, state):
         """Generate a report.
 

--- a/wrappers/python/simtk/openmm/app/pdbreporter.py
+++ b/wrappers/python/simtk/openmm/app/pdbreporter.py
@@ -32,7 +32,7 @@ __author__ = "Peter Eastman"
 __version__ = "1.0"
 
 import simtk.openmm as mm
-from simtk.openmm.app import PDBFile
+from simtk.openmm.app import PDBFile, PDBxFile
 
 class PDBReporter(object):
     """PDBReporter outputs a series of frames from a Simulation to a PDB file.

--- a/wrappers/python/simtk/openmm/app/pdbxfile.py
+++ b/wrappers/python/simtk/openmm/app/pdbxfile.py
@@ -240,12 +240,12 @@ class PDBxFile(object):
         if vectors is not None:
             a, b, c, alpha, beta, gamma = computeLengthsAndAngles(vectors)
             RAD_TO_DEG = 180/math.pi
-            print('_cell.length_a     %10.4f' % a_length*10, file=file)
-            print('_cell.length_b     %10.4f' % b_length*10, file=file)
-            print('_cell.length_c     %10.4f' % c_length*10, file=file)
-            print('_cell.angle_alpha  %10.4f' % alpha*RAD_TO_DEG, file=file)
-            print('_cell.angle_beta   %10.4f' % beta*RAD_TO_DEG, file=file)
-            print('_cell.angle_gamma  %10.4f' % gamma*RAD_TO_DEG, file=file)
+            print('_cell.length_a     %10.4f' % (a*10), file=file)
+            print('_cell.length_b     %10.4f' % (b*10), file=file)
+            print('_cell.length_c     %10.4f' % (c*10), file=file)
+            print('_cell.angle_alpha  %10.4f' % (alpha*RAD_TO_DEG), file=file)
+            print('_cell.angle_beta   %10.4f' % (beta*RAD_TO_DEG), file=file)
+            print('_cell.angle_gamma  %10.4f' % (gamma*RAD_TO_DEG), file=file)
             print('##', file=file)
         print('loop_', file=file)
         print('_atom_site.group_PDB', file=file)

--- a/wrappers/python/simtk/openmm/app/pdbxfile.py
+++ b/wrappers/python/simtk/openmm/app/pdbxfile.py
@@ -1,14 +1,14 @@
 """
-pdbfile.py: Used for loading PDB files.
+pdbxfile.py: Used for loading PDBx/mmCIF files.
 
 This is part of the OpenMM molecular simulation toolkit originating from
 Simbios, the NIH National Center for Physics-Based Simulation of
 Biological Structures at Stanford, funded under the NIH Roadmap for
 Medical Research, grant U54 GM072970. See https://simtk.org.
 
-Portions copyright (c) 2014-2015 Stanford University and the Authors.
+Portions copyright (c) 2015 Stanford University and the Authors.
 Authors: Peter Eastman
-Contributors:
+Contributors: Jason Swails
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -28,8 +28,10 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
+from __future__ import division, absolute_import, print_function
+
 __author__ = "Peter Eastman"
-__version__ = "1.0"
+__version__ = "2.0"
 
 import os
 import sys
@@ -201,3 +203,133 @@ class PDBxFile(object):
                 self._numpyPositions[frame] = Quantity(numpy.array(self._positions[frame].value_in_unit(nanometers)), nanometers)
             return self._numpyPositions[frame]
         return self._positions[frame]
+
+    @staticmethod
+    def writeFile(topology, positions, file=sys.stdout, keepIds=False,
+                  entry=None):
+        """Write a PDB file containing a single model.
+
+        Parameters:
+         - topology (Topology) The Topology defining the model to write
+         - positions (list) The list of atomic positions to write
+         - file (file=stdout) A file to write to
+         - keepIds (bool=False) If True, keep the residue and chain IDs specified in the Topology rather than generating
+           new ones.  Warning: It is up to the caller to make sure these are valid IDs that satisfy the requirements of
+           the PDB format.  Otherwise, the output file will be invalid.
+         - entry (str=None) The entry ID to assign to the CIF file
+        """
+        PDBxFile.writeHeader(topology, file, entry)
+        PDBxFile.writeModel(topology, positions, file, keepIds=keepIds)
+
+    @staticmethod
+    def writeHeader(topology, file=sys.stdout, entry=None):
+        """Write out the header for a PDB file.
+
+        Parameters:
+         - topology (Topology) The Topology defining the molecular system being written
+         - file (file=stdout) A file to write the file to
+         - entry (str=None) The entry ID to assign to the CIF file
+        """
+        if entry is not None:
+            print('data_%s' % entry, file=file)
+        else:
+            print('data_cell', file=file)
+        print("# Created with OpenMM %s, %s" % (Platform.getOpenMMVersion(), str(date.today())), file=file)
+        print('#', file=file)
+        vectors = topology.getPeriodicBoxVectors()
+        if vectors is not None:
+            (a, b, c) = vectors.value_in_unit(angstroms)
+            a_length = norm(a)
+            b_length = norm(b)
+            c_length = norm(c)
+            alpha = math.acos(dot(b, c)/(b_length*c_length))*180.0/math.pi
+            beta = math.acos(dot(c, a)/(c_length*a_length))*180.0/math.pi
+            gamma = math.acos(dot(a, b)/(a_length*b_length))*180.0/math.pi
+            print('_cell.length_a     %10.4f', file=file)
+            print('_cell.length_b     %10.4f', file=file)
+            print('_cell.length_c     %10.4f', file=file)
+            print('_cell.angle_alpha  %10.4f', file=file)
+            print('_cell.angle_beta   %10.4f', file=file)
+            print('_cell.angle_gamma  %10.4f', file=file)
+            print('##', file=file)
+        print('loop_', file=file)
+        print('_atom_site.group_PDB', file=file)
+        print('_atom_site.id', file=file)
+        print('_atom_site.type_symbol', file=file)
+        print('_atom_site.label_atom_id', file=file)
+        print('_atom_site.label_alt_id', file=file)
+        print('_atom_site.label_comp_id', file=file)
+        print('_atom_site.label_asym_id', file=file)
+        print('_atom_site.label_entity_id', file=file)
+        print('_atom_site.label_seq_id', file=file)
+        print('_atom_site.pdbx_PDB_ins_code', file=file)
+        print('_atom_site.Cartn_x', file=file)
+        print('_atom_site.Cartn_y', file=file)
+        print('_atom_site.Cartn_z', file=file)
+        print('_atom_site.occupancy', file=file)
+        print('_atom_site.B_iso_or_equiv', file=file)
+        print('_atom_site.Cartn_x_esd', file=file)
+        print('_atom_site.Cartn_y_esd', file=file)
+        print('_atom_site.Cartn_z_esd', file=file)
+        print('_atom_site.occupancy_esd', file=file)
+        print('_atom_site.B_iso_or_equiv_esd', file=file)
+        print('_atom_site.pdbx_formal_charge', file=file)
+        print('_atom_site.auth_seq_id', file=file)
+        print('_atom_site.auth_comp_id', file=file)
+        print('_atom_site.auth_asym_id', file=file)
+        print('_atom_site.auth_atom_id', file=file)
+        print('_atom_site.pdbx_PDB_model_num', file=file)
+
+    @staticmethod
+    def writeModel(topology, positions, file=sys.stdout, modelIndex=1, keepIds=False):
+        """Write out a model to a PDB file.
+
+        Parameters:
+         - topology (Topology) The Topology defining the model to write
+         - positions (list) The list of atomic positions to write
+         - file (file=stdout) A file to write the model to
+         - modelIndex (int=1) The model number of this frame
+         - keepIds (bool=False) If True, keep the residue and chain IDs specified in the Topology rather than generating
+           new ones.  Warning: It is up to the caller to make sure these are valid IDs that satisfy the requirements of
+           the PDB format.  Otherwise, the output file will be invalid.
+        """
+        if len(list(topology.atoms())) != len(positions):
+            raise ValueError('The number of positions must match the number of atoms')
+        if is_quantity(positions):
+            positions = positions.value_in_unit(angstroms)
+        if any(math.isnan(norm(pos)) for pos in positions):
+            raise ValueError('Particle position is NaN')
+        if any(math.isinf(norm(pos)) for pos in positions):
+            raise ValueError('Particle position is infinite')
+        atomIndex = 1
+        posIndex = 0
+        for (chainIndex, chain) in enumerate(topology.chains()):
+            if keepIds:
+                chainName = chain.id
+            else:
+                chainName = chr(ord('A')+chainIndex%26)
+            residues = list(chain.residues())
+            for (resIndex, res) in enumerate(residues):
+                resName = res.name
+                if keepIds:
+                    resId = res.id
+                else:
+                    resId = resIndex + 1
+                for atom in res.atoms():
+                    atomName = atom.name
+                    if len(atom.name) < 4 and atom.name[:1].isalpha() and (atom.element is None or len(atom.element.symbol) < 2):
+                        atomName = ' '+atom.name
+                    elif len(atom.name) > 4:
+                        atomName = atom.name[:4]
+                    else:
+                        atomName = atom.name
+                    coords = positions[posIndex]
+                    if atom.element is not None:
+                        symbol = atom.element.symbol
+                    else:
+                        symbol = '?'
+                    line = "ATOM  %5d %-3s %-4s . %-4s %s ? %5s . %10.4f %10.4f %10.4f  0.0  0.0  ?  ?  ?  ?  ?  .  %5s %4s %s %4d"
+                    print(line % (atomIndex, symbol, atom.name, res.name, chainName, resId, coords[0], coords[1], coords[2],
+                                  resId, res.name, chainName, atom.name, modelIndex), file=file)
+                    posIndex += 1
+                    atomIndex += 1

--- a/wrappers/python/simtk/openmm/app/pdbxfile.py
+++ b/wrappers/python/simtk/openmm/app/pdbxfile.py
@@ -33,15 +33,15 @@ from __future__ import division, absolute_import, print_function
 __author__ = "Peter Eastman"
 __version__ = "2.0"
 
-import os
 import sys
 import math
-from simtk.openmm import Vec3
+from simtk.openmm import Vec3, Platform
+from datetime import date
 from simtk.openmm.app.internal.pdbx.reader.PdbxReader import PdbxReader
 from simtk.openmm.app.internal.unitcell import computePeriodicBoxVectors
 from simtk.openmm.app import Topology
-from simtk.unit import nanometers, angstroms, is_quantity, norm, Quantity
-import element as elem
+from simtk.unit import nanometers, angstroms, is_quantity, norm, Quantity, dot
+from . import element as elem
 try:
     import numpy
 except:
@@ -245,12 +245,12 @@ class PDBxFile(object):
             alpha = math.acos(dot(b, c)/(b_length*c_length))*180.0/math.pi
             beta = math.acos(dot(c, a)/(c_length*a_length))*180.0/math.pi
             gamma = math.acos(dot(a, b)/(a_length*b_length))*180.0/math.pi
-            print('_cell.length_a     %10.4f', file=file)
-            print('_cell.length_b     %10.4f', file=file)
-            print('_cell.length_c     %10.4f', file=file)
-            print('_cell.angle_alpha  %10.4f', file=file)
-            print('_cell.angle_beta   %10.4f', file=file)
-            print('_cell.angle_gamma  %10.4f', file=file)
+            print('_cell.length_a     %10.4f' % a_length, file=file)
+            print('_cell.length_b     %10.4f' % b_length, file=file)
+            print('_cell.length_c     %10.4f' % c_length, file=file)
+            print('_cell.angle_alpha  %10.4f' % alpha, file=file)
+            print('_cell.angle_beta   %10.4f' % beta, file=file)
+            print('_cell.angle_gamma  %10.4f' % gamma, file=file)
             print('##', file=file)
         print('loop_', file=file)
         print('_atom_site.group_PDB', file=file)
@@ -310,25 +310,17 @@ class PDBxFile(object):
                 chainName = chr(ord('A')+chainIndex%26)
             residues = list(chain.residues())
             for (resIndex, res) in enumerate(residues):
-                resName = res.name
                 if keepIds:
                     resId = res.id
                 else:
                     resId = resIndex + 1
                 for atom in res.atoms():
-                    atomName = atom.name
-                    if len(atom.name) < 4 and atom.name[:1].isalpha() and (atom.element is None or len(atom.element.symbol) < 2):
-                        atomName = ' '+atom.name
-                    elif len(atom.name) > 4:
-                        atomName = atom.name[:4]
-                    else:
-                        atomName = atom.name
                     coords = positions[posIndex]
                     if atom.element is not None:
                         symbol = atom.element.symbol
                     else:
                         symbol = '?'
-                    line = "ATOM  %5d %-3s %-4s . %-4s %s ? %5s . %10.4f %10.4f %10.4f  0.0  0.0  ?  ?  ?  ?  ?  .  %5s %4s %s %4d"
+                    line = "ATOM  %5d %-3s %-4s . %-4s %s ? %5s . %10.4f %10.4f %10.4f  0.0  0.0  ?  ?  ?  ?  ?  .  %5s %4s %s %4s %5d"
                     print(line % (atomIndex, symbol, atom.name, res.name, chainName, resId, coords[0], coords[1], coords[2],
                                   resId, res.name, chainName, atom.name, modelIndex), file=file)
                     posIndex += 1

--- a/wrappers/python/tests/TestPdbxFile.py
+++ b/wrappers/python/tests/TestPdbxFile.py
@@ -3,6 +3,7 @@ from simtk.openmm.app import *
 from simtk.openmm import *
 from simtk.unit import *
 import simtk.openmm.app.element as elem
+import os
 
 class TestPdbxFile(unittest.TestCase):
     """Test the PDBx/mmCIF file parser"""
@@ -48,6 +49,69 @@ class TestPdbxFile(unittest.TestCase):
             diff = abs(p1[i]-p2[i])/scale
             self.assertTrue(diff < tol)
 
+    def testReporterImplicit(self):
+        """ Tests the PDBxReporter without PBC """
+        parm = AmberPrmtopFile('systems/alanine-dipeptide-implicit.prmtop')
+        system = parm.createSystem()
+        sim = Simulation(parm.topology, system, VerletIntegrator(1*femtoseconds),
+                         Platform.getPlatformByName('Reference'))
+        sim.context.setPositions(PDBFile('systems/alanine-dipeptide-implicit.pdb').getPositions())
+        sim.reporters.append(PDBxReporter('test.cif', 1))
+        sim.step(10)
+        pdb = PDBxFile('test.cif')
+        self.assertEqual(len(list(pdb.topology.atoms())), len(list(parm.topology.atoms())))
+        self.assertEqual(len(list(pdb.topology.residues())), len(list(parm.topology.residues())))
+        for res1, res2 in zip(pdb.topology.residues(), parm.topology.residues()):
+            self.assertEqual(res1.name, res2.name)
+            for atom1, atom2 in zip(res1.atoms(), res2.atoms()):
+                self.assertEqual(atom1.name, atom2.name)
+        positions = pdb.getPositions(frame=9)
+        self.assertFalse(all(x1 == x2 for x1, x2 in zip(positions, pdb.getPositions(frame=0))))
+        # There should only be 10 frames (0 through 9)
+        self.assertRaises(IndexError, lambda: pdb.getPositions(frame=10))
+        self.assertIs(pdb.topology.getPeriodicBoxVectors(), None)
+        os.unlink('test.cif')
+
+    def assertAlmostEqualVec(self, vec1, vec2, *args, **kwargs):
+        if is_quantity(vec1):
+            vec1 = vec1.value_in_unit_system(md_unit_system)
+        if is_quantity(vec2):
+            vec2 = vec2.value_in_unit_system(md_unit_system)
+        for x, y in zip(vec1, vec2):
+            self.assertAlmostEqual(x, y, *args, **kwargs)
+
+    def testReporterExplicit(self):
+        """ Tests the PDBxReporter with PBC """
+        parm = AmberPrmtopFile('systems/alanine-dipeptide-explicit.prmtop')
+        system = parm.createSystem(nonbondedCutoff=1.0, nonbondedMethod=PME)
+        sim = Simulation(parm.topology, system, VerletIntegrator(1*femtoseconds),
+                         Platform.getPlatformByName('Reference'))
+        orig_pdb = PDBFile('systems/alanine-dipeptide-explicit.pdb')
+        sim.context.setPositions(orig_pdb.getPositions())
+        sim.context.setPeriodicBoxVectors(*parm.topology.getPeriodicBoxVectors())
+        sim.reporters.append(PDBxReporter('test.cif', 1))
+        sim.step(10)
+        pdb = PDBxFile('test.cif')
+        self.assertEqual(len(list(pdb.topology.atoms())), len(list(parm.topology.atoms())))
+        self.assertEqual(len(list(pdb.topology.residues())), len(list(parm.topology.residues())))
+        for res1, res2 in zip(pdb.topology.residues(), parm.topology.residues()):
+            self.assertEqual(res1.name, res2.name)
+            for atom1, atom2 in zip(res1.atoms(), res2.atoms()):
+                self.assertEqual(atom1.name, atom2.name)
+        positions = pdb.getPositions(frame=9)
+        self.assertFalse(all(x1 == x2 for x1, x2 in zip(positions, pdb.getPositions(frame=0))))
+        # There should only be 10 frames (0 through 9)
+        self.assertRaises(IndexError, lambda: pdb.getPositions(frame=10))
+        self.assertAlmostEqualVec(parm.topology.getPeriodicBoxVectors()[0],
+                                  pdb.topology.getPeriodicBoxVectors()[0],
+                                  places=5)
+        self.assertAlmostEqualVec(parm.topology.getPeriodicBoxVectors()[1],
+                                  pdb.topology.getPeriodicBoxVectors()[1],
+                                  places=5)
+        self.assertAlmostEqualVec(parm.topology.getPeriodicBoxVectors()[2],
+                                  pdb.topology.getPeriodicBoxVectors()[2],
+                                  places=5)
+        os.unlink('test.cif')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add a `PDBxReporter` class that writes a PDBx/mmCIF trajectory just like the PDB reporter does.  The mmCIF writer implemented here is my own code and unlike the RCSB module does not require storing everything in memory before writing the file, so it can be written continuously and does not have to store stuff in memory.

Also adds two tests and makes sure that the CIF files generated can actually be read back in by `PDBxFile` correctly.

There are also a couple other fixes, like changing some implicit relative imports to explicit relative imports (part of the "single code-base for Py2 and Py3 without using `2to3`" -- still a lot to do on that regard, though).

The last change I made here was to have PDBReporter and PDBxReporter automatically call `flush()` on any file object opened for that reporter following any frame writes as long as that file object supports flushing.

This closes #1072 and #1074 