### PR TITLE
Ensure neighbor list is large enough on first step

### DIFF
--- a/platforms/cuda/include/CudaNonbondedUtilities.h
+++ b/platforms/cuda/include/CudaNonbondedUtilities.h
@@ -142,8 +142,10 @@ public:
     void computeInteractions(int forceGroups);
     /**
      * Check to see if the neighbor list arrays are large enough, and make them bigger if necessary.
+     *
+     * @return true if the neighbor list needed to be enlarged.
      */
-    void updateNeighborListSize();
+    bool updateNeighborListSize();
     /**
      * Get the array containing the center of each atom block.
      */

--- a/platforms/opencl/include/OpenCLNonbondedUtilities.h
+++ b/platforms/opencl/include/OpenCLNonbondedUtilities.h
@@ -154,8 +154,10 @@ public:
     void computeInteractions(int forceGroups);
     /**
      * Check to see if the neighbor list arrays are large enough, and make them bigger if necessary.
+     *
+     * @return true if the neighbor list needed to be enlarged.
      */
-    void updateNeighborListSize();
+    bool updateNeighborListSize();
     /**
      * Get the array containing the center of each atom block.
      */


### PR DESCRIPTION
This is a workaround for simulating large systems on Windows.  If any kernel takes longer than 2 seconds, the OS resets the driver.  That was sometimes happening because there wouldn't initially be enough space for the neighbor list, so it would fall back to the O(n^2) algorithm for the first step.