### PR TITLE
Fix three tests on windows

### DIFF
--- a/wrappers/python/tests/TestAmberPrmtopFile.py
+++ b/wrappers/python/tests/TestAmberPrmtopFile.py
@@ -315,6 +315,7 @@ class TestAmberPrmtopFile(unittest.TestCase):
         fname = tempfile.mktemp(suffix='.dcd')
         simulation.reporters.append(DCDReporter(fname, 1))  # This is an explicit test for the bugs in issue #850
         simulation.step(5)
+        del simulation
         os.remove(fname)
 
     def testChamber(self):

--- a/wrappers/python/tests/TestCheckpointReporter.py
+++ b/wrappers/python/tests/TestCheckpointReporter.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 import tempfile
 import numpy as np
@@ -18,7 +19,7 @@ class TestCheckpointReporter(unittest.TestCase):
         self.simulation.context.setPositions(pdb.positions)
 
     def test_1(self):
-        file = tempfile.NamedTemporaryFile()
+        file = tempfile.NamedTemporaryFile(delete=False)
         self.simulation.reporters.append(app.CheckpointReporter(file, 1))
         self.simulation.step(1)
 
@@ -27,9 +28,10 @@ class TestCheckpointReporter(unittest.TestCase):
         # now set the positions into junk...
         self.simulation.context.setPositions(np.random.random(positions.shape))
         # then reload the right positions from the checkpoint
+        file.close()
         with open(file.name, 'rb') as f:
             self.simulation.context.loadCheckpoint(f.read())
-        file.close()
+        os.unlink(file.name)
 
         newPositions = self.simulation.context.getState(getPositions=True).getPositions(asNumpy=True)._value
         np.testing.assert_array_equal(positions, newPositions)

--- a/wrappers/python/tests/TestPdbxFile.py
+++ b/wrappers/python/tests/TestPdbxFile.py
@@ -70,6 +70,7 @@ class TestPdbxFile(unittest.TestCase):
         # There should only be 10 frames (0 through 9)
         self.assertRaises(IndexError, lambda: pdb.getPositions(frame=10))
         self.assertIs(pdb.topology.getPeriodicBoxVectors(), None)
+        del sim
         os.unlink('test.cif')
 
     def assertAlmostEqualVec(self, vec1, vec2, *args, **kwargs):
@@ -111,6 +112,7 @@ class TestPdbxFile(unittest.TestCase):
         self.assertAlmostEqualVec(parm.topology.getPeriodicBoxVectors()[2],
                                   pdb.topology.getPeriodicBoxVectors()[2],
                                   places=5)
+        del sim
         os.unlink('test.cif')
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes filesystem issues in 3 tests for windows, all related to closing files before deleting them or not having the same file simultaneously opened in both read and write mode.