### PR TITLE
Workaround for bug in CUDA 7.5

### DIFF
--- a/plugins/amoeba/platforms/cuda/src/kernels/multipoleFixedField.cu
+++ b/plugins/amoeba/platforms/cuda/src/kernels/multipoleFixedField.cu
@@ -545,6 +545,9 @@ extern "C" __global__ void computeFixedField(
                     localData[tbx+tj].field += fields[2];
                     localData[tbx+tj].fieldPolar += fields[3];
 #ifdef USE_GK
+                }
+                if (atom1 < NUM_ATOMS && atom2 < NUM_ATOMS) {
+                    real3 fields[2];
                     computeOneGkInteraction(data, localData[tbx+tj], delta, fields);
                     data.gkField += fields[0];
                     localData[tbx+tj].gkField += fields[1];
@@ -684,6 +687,9 @@ extern "C" __global__ void computeFixedField(
                     localData[tbx+tj].field += fields[2];
                     localData[tbx+tj].fieldPolar += fields[3];
 #ifdef USE_GK
+                }
+                if (atom1 < NUM_ATOMS && atom2 < NUM_ATOMS) {
+                    real3 fields[2];
                     computeOneGkInteraction(data, localData[tbx+tj], delta, fields);
                     data.gkField += fields[0];
                     localData[tbx+tj].gkField += fields[1];


### PR DESCRIPTION
CUDA 7.5 seems to have introduced a bug that was causing AMOEBA GK to crash.  After a lot of experimenting, I came up with this change which makes the error go away.  No idea what the root problem is, though I'm pretty sure it's something in the compiler.