### PR TITLE
Fix units of returned dipoles and quadrupoles from AmoebaMultipoleForce.

### DIFF
--- a/wrappers/python/src/swig_doxygen/swigInputConfig.py
+++ b/wrappers/python/src/swig_doxygen/swigInputConfig.py
@@ -256,8 +256,8 @@ UNITS = {
 #    void getCovalentMap(int index, CovalentType typeId, std::vector<int>& covalentAtoms )
 #    void getCovalentMaps(int index, std::vector < std::vector<int> >& covalentLists )
 
-("AmoebaMultipoleForce",                 "getMultipoleParameters")                        :  ( None, ('unit.elementary_charge', 'unit.elementary_charge/unit.nanometer',
-                                                                                                      'unit.elementary_charge/unit.nanometer**2', None, None, None, None, None, None,
+("AmoebaMultipoleForce",                 "getMultipoleParameters")                        :  ( None, ('unit.elementary_charge', 'unit.elementary_charge*unit.nanometer',
+                                                                                                      'unit.elementary_charge*unit.nanometer**2', None, None, None, None, None, None,
                                                                                                       'unit.nanometer**3')),
 ("AmoebaMultipoleForce",                 "getCovalentMap")                                :  ( None, ()),
 ("AmoebaMultipoleForce",                 "getCovalentMaps")                               :  ( None, ()),

--- a/wrappers/python/tests/TestAPIUnits.py
+++ b/wrappers/python/tests/TestAPIUnits.py
@@ -1074,8 +1074,8 @@ class TestAPIUnits(unittest.TestCase):
 
         force.addMultipole(1.0, [0.5, 0, -0.5], list(range(9)),
                 AmoebaMultipoleForce.ZThenX, 1, 2, 3, 0.5, 0.5, 1.0)
-        force.addMultipole(1.0*elementary_charge, [0.5, 0, -0.5]*elementary_charge/angstrom,
-                list(range(9))*elementary_charge/angstrom**2,
+        force.addMultipole(1.0*elementary_charge, [0.5, 0, -0.5]*elementary_charge*angstrom,
+                list(range(9))*elementary_charge*angstrom**2,
                 AmoebaMultipoleForce.Bisector, 2, 3, 4, 0.5, 0.5, 1.0*angstrom**3)
 
         self.assertEqual(force.getNumMultipoles(), 2)
@@ -1083,8 +1083,8 @@ class TestAPIUnits(unittest.TestCase):
         q, mu, quad, ax, i, j, k, thole, damp, polarity = force.getMultipoleParameters(0)
 
         self.assertEqual(q, 1.0*elementary_charge)
-        self.assertEqual(mu, (0.5, 0, -0.5)*elementary_charge/nanometer)
-        self.assertEqual(quad, tuple(range(9))*elementary_charge/nanometer**2)
+        self.assertEqual(mu, (0.5, 0, -0.5)*elementary_charge*nanometer)
+        self.assertEqual(quad, tuple(range(9))*elementary_charge*nanometer**2)
         self.assertEqual(ax, AmoebaMultipoleForce.ZThenX)
         self.assertEqual(i, 1)
         self.assertEqual(j, 2)
@@ -1096,8 +1096,8 @@ class TestAPIUnits(unittest.TestCase):
         q, mu, quad, ax, i, j, k, thole, damp, polarity = force.getMultipoleParameters(1)
 
         self.assertEqual(q, 1.0*elementary_charge)
-        self.assertEqual(mu, (0.5, 0, -0.5)*elementary_charge/angstrom)
-        self.assertAlmostEqualUnitArray(quad, tuple(range(9))*elementary_charge/angstrom**2)
+        self.assertEqual(mu, (0.5, 0, -0.5)*elementary_charge*angstrom)
+        self.assertAlmostEqualUnitArray(quad, tuple(range(9))*elementary_charge*angstrom**2)
         self.assertEqual(ax, AmoebaMultipoleForce.Bisector)
         self.assertEqual(i, 2)
         self.assertEqual(j, 3)


### PR DESCRIPTION
Now that I have my head on straight, that is.

For some reason I was dividing by length instead of multiplying by it.  These are the correct units.  Not sure what I was doing originally.