### PR TITLE
Fix OpenCL platform on low-end devices

### DIFF
--- a/platforms/opencl/src/OpenCLContext.cpp
+++ b/platforms/opencl/src/OpenCLContext.cpp
@@ -130,7 +130,7 @@ OpenCLContext::OpenCLContext(const System& system, int platformIndex, int device
                             // This will be less than the wavefront width since it takes several
                             // cycles to execute the full wavefront.
                             // The SIMD instruction width is the VLIW instruction width (or 1 for scalar),
-                            // this is the number of ALUs that can be executing per instruction per thread. 
+                            // this is the number of ALUs that can be executing per instruction per thread.
                             devices[i].getInfo<CL_DEVICE_SIMD_PER_COMPUTE_UNIT_AMD>() *
                             devices[i].getInfo<CL_DEVICE_SIMD_WIDTH_AMD>() *
                             devices[i].getInfo<CL_DEVICE_SIMD_INSTRUCTION_WIDTH_AMD>();
@@ -342,9 +342,9 @@ OpenCLContext::OpenCLContext(const System& system, int platformIndex, int device
         compilationDefines["EXP"] = "exp";
         compilationDefines["LOG"] = "log";
     }
-    
+
     // Set defines for applying periodic boundary conditions.
-    
+
     Vec3 boxVectors[3];
     system.getDefaultPeriodicBoxVectors(boxVectors[0], boxVectors[1], boxVectors[2]);
     boxIsTriclinic = (boxVectors[0][1] != 0.0 || boxVectors[0][2] != 0.0 ||
@@ -392,11 +392,11 @@ OpenCLContext::OpenCLContext(const System& system, int platformIndex, int device
     }
 
     // Create the work thread used for parallelization when running on multiple devices.
-    
+
     thread = new WorkThread();
-    
+
     // Create utilities objects.
-    
+
     bonded = new OpenCLBondedUtilities(*this);
     nonbonded = new OpenCLNonbondedUtilities(*this);
     integration = new OpenCLIntegrationUtilities(*this, system);
@@ -512,7 +512,7 @@ string OpenCLContext::replaceStrings(const string& input, const std::map<std::st
             if (index != result.npos) {
                 if ((index == 0 || symbolChars.find(result[index-1]) == symbolChars.end()) && (index == result.size()-size || symbolChars.find(result[index+size]) == symbolChars.end())) {
                     // We have found a complete symbol, not part of a longer symbol.
-                    
+
                     result.replace(index, size, iter->second);
                     index += iter->second.size();
                 }
@@ -797,7 +797,7 @@ private:
 
 void OpenCLContext::findMoleculeGroups() {
     // The first time this is called, we need to identify all the molecules in the system.
-    
+
     if (moleculeGroups.size() == 0) {
         // Add a ForceInfo that makes sure reordering doesn't break virtual sites.
 
@@ -879,7 +879,7 @@ void OpenCLContext::findMoleculeGroups() {
                     if (!forces[k]->areParticlesIdentical(mol.atoms[i], mol2.atoms[i]))
                         identical = false;
             }
-            
+
             // See if the constraints are identical.
 
             for (int i = 0; i < (int) mol.constraints.size() && identical; i++) {
@@ -960,11 +960,11 @@ void OpenCLContext::invalidateMolecules() {
     }
     if (valid)
         return;
-    
+
     // The list of which molecules are identical is no longer valid.  We need to restore the
     // atoms to their original order, rebuild the list of identical molecules, and sort them
     // again.
-    
+
     vector<mm_int4> newCellOffsets(numAtoms);
     if (useDoublePrecision) {
         vector<mm_double4> oldPosq(paddedNumAtoms);

--- a/platforms/opencl/src/OpenCLNonbondedUtilities.cpp
+++ b/platforms/opencl/src/OpenCLNonbondedUtilities.cpp
@@ -186,7 +186,7 @@ static bool compareUshort2(mm_ushort2 a, mm_ushort2 b) {
 void OpenCLNonbondedUtilities::initialize(const System& system) {
     if (atomExclusions.size() == 0) {
         // No exclusions were specifically requested, so just mark every atom as not interacting with itself.
-        
+
         atomExclusions.resize(context.getNumAtoms());
         for (int i = 0; i < (int) atomExclusions.size(); i++)
             atomExclusions[i].push_back(i);
@@ -199,7 +199,7 @@ void OpenCLNonbondedUtilities::initialize(const System& system) {
     setAtomBlockRange(context.getContextIndex()/(double) numContexts, (context.getContextIndex()+1)/(double) numContexts);
 
     // Build a list of tiles that contain exclusions.
-    
+
     set<pair<int, int> > tilesWithExclusions;
     for (int atom1 = 0; atom1 < (int) atomExclusions.size(); ++atom1) {
         int x = atom1/OpenCLContext::TileSize;
@@ -410,7 +410,7 @@ void OpenCLNonbondedUtilities::setAtomBlockRange(double startFraction, double en
     numTiles = (int) (endFraction*totalTiles)-startTileIndex;
     if (useCutoff) {
         // We are using a cutoff, and the kernels have already been created.
-        
+
         for (map<int, KernelSet>::iterator iter = groupKernels.begin(); iter != groupKernels.end(); ++iter) {
             iter->second.forceKernel.setArg<cl_uint>(5, startTileIndex);
             iter->second.forceKernel.setArg<cl_uint>(6, numTiles);
@@ -491,7 +491,7 @@ void OpenCLNonbondedUtilities::createKernelsForGroups(int groups) {
             kernels.findInteractingBlocksKernel.setArg<cl::Buffer>(18, rebuildNeighborList->getDeviceBuffer());
             if (kernels.findInteractingBlocksKernel.getWorkGroupInfo<CL_KERNEL_WORK_GROUP_SIZE>(context.getDevice()) < groupSize) {
                 // The device can't handle this block size, so reduce it.
-                
+
                 groupSize -= 32;
                 if (groupSize < 32)
                     throw OpenMMException("Failed to create findInteractingBlocks kernel");

--- a/platforms/opencl/src/kernels/nonbonded.cl
+++ b/platforms/opencl/src/kernels/nonbonded.cl
@@ -25,7 +25,7 @@ __kernel void computeNonbonded(
         __global real* restrict energyBuffer, __global const real4* restrict posq, __global const unsigned int* restrict exclusions,
         __global const ushort2* restrict exclusionTiles, unsigned int startTileIndex, unsigned int numTileIndices
 #ifdef USE_CUTOFF
-        , __global const int* restrict tiles, __global const unsigned int* restrict interactionCount, real4 periodicBoxSize, real4 invPeriodicBoxSize, 
+        , __global const int* restrict tiles, __global const unsigned int* restrict interactionCount, real4 periodicBoxSize, real4 invPeriodicBoxSize,
         real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ, unsigned int maxTiles, __global const real4* restrict blockCenter,
         __global const real4* restrict blockSize, __global const int* restrict interactingAtoms
 #endif
@@ -38,7 +38,7 @@ __kernel void computeNonbonded(
     __local AtomData localData[FORCE_WORK_GROUP_SIZE];
 
     // First loop: process tiles that contain exclusions.
-    
+
     const unsigned int firstExclusionTile = FIRST_EXCLUSION_TILE+warp*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
     const unsigned int lastExclusionTile = FIRST_EXCLUSION_TILE+(warp+1)*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/totalWarps;
     for (int pos = firstExclusionTile; pos < lastExclusionTile; pos++) {
@@ -100,7 +100,7 @@ __kernel void computeNonbonded(
         }
         else {
             // This is an off-diagonal tile.
-            
+
             const unsigned int localAtomIndex = get_local_id(0);
             unsigned int j = y*TILE_SIZE + tgx;
             real4 tempPosq = posq[j];
@@ -126,7 +126,7 @@ __kernel void computeNonbonded(
 #endif
                 real r2 = delta.x*delta.x + delta.y*delta.y + delta.z*delta.z;
 #ifdef PRUNE_BY_CUTOFF
-                if (r2 < CUTOFF_SQUARED) {
+                if (r2 < MAX_CUTOFF*MAX_CUTOFF) {
 #endif
                     real invR = RSQRT(r2);
                     real r = r2*invR;
@@ -213,7 +213,7 @@ __kernel void computeNonbonded(
         bool includeTile = true;
 
         // Extract the coordinates of this tile.
-        
+
         int x, y;
         bool singlePeriodicCopy = false;
 #ifdef USE_CUTOFF
@@ -245,7 +245,7 @@ __kernel void computeNonbonded(
                 }
                 else
                     skipTiles[get_local_id(0)] = end;
-                skipBase += TILE_SIZE;            
+                skipBase += TILE_SIZE;
                 currentSkipIndex = tbx;
                 SYNC_WARPS;
             }
@@ -300,7 +300,7 @@ __kernel void computeNonbonded(
                     real4 delta = (real4) (posq2.xyz - posq1.xyz, 0);
                     real r2 = delta.x*delta.x + delta.y*delta.y + delta.z*delta.z;
 #ifdef PRUNE_BY_CUTOFF
-                    if (r2 < CUTOFF_SQUARED) {
+                    if (r2 < MAX_CUTOFF*MAX_CUTOFF) {
 #endif
                         real invR = RSQRT(r2);
                         real r = r2*invR;
@@ -352,7 +352,7 @@ __kernel void computeNonbonded(
 #endif
                     real r2 = delta.x*delta.x + delta.y*delta.y + delta.z*delta.z;
 #ifdef PRUNE_BY_CUTOFF
-                    if (r2 < CUTOFF_SQUARED) {
+                    if (r2 < MAX_CUTOFF*MAX_CUTOFF) {
 #endif
                         real invR = RSQRT(r2);
                         real r = r2*invR;

--- a/platforms/opencl/src/kernels/nonbonded_cpu.cl
+++ b/platforms/opencl/src/kernels/nonbonded_cpu.cl
@@ -22,7 +22,7 @@ __kernel void computeNonbonded(
         __global real* restrict energyBuffer, __global const real4* restrict posq, __global const unsigned int* restrict exclusions,
         __global const ushort2* restrict exclusionTiles, unsigned int startTileIndex, unsigned int numTileIndices
 #ifdef USE_CUTOFF
-        , __global const int* restrict tiles, __global const unsigned int* restrict interactionCount, real4 periodicBoxSize, real4 invPeriodicBoxSize, 
+        , __global const int* restrict tiles, __global const unsigned int* restrict interactionCount, real4 periodicBoxSize, real4 invPeriodicBoxSize,
         real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ, unsigned int maxTiles, __global const real4* restrict blockCenter,
         __global const real4* restrict blockSize, __global const int* restrict interactingAtoms
 #endif
@@ -31,7 +31,7 @@ __kernel void computeNonbonded(
     __local AtomData localData[TILE_SIZE];
 
     // First loop: process tiles that contain exclusions.
-    
+
     const unsigned int firstExclusionTile = FIRST_EXCLUSION_TILE+get_group_id(0)*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/get_num_groups(0);
     const unsigned int lastExclusionTile = FIRST_EXCLUSION_TILE+(get_group_id(0)+1)*(LAST_EXCLUSION_TILE-FIRST_EXCLUSION_TILE)/get_num_groups(0);
     for (int pos = firstExclusionTile; pos < lastExclusionTile; pos++) {
@@ -70,7 +70,7 @@ __kernel void computeNonbonded(
 #endif
                     real r2 = dot(delta.xyz, delta.xyz);
 #ifdef USE_CUTOFF
-                    if (r2 < CUTOFF_SQUARED) {
+                    if (r2 < MAX_CUTOFF*MAX_CUTOFF) {
 #endif
                         real invR = RSQRT(r2);
                         real r = r2*invR;
@@ -138,7 +138,7 @@ __kernel void computeNonbonded(
 #endif
                     real r2 = dot(delta.xyz, delta.xyz);
 #ifdef USE_CUTOFF
-                    if (r2 < CUTOFF_SQUARED) {
+                    if (r2 < MAX_CUTOFF*MAX_CUTOFF) {
 #endif
                         real invR = RSQRT(r2);
                         real r = r2*invR;
@@ -228,9 +228,9 @@ __kernel void computeNonbonded(
     while (pos < end) {
         const bool hasExclusions = false;
         bool includeTile = true;
-        
+
         // Extract the coordinates of this tile.
-        
+
         int x, y;
         bool singlePeriodicCopy = false;
 #ifdef USE_CUTOFF
@@ -304,7 +304,7 @@ __kernel void computeNonbonded(
                         real4 posq2 = (real4) (localData[j].x, localData[j].y, localData[j].z, localData[j].q);
                         real4 delta = (real4) (posq2.xyz - posq1.xyz, 0);
                         real r2 = dot(delta.xyz, delta.xyz);
-                        if (r2 < CUTOFF_SQUARED) {
+                        if (r2 < MAX_CUTOFF*MAX_CUTOFF) {
                             real invR = RSQRT(r2);
                             real r = r2*invR;
                             unsigned int atom2 = j;
@@ -367,7 +367,7 @@ __kernel void computeNonbonded(
 #endif
                         real r2 = dot(delta.xyz, delta.xyz);
 #ifdef USE_CUTOFF
-                        if (r2 < CUTOFF_SQUARED) {
+                        if (r2 < MAX_CUTOFF*MAX_CUTOFF) {
 #endif
                             real invR = RSQRT(r2);
                             real r = r2*invR;


### PR DESCRIPTION
Code from @peastman on my machine. Test results on OSX laptop (integrated GPU) cc #1089.

```
$ ctest
Test project /Users/rmcgibbo/projects/openmm/build
        Start   1: TestReferenceAndersenThermostat
  1/149 Test   #1: TestReferenceAndersenThermostat .................   Passed    0.40 sec
        Start   2: TestReferenceBrownianIntegrator
  2/149 Test   #2: TestReferenceBrownianIntegrator .................   Passed    0.20 sec
        Start   3: TestReferenceCheckpoints
  3/149 Test   #3: TestReferenceCheckpoints ........................   Passed    0.03 sec
        Start   4: TestReferenceCMAPTorsionForce
  4/149 Test   #4: TestReferenceCMAPTorsionForce ...................   Passed    0.03 sec
        Start   5: TestReferenceCMMotionRemover
  5/149 Test   #5: TestReferenceCMMotionRemover ....................   Passed    0.02 sec
        Start   6: TestReferenceCustomAngleForce
  6/149 Test   #6: TestReferenceCustomAngleForce ...................   Passed    0.01 sec
        Start   7: TestReferenceCustomBondForce
  7/149 Test   #7: TestReferenceCustomBondForce ....................   Passed    0.01 sec
        Start   8: TestReferenceCustomCompoundBondForce
  8/149 Test   #8: TestReferenceCustomCompoundBondForce ............   Passed    1.53 sec
        Start   9: TestReferenceCustomExternalForce
  9/149 Test   #9: TestReferenceCustomExternalForce ................   Passed    0.01 sec
        Start  10: TestReferenceCustomGBForce
 10/149 Test  #10: TestReferenceCustomGBForce ......................   Passed    2.99 sec
        Start  11: TestReferenceCustomHbondForce
 11/149 Test  #11: TestReferenceCustomHbondForce ...................   Passed    0.01 sec
        Start  12: TestReferenceCustomIntegrator
 12/149 Test  #12: TestReferenceCustomIntegrator ...................   Passed    4.99 sec
        Start  13: TestReferenceCustomManyParticleForce
 13/149 Test  #13: TestReferenceCustomManyParticleForce ............   Passed    0.14 sec
        Start  14: TestReferenceCustomNonbondedForce
 14/149 Test  #14: TestReferenceCustomNonbondedForce ...............   Passed   11.71 sec
        Start  15: TestReferenceCustomTorsionForce
 15/149 Test  #15: TestReferenceCustomTorsionForce .................   Passed    0.01 sec
        Start  16: TestReferenceEwald
 16/149 Test  #16: TestReferenceEwald ..............................   Passed    1.72 sec
        Start  17: TestReferenceGBSAOBCForce
 17/149 Test  #17: TestReferenceGBSAOBCForce .......................   Passed    0.01 sec
        Start  18: TestReferenceGBVIForce
 18/149 Test  #18: TestReferenceGBVIForce ..........................   Passed    0.01 sec
        Start  19: TestReferenceHarmonicAngleForce
 19/149 Test  #19: TestReferenceHarmonicAngleForce .................   Passed    0.01 sec
        Start  20: TestReferenceHarmonicBondForce
 20/149 Test  #20: TestReferenceHarmonicBondForce ..................   Passed    0.01 sec
        Start  21: TestReferenceKineticEnergy
 21/149 Test  #21: TestReferenceKineticEnergy ......................   Passed    0.01 sec
        Start  22: TestReferenceLangevinIntegrator
 22/149 Test  #22: TestReferenceLangevinIntegrator .................   Passed    0.07 sec
        Start  23: TestReferenceLocalEnergyMinimizer
 23/149 Test  #23: TestReferenceLocalEnergyMinimizer ...............   Passed    6.88 sec
        Start  24: TestReferenceMonteCarloAnisotropicBarostat
 24/149 Test  #24: TestReferenceMonteCarloAnisotropicBarostat ......   Passed    1.78 sec
        Start  25: TestReferenceMonteCarloBarostat
 25/149 Test  #25: TestReferenceMonteCarloBarostat .................   Passed    0.47 sec
        Start  26: TestReferenceMonteCarloMembraneBarostat
 26/149 Test  #26: TestReferenceMonteCarloMembraneBarostat .........   Passed    1.27 sec
        Start  27: TestReferenceNeighborList
 27/149 Test  #27: TestReferenceNeighborList .......................   Passed    0.06 sec
        Start  28: TestReferenceNonbondedForce
 28/149 Test  #28: TestReferenceNonbondedForce .....................   Passed    0.09 sec
        Start  29: TestReferencePeriodicTorsionForce
 29/149 Test  #29: TestReferencePeriodicTorsionForce ...............   Passed    0.01 sec
        Start  30: TestReferenceRandom
 30/149 Test  #30: TestReferenceRandom .............................   Passed    1.87 sec
        Start  31: TestReferenceRBTorsionForce
 31/149 Test  #31: TestReferenceRBTorsionForce .....................   Passed    0.01 sec
        Start  32: TestReferenceSettle
 32/149 Test  #32: TestReferenceSettle .............................   Passed    0.05 sec
        Start  33: TestReferenceVariableLangevinIntegrator
 33/149 Test  #33: TestReferenceVariableLangevinIntegrator .........   Passed   25.81 sec
        Start  34: TestReferenceVariableVerletIntegrator
 34/149 Test  #34: TestReferenceVariableVerletIntegrator ...........   Passed    4.03 sec
        Start  35: TestReferenceVerletIntegrator
 35/149 Test  #35: TestReferenceVerletIntegrator ...................   Passed    0.02 sec
        Start  36: TestReferenceVirtualSites
 36/149 Test  #36: TestReferenceVirtualSites .......................   Passed    0.48 sec
        Start  37: TestOpenCLAndersenThermostatSingle
 37/149 Test  #37: TestOpenCLAndersenThermostatSingle ..............   Passed   51.24 sec
        Start  38: TestOpenCLBrownianIntegratorSingle
 38/149 Test  #38: TestOpenCLBrownianIntegratorSingle ..............   Passed   19.88 sec
        Start  39: TestOpenCLCheckpointsSingle
 39/149 Test  #39: TestOpenCLCheckpointsSingle .....................   Passed    3.47 sec
        Start  40: TestOpenCLCMAPTorsionForceSingle
 40/149 Test  #40: TestOpenCLCMAPTorsionForceSingle ................   Passed    0.73 sec
        Start  41: TestOpenCLCMMotionRemoverSingle
 41/149 Test  #41: TestOpenCLCMMotionRemoverSingle .................   Passed    1.08 sec
        Start  42: TestOpenCLCustomAngleForceSingle
 42/149 Test  #42: TestOpenCLCustomAngleForceSingle ................   Passed    0.56 sec
        Start  43: TestOpenCLCustomBondForceSingle
 43/149 Test  #43: TestOpenCLCustomBondForceSingle .................   Passed    0.41 sec
        Start  44: TestOpenCLCustomCompoundBondForceSingle
 44/149 Test  #44: TestOpenCLCustomCompoundBondForceSingle .........   Passed    2.57 sec
        Start  45: TestOpenCLCustomExternalForceSingle
 45/149 Test  #45: TestOpenCLCustomExternalForceSingle .............   Passed    0.24 sec
        Start  46: TestOpenCLCustomGBForceSingle
 46/149 Test  #46: TestOpenCLCustomGBForceSingle ...................   Passed   10.67 sec
        Start  47: TestOpenCLCustomHbondForceSingle
 47/149 Test  #47: TestOpenCLCustomHbondForceSingle ................   Passed    0.84 sec
        Start  48: TestOpenCLCustomIntegratorSingle
 48/149 Test  #48: TestOpenCLCustomIntegratorSingle ................   Passed   59.17 sec
        Start  49: TestOpenCLCustomManyParticleForceSingle
 49/149 Test  #49: TestOpenCLCustomManyParticleForceSingle .........***Failed    0.04 sec
        Start  50: TestOpenCLCustomNonbondedForceSingle
 50/149 Test  #50: TestOpenCLCustomNonbondedForceSingle ............   Passed   13.95 sec
        Start  51: TestOpenCLCustomTorsionForceSingle
 51/149 Test  #51: TestOpenCLCustomTorsionForceSingle ..............   Passed    1.02 sec
        Start  52: TestOpenCLEwaldSingle
 52/149 Test  #52: TestOpenCLEwaldSingle ...........................   Passed   40.99 sec
        Start  53: TestOpenCLFFTSingle
 53/149 Test  #53: TestOpenCLFFTSingle .............................   Passed    1.92 sec
        Start  54: TestOpenCLGBSAOBCForceSingle
 54/149 Test  #54: TestOpenCLGBSAOBCForceSingle ....................   Passed   31.42 sec
        Start  55: TestOpenCLHarmonicAngleForceSingle
 55/149 Test  #55: TestOpenCLHarmonicAngleForceSingle ..............   Passed    0.29 sec
        Start  56: TestOpenCLHarmonicBondForceSingle
 56/149 Test  #56: TestOpenCLHarmonicBondForceSingle ...............   Passed    0.41 sec
        Start  57: TestOpenCLLangevinIntegratorSingle
 57/149 Test  #57: TestOpenCLLangevinIntegratorSingle ..............   Passed   16.02 sec
        Start  58: TestOpenCLLocalEnergyMinimizerSingle
 58/149 Test  #58: TestOpenCLLocalEnergyMinimizerSingle ............   Passed   15.73 sec
        Start  59: TestOpenCLMonteCarloAnisotropicBarostatSingle
 59/149 Test  #59: TestOpenCLMonteCarloAnisotropicBarostatSingle ...   Passed   64.60 sec
        Start  60: TestOpenCLMonteCarloBarostatSingle
 60/149 Test  #60: TestOpenCLMonteCarloBarostatSingle ..............   Passed   36.98 sec
        Start  61: TestOpenCLMultipleForcesSingle
 61/149 Test  #61: TestOpenCLMultipleForcesSingle ..................   Passed    0.43 sec
        Start  62: TestOpenCLNonbondedForceSingle
 62/149 Test  #62: TestOpenCLNonbondedForceSingle ..................   Passed   18.19 sec
        Start  63: TestOpenCLPeriodicTorsionForceSingle
 63/149 Test  #63: TestOpenCLPeriodicTorsionForceSingle ............   Passed    0.62 sec
        Start  64: TestOpenCLRandomSingle
 64/149 Test  #64: TestOpenCLRandomSingle ..........................   Passed    1.83 sec
        Start  65: TestOpenCLRBTorsionForceSingle
 65/149 Test  #65: TestOpenCLRBTorsionForceSingle ..................   Passed    0.55 sec
        Start  66: TestOpenCLSettleSingle
 66/149 Test  #66: TestOpenCLSettleSingle ..........................   Passed    1.30 sec
        Start  67: TestOpenCLSortSingle
 67/149 Test  #67: TestOpenCLSortSingle ............................   Passed    0.17 sec
        Start  68: TestOpenCLVariableLangevinIntegratorSingle
 68/149 Test  #68: TestOpenCLVariableLangevinIntegratorSingle ......   Passed   20.68 sec
        Start  69: TestOpenCLVariableVerletIntegratorSingle
 69/149 Test  #69: TestOpenCLVariableVerletIntegratorSingle ........   Passed    6.46 sec
        Start  70: TestOpenCLVerletIntegratorSingle
 70/149 Test  #70: TestOpenCLVerletIntegratorSingle ................   Passed    4.63 sec
        Start  71: TestOpenCLVirtualSitesSingle
 71/149 Test  #71: TestOpenCLVirtualSitesSingle ....................   Passed    6.24 sec
        Start  72: TestCpuCustomGBForce
 72/149 Test  #72: TestCpuCustomGBForce ............................   Passed    0.34 sec
        Start  73: TestCpuCustomManyParticleForce
 73/149 Test  #73: TestCpuCustomManyParticleForce ..................   Passed   12.32 sec
        Start  74: TestCpuCustomNonbondedForce
 74/149 Test  #74: TestCpuCustomNonbondedForce .....................   Passed    1.11 sec
        Start  75: TestCpuEwald
 75/149 Test  #75: TestCpuEwald ....................................   Passed    1.48 sec
        Start  76: TestCpuGBSAOBCForce
 76/149 Test  #76: TestCpuGBSAOBCForce .............................   Passed    0.83 sec
        Start  77: TestCpuLangevinIntegrator
 77/149 Test  #77: TestCpuLangevinIntegrator .......................   Passed    7.50 sec
        Start  78: TestCpuNeighborList
 78/149 Test  #78: TestCpuNeighborList .............................   Passed    0.07 sec
        Start  79: TestCpuNonbondedForce
 79/149 Test  #79: TestCpuNonbondedForce ...........................   Passed    0.58 sec
        Start  80: TestCpuPeriodicTorsionForce
 80/149 Test  #80: TestCpuPeriodicTorsionForce .....................   Passed    0.01 sec
        Start  81: TestCpuRBTorsionForce
 81/149 Test  #81: TestCpuRBTorsionForce ...........................   Passed    0.01 sec
        Start  82: TestCpuSettle
 82/149 Test  #82: TestCpuSettle ...................................   Passed    0.42 sec
        Start  83: TestReferenceAmoebaAngleForce
 83/149 Test  #83: TestReferenceAmoebaAngleForce ...................   Passed    0.02 sec
        Start  84: TestReferenceAmoebaBondForce
 84/149 Test  #84: TestReferenceAmoebaBondForce ....................   Passed    0.01 sec
        Start  85: TestReferenceAmoebaGeneralizedKirkwoodForce
 85/149 Test  #85: TestReferenceAmoebaGeneralizedKirkwoodForce .....   Passed    1.97 sec
        Start  86: TestReferenceAmoebaInPlaneAngleForce
 86/149 Test  #86: TestReferenceAmoebaInPlaneAngleForce ............   Passed    0.01 sec
        Start  87: TestReferenceAmoebaMultipoleForce
 87/149 Test  #87: TestReferenceAmoebaMultipoleForce ...............   Passed    1.03 sec
        Start  88: TestReferenceAmoebaOutOfPlaneBendForce
 88/149 Test  #88: TestReferenceAmoebaOutOfPlaneBendForce ..........   Passed    0.01 sec
        Start  89: TestReferenceAmoebaPiTorsionForce
 89/149 Test  #89: TestReferenceAmoebaPiTorsionForce ...............   Passed    0.01 sec
        Start  90: TestReferenceAmoebaStretchBendForce
 90/149 Test  #90: TestReferenceAmoebaStretchBendForce .............   Passed    0.01 sec
        Start  91: TestReferenceAmoebaTorsionTorsionForce
 91/149 Test  #91: TestReferenceAmoebaTorsionTorsionForce ..........   Passed    0.01 sec
        Start  92: TestReferenceAmoebaVdwForce
 92/149 Test  #92: TestReferenceAmoebaVdwForce .....................   Passed    0.12 sec
        Start  93: TestReferenceWcaDispersionForce
 93/149 Test  #93: TestReferenceWcaDispersionForce .................   Passed    0.01 sec
        Start  94: TestSerializeAmoebaAngleForce
 94/149 Test  #94: TestSerializeAmoebaAngleForce ...................   Passed    0.01 sec
        Start  95: TestSerializeAmoebaBondForce
 95/149 Test  #95: TestSerializeAmoebaBondForce ....................   Passed    0.01 sec
        Start  96: TestSerializeAmoebaGeneralizedKirkwoodForce
 96/149 Test  #96: TestSerializeAmoebaGeneralizedKirkwoodForce .....   Passed    0.01 sec
        Start  97: TestSerializeAmoebaInPlaneAngleForce
 97/149 Test  #97: TestSerializeAmoebaInPlaneAngleForce ............   Passed    0.01 sec
        Start  98: TestSerializeAmoebaMultipoleForce
 98/149 Test  #98: TestSerializeAmoebaMultipoleForce ...............   Passed    0.01 sec
        Start  99: TestSerializeAmoebaOutOfPlaneBendForce
 99/149 Test  #99: TestSerializeAmoebaOutOfPlaneBendForce ..........   Passed    0.01 sec
        Start 100: TestSerializeAmoebaPiTorsionForce
100/149 Test #100: TestSerializeAmoebaPiTorsionForce ...............   Passed    0.01 sec
        Start 101: TestSerializeAmoebaStretchBendForce
101/149 Test #101: TestSerializeAmoebaStretchBendForce .............   Passed    0.01 sec
        Start 102: TestSerializeAmoebaTorsionTorsionForce
102/149 Test #102: TestSerializeAmoebaTorsionTorsionForce ..........   Passed    0.11 sec
        Start 103: TestSerializeAmoebaVdwForce
103/149 Test #103: TestSerializeAmoebaVdwForce .....................   Passed    0.01 sec
        Start 104: TestSerializeAmoebaWcaDispersionForce
104/149 Test #104: TestSerializeAmoebaWcaDispersionForce ...........   Passed    0.01 sec
        Start 105: TestReferenceRpmd
105/149 Test #105: TestReferenceRpmd ...............................   Passed   24.53 sec
        Start 106: TestOpenCLRpmdSingle
106/149 Test #106: TestOpenCLRpmdSingle ............................   Passed  129.63 sec
        Start 107: TestReferenceDrudeForce
107/149 Test #107: TestReferenceDrudeForce .........................   Passed    0.01 sec
        Start 108: TestReferenceDrudeLangevinIntegrator
108/149 Test #108: TestReferenceDrudeLangevinIntegrator ............   Passed    7.24 sec
        Start 109: TestReferenceDrudeSCFIntegrator
109/149 Test #109: TestReferenceDrudeSCFIntegrator .................   Passed   10.75 sec
        Start 110: TestOpenCLDrudeForceSingle
110/149 Test #110: TestOpenCLDrudeForceSingle ......................   Passed    0.94 sec
        Start 111: TestOpenCLDrudeLangevinIntegratorSingle
111/149 Test #111: TestOpenCLDrudeLangevinIntegratorSingle .........   Passed   22.62 sec
        Start 112: TestOpenCLDrudeSCFIntegratorSingle
112/149 Test #112: TestOpenCLDrudeSCFIntegratorSingle ..............   Passed   30.55 sec
        Start 113: TestSerializeDrudeForce
113/149 Test #113: TestSerializeDrudeForce .........................   Passed    0.01 sec
        Start 114: TestSerializeDrudeLangevinIntegrator
114/149 Test #114: TestSerializeDrudeLangevinIntegrator ............   Passed    0.01 sec
        Start 115: TestCpuPme
115/149 Test #115: TestCpuPme ......................................   Passed    0.57 sec
        Start 116: TestSerializationNode
116/149 Test #116: TestSerializationNode ...........................   Passed    0.01 sec
        Start 117: TestSerializeAndersenThermostat
117/149 Test #117: TestSerializeAndersenThermostat .................   Passed    0.01 sec
        Start 118: TestSerializeCMAPTorsion
118/149 Test #118: TestSerializeCMAPTorsion ........................   Passed    0.01 sec
        Start 119: TestSerializeCMMotionRemover
119/149 Test #119: TestSerializeCMMotionRemover ....................   Passed    0.01 sec
        Start 120: TestSerializeCustomAngleForce
120/149 Test #120: TestSerializeCustomAngleForce ...................   Passed    0.01 sec
        Start 121: TestSerializeCustomBondForce
121/149 Test #121: TestSerializeCustomBondForce ....................   Passed    0.01 sec
        Start 122: TestSerializeCustomCompoundBondForce
122/149 Test #122: TestSerializeCustomCompoundBondForce ............   Passed    0.01 sec
        Start 123: TestSerializeCustomExternalForce
123/149 Test #123: TestSerializeCustomExternalForce ................   Passed    0.01 sec
        Start 124: TestSerializeCustomGBForce
124/149 Test #124: TestSerializeCustomGBForce ......................   Passed    0.01 sec
        Start 125: TestSerializeCustomHbondForce
125/149 Test #125: TestSerializeCustomHbondForce ...................   Passed    0.01 sec
        Start 126: TestSerializeCustomManyParticleForce
126/149 Test #126: TestSerializeCustomManyParticleForce ............   Passed    0.01 sec
        Start 127: TestSerializeCustomNonbondedForce
127/149 Test #127: TestSerializeCustomNonbondedForce ...............   Passed    0.01 sec
        Start 128: TestSerializeCustomTorsionForce
128/149 Test #128: TestSerializeCustomTorsionForce .................   Passed    0.01 sec
        Start 129: TestSerializeGBSAOBCForce
129/149 Test #129: TestSerializeGBSAOBCForce .......................   Passed    0.01 sec
        Start 130: TestSerializeGBVIForce
130/149 Test #130: TestSerializeGBVIForce ..........................   Passed    0.01 sec
        Start 131: TestSerializeHarmonicAngleForce
131/149 Test #131: TestSerializeHarmonicAngleForce .................   Passed    0.01 sec
        Start 132: TestSerializeHarmonicBondForce
132/149 Test #132: TestSerializeHarmonicBondForce ..................   Passed    0.01 sec
        Start 133: TestSerializeIntegrator
133/149 Test #133: TestSerializeIntegrator .........................   Passed    0.01 sec
        Start 134: TestSerializeMonteCarloAnisotropicBarostat
134/149 Test #134: TestSerializeMonteCarloAnisotropicBarostat ......   Passed    0.01 sec
        Start 135: TestSerializeMonteCarloBarostat
135/149 Test #135: TestSerializeMonteCarloBarostat .................   Passed    0.01 sec
        Start 136: TestSerializeMonteCarloMembraneBarostat
136/149 Test #136: TestSerializeMonteCarloMembraneBarostat .........   Passed    0.01 sec
        Start 137: TestSerializeNonbondedForce
137/149 Test #137: TestSerializeNonbondedForce .....................   Passed    0.01 sec
        Start 138: TestSerializePeriodicTorsionForce
138/149 Test #138: TestSerializePeriodicTorsionForce ...............   Passed    0.01 sec
        Start 139: TestSerializeRBTorsionForce
139/149 Test #139: TestSerializeRBTorsionForce .....................   Passed    0.01 sec
        Start 140: TestSerializeState
140/149 Test #140: TestSerializeState ..............................   Passed    0.03 sec
        Start 141: TestSerializeSystem
141/149 Test #141: TestSerializeSystem .............................   Passed    0.01 sec
        Start 142: TestSerializeTabulatedFunctions
142/149 Test #142: TestSerializeTabulatedFunctions .................   Passed    0.01 sec
        Start 143: TestFindExclusions
143/149 Test #143: TestFindExclusions ..............................   Passed    0.01 sec
        Start 144: TestFindMolecules
144/149 Test #144: TestFindMolecules ...............................   Passed    0.02 sec
        Start 145: TestParser
145/149 Test #145: TestParser ......................................   Passed    0.04 sec
        Start 146: TestSplineFitter
146/149 Test #146: TestSplineFitter ................................   Passed    0.01 sec
        Start 147: TestSystem
147/149 Test #147: TestSystem ......................................   Passed    0.01 sec
        Start 148: TestVectorize
148/149 Test #148: TestVectorize ...................................   Passed    0.01 sec
        Start 149: TestVectorize8
149/149 Test #149: TestVectorize8 ..................................   Passed    0.01 sec

99% tests passed, 1 tests failed out of 149

Total Test time (real) = 757.72 sec

The following tests FAILED:
	 49 - TestOpenCLCustomManyParticleForceSingle (Failed)
Errors while running CTest
rmcgibbo@MacBook-Pro  ~/projects/openmm/build (3.4.2) ‹master*›
$ TestOpenCLCustomManyParticleForce single
exception: CustomManyParticleForce requires a device that supports 64 bit atomic operations
```