### PR TITLE
Add OpenCL on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: python
-python:
-  - "2.7_with_system_site_packages"
-  - "3.4"
 
-sudo: false
 addons:
   apt:
     sources:
@@ -16,15 +12,24 @@ addons:
       - python-numpy
       - python-scipy
 
-
-env:
-  matrix:
-    - OPENMM_BUILD_STATIC_LIB="OFF"
-    - OPENMM_BUILD_STATIC_LIB="ON"
+matrix:
+  include:
+    - sudo: required
+      python: 3.4
+      env: SUDO=true OPENMM_BUILD_STATIC_LIB=OFF CC=gcc CXX=g++
+    - sudo: false
+      python: 2.7_with_system_site_packages
+      env: SUDO=false OPENMM_BUILD_STATIC_LIB=ON CC=clang CXX=clang++
+    - sudo: false
+      python: 2.7_with_system_site_packages
+      env: SUDO=false OPENMM_BUILD_STATIC_LIB=OFF CC=clang CXX=clang++
+    - sudo: false
+      python: 3.4
+      env: SUDO=false OPENMM_BUILD_STATIC_LIB=OFF CC=gcc CXX=g++
 
 before_install:
-  - export CC=clang
-  - export CXX=clang++
+  - echo $SUDO
+  - if [[ "$SUDO" == "true" ]]; then sudo apt-get install -qq fglrx=2:8.960-0ubuntu1 opencl-headers; fi
 
   - wget https://anaconda.org/anaconda/swig/3.0.2/download/linux-64/swig-3.0.2-0.tar.bz2
   - mkdir $HOME/swig
@@ -34,7 +39,6 @@ before_install:
 
 script:
   - cmake -DCMAKE_INSTALL_PREFIX=$HOME/OpenMM -DOPENMM_BUILD_STATIC_LIB=$OPENMM_BUILD_STATIC_LIB .
-  - make -j2
   - make -j2 install
   - make PythonInstall
   - # Run the testInstallation script
@@ -46,7 +50,7 @@ script:
   - # rerun all of the failed tests
   - if [ -s Testing/Temporary/LastTestsFailed.log ]; then ctest -I FailedTests.log; fi;
   - # run the python tests too
-  - cd python/tests  
+  - cd python/tests
   - # nosetests -vv --processes=-1 --process-timeout=200
   - # nosetests -vv
   - py.test -v *

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_install:
   - export SWIG_LIB=$HOME/swig/share/swig/3.0.2
 
 script:
-  - CTEST_STOP_TIME=$(python -c "from datetime import datetime, timedelta; import sys; sys.stdout.write((datetime.now() + timedelta(minutes=40)).strftime('%H:%M:%S'))")
+  - CTEST_STOP_TIME=$(python -c "from datetime import datetime, timedelta; import sys; sys.stdout.write((datetime.now() + timedelta(minutes=30)).strftime('%H:%M:%S'))")
   - cmake -DCMAKE_INSTALL_PREFIX=$HOME/OpenMM -DOPENMM_BUILD_STATIC_LIB=$OPENMM_BUILD_STATIC_LIB .
   - make -j2 install
   - make PythonInstall

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ script:
   - CTEST_STOP_TIME=$(python -c "from datetime import datetime, timedelta; import sys; sys.stdout.write((datetime.now() + timedelta(minutes=30)).strftime('%H:%M:%S'))")
   - cmake -DCMAKE_INSTALL_PREFIX=$HOME/OpenMM -DOPENMM_BUILD_STATIC_LIB=$OPENMM_BUILD_STATIC_LIB .
   - make -j2 install
+  - if [[ "$SUDO" == "true" ]]; then ./TestOpenCLDeviceQuery; fi
   - make PythonInstall
   - # Run the testInstallation script
   - python -m simtk.testInstallation

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_install:
   - export SWIG_LIB=$HOME/swig/share/swig/3.0.2
 
 script:
-  - CTEST_STOP_TIME=$(python -c "from datetime import datetime, timedelta; import sys; sys.stdout.write((datetime.now() + timedelta(minutes=30)).strftime('%H:%M:%S'))")
+  - CTEST_STOP_TIME=$(python -c "from datetime import datetime, timedelta; import sys; sys.stdout.write((datetime.now() + timedelta(minutes=40)).strftime('%H:%M:%S'))")
   - cmake -DCMAKE_INSTALL_PREFIX=$HOME/OpenMM -DOPENMM_BUILD_STATIC_LIB=$OPENMM_BUILD_STATIC_LIB .
   - make -j2 install
   - make PythonInstall

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ matrix:
     - sudo: false
       python: 3.4
       env: SUDO=false OPENMM_BUILD_STATIC_LIB=OFF CC=gcc CXX=g++
+  allow_failures:
+   - sudo: required
 
 before_install:
   - echo $SUDO
@@ -44,7 +46,7 @@ script:
   - # Run the testInstallation script
   - python -m simtk.testInstallation
   - # run all of the tests, making sure failures at this stage don't cause travis failures
-  - ctest -j2 || true
+  - ctest -j2 --schedule-random || true
   - # get a list of all of the failed tests into this stupid ctest format
   - python -c "import os; fn = os.path.join('Testing', 'Temporary', 'LastTestsFailed.log'); os.path.exists(fn) or exit(0); failed = [line.split(':')[0] for line in open(fn)]; print(','.join(x+','+x for x in failed))" > FailedTests.log
   - # rerun all of the failed tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,13 +40,14 @@ before_install:
   - export SWIG_LIB=$HOME/swig/share/swig/3.0.2
 
 script:
+  - CTEST_STOP_TIME=$(python -c "from datetime import datetime, timedelta; import sys; sys.stdout.write((datetime.now() + timedelta(minutes=30)).strftime('%H:%M:%S'))")
   - cmake -DCMAKE_INSTALL_PREFIX=$HOME/OpenMM -DOPENMM_BUILD_STATIC_LIB=$OPENMM_BUILD_STATIC_LIB .
   - make -j2 install
   - make PythonInstall
   - # Run the testInstallation script
   - python -m simtk.testInstallation
   - # run all of the tests, making sure failures at this stage don't cause travis failures
-  - ctest -j2 --schedule-random || true
+  - ctest -j2 --schedule-random --stop-time $CTEST_STOP_TIME || true
   - # get a list of all of the failed tests into this stupid ctest format
   - python -c "import os; fn = os.path.join('Testing', 'Temporary', 'LastTestsFailed.log'); os.path.exists(fn) or exit(0); failed = [line.split(':')[0] for line in open(fn)]; print(','.join(x+','+x for x in failed))" > FailedTests.log
   - # rerun all of the failed tests

--- a/platforms/cuda/src/CudaContext.cpp
+++ b/platforms/cuda/src/CudaContext.cpp
@@ -149,7 +149,7 @@ CudaContext::CudaContext(const System& system, int deviceIndex, bool useBlocking
     if (this->deviceIndex == -1)
         throw OpenMMException("No compatible CUDA device is available");
 
-    int major, minor
+    int major, minor;
     CHECK_RESULT(cuDeviceComputeCapability(&major, &minor, device));
 #if __CUDA_API_VERSION < 7000
         // This is a workaround to support GTX 980 with CUDA 6.5.  It reports

--- a/platforms/opencl/tests/TestOpenCLDeviceQuery.cpp
+++ b/platforms/opencl/tests/TestOpenCLDeviceQuery.cpp
@@ -30,7 +30,7 @@ int main() {
            << "\"" << endl << "    " << left << setw(32) << "CL_PLATFORM_NAME" << " = "
            << cl::Platform(d.getInfo<CL_DEVICE_PLATFORM>()).getInfo<CL_PLATFORM_NAME>()
            << endl
-           << "    " << left << setw(32) << "CL_PLATFORM_NAME" << " = "
+           << "    " << left << setw(32) << "CL_PLATFORM_VENDOR" << " = "
            << platforms[j].getInfo<CL_PLATFORM_VENDOR>()
            << endl;
 

--- a/platforms/opencl/tests/TestOpenCLDeviceQuery.cpp
+++ b/platforms/opencl/tests/TestOpenCLDeviceQuery.cpp
@@ -2,7 +2,7 @@
  * This file is adapted from vexcl's (https://github.com/ddemidov/vexcl)
  * example "devlist.cpp", which is
  *
- *  Copyright (c) 2012-2014 Denis Demidov <dennis.demidov@gmail.com>
+ * Copyright (c) 2012-2014 Denis Demidov <dennis.demidov@gmail.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,7 +22,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-                    
+
 #include <iostream>
 #include <iomanip>
 #include <sstream>
@@ -48,7 +48,7 @@ int main() {
   for (int j = 0; j < platforms.size(); j++) {
     vector<cl::Device> devices;
     platforms[j].getDevices(CL_DEVICE_TYPE_ALL, &devices);
-    
+
     for (int i = 0; i < devices.size(); i++) {
       cl::Device d = devices[i];
       cout << "OpenCLPlatformIndex " << j << ", OpenCLDeviceIndex " << i << ": \"" << d.getInfo<CL_DEVICE_NAME>()
@@ -61,13 +61,54 @@ int main() {
 
       SHOW_DEVPROP(CL_DEVICE_VENDOR);
       SHOW_DEVPROP(CL_DEVICE_VERSION);
+      cout << "    " << left << setw(32) << "CL_DEVICE_TYPE" << " = ";
+      if (d.getInfo<CL_DEVICE_TYPE>() == CL_DEVICE_TYPE_CPU) {
+	  cout << "CL_DEVICE_TYPE_CPU" << endl;
+      } else if (d.getInfo<CL_DEVICE_TYPE>() == CL_DEVICE_TYPE_GPU) {
+	  cout << "CL_DEVICE_TYPE_GPU" << endl;
+      } else if (d.getInfo<CL_DEVICE_TYPE>() == CL_DEVICE_TYPE_ACCELERATOR) {
+	  cout << "CL_DEVICE_TYPE_ACCELERATOR" << endl;
+      } else {
+	  cout << "Unknown" << endl;
+      }
+
+
       SHOW_DEVPROP(CL_DEVICE_MAX_COMPUTE_UNITS);
+      cout << "    " << left << setw(32) << "CL_DEVICE_MAX_WORK_ITEM_SIZES" << " = [";
+      for (int k = 0; k < d.getInfo<CL_DEVICE_MAX_WORK_ITEM_SIZES>().size(); k++) {
+	  cout << d.getInfo<CL_DEVICE_MAX_WORK_ITEM_SIZES>()[k];
+	  if (k < d.getInfo<CL_DEVICE_MAX_WORK_ITEM_SIZES>().size() - 1)
+	      cout << ", ";
+      }
+      cout << "]" << endl;
+
       SHOW_DEVPROP(CL_DEVICE_HOST_UNIFIED_MEMORY);
       SHOW_DEVPROP(CL_DEVICE_GLOBAL_MEM_SIZE);
       SHOW_DEVPROP(CL_DEVICE_LOCAL_MEM_SIZE);
       SHOW_DEVPROP(CL_DEVICE_MAX_MEM_ALLOC_SIZE);
       SHOW_DEVPROP(CL_DEVICE_ADDRESS_BITS);
       SHOW_DEVPROP(CL_DEVICE_MAX_CLOCK_FREQUENCY);
+
+      int processingElementsPerComputeUnit;
+      if (d.getInfo<CL_DEVICE_TYPE>() != CL_DEVICE_TYPE_GPU) {
+	  processingElementsPerComputeUnit = 1;
+      } else if  (d.getInfo<CL_DEVICE_EXTENSIONS>().find("cl_nv_device_attribute_query") != string::npos) {
+	  cl_uint computeCapabilityMajor;
+	  clGetDeviceInfo(d(), CL_DEVICE_COMPUTE_CAPABILITY_MAJOR_NV, sizeof(cl_uint), &computeCapabilityMajor, NULL);
+	  processingElementsPerComputeUnit = (computeCapabilityMajor < 2 ? 8 : 32);
+      } else if (d.getInfo<CL_DEVICE_EXTENSIONS>().find("cl_amd_device_attribute_query") != string::npos) {
+
+	  try {
+	      processingElementsPerComputeUnit = d.getInfo<CL_DEVICE_SIMD_PER_COMPUTE_UNIT_AMD>() *
+		  d.getInfo<CL_DEVICE_SIMD_WIDTH_AMD>() *
+		  d.getInfo<CL_DEVICE_SIMD_INSTRUCTION_WIDTH_AMD>();
+	  } catch (cl::Error err) {}
+      }
+      cout << "    processingElementsPerComputeUnit" << " = " << processingElementsPerComputeUnit << endl;
+      int speed = devices[i].getInfo<CL_DEVICE_MAX_COMPUTE_UNITS>()*processingElementsPerComputeUnit*d.getInfo<CL_DEVICE_MAX_CLOCK_FREQUENCY>();
+      cout << "    estimatedSpeed                   = " << speed << endl;
+
+
       cout << "    " << left << setw(32) << "CL_DEVICE_EXTENSIONS" << " = ";
       {
         istringstream iss(d.getInfo<CL_DEVICE_EXTENSIONS>());
@@ -76,7 +117,7 @@ int main() {
         extensions.insert(istream_iterator<string>(iss), istream_iterator<string>());
         size_t w = 40;
         for (set<string>::iterator s = extensions.begin(); s != extensions.end(); ++s) {
-               
+
           w += s->length() + 1;
           if (w > 80) {
             cout << endl << setw(w = 8) << "";

--- a/platforms/opencl/tests/TestOpenCLDeviceQuery.cpp
+++ b/platforms/opencl/tests/TestOpenCLDeviceQuery.cpp
@@ -1,3 +1,28 @@
+/**
+ * This file is adapted from vexcl's (https://github.com/ddemidov/vexcl)
+ * example "devlist.cpp", which is
+ *
+ *  Copyright (c) 2012-2014 Denis Demidov <dennis.demidov@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+                    
 #include <iostream>
 #include <iomanip>
 #include <sstream>

--- a/platforms/opencl/tests/TestOpenCLDeviceQuery.cpp
+++ b/platforms/opencl/tests/TestOpenCLDeviceQuery.cpp
@@ -51,7 +51,7 @@ int main() {
     
     for (int i = 0; i < devices.size(); i++) {
       cl::Device d = devices[i];
-      cout << "OpenCL Platform " << j << ", Device " << i << ": \"" << d.getInfo<CL_DEVICE_NAME>()
+      cout << "OpenCLPlatformIndex " << j << ", OpenCLDeviceIndex " << i << ": \"" << d.getInfo<CL_DEVICE_NAME>()
            << "\"" << endl << "    " << left << setw(32) << "CL_PLATFORM_NAME" << " = "
            << cl::Platform(d.getInfo<CL_DEVICE_PLATFORM>()).getInfo<CL_PLATFORM_NAME>()
            << endl

--- a/platforms/opencl/tests/TestOpenCLDeviceQuery.cpp
+++ b/platforms/opencl/tests/TestOpenCLDeviceQuery.cpp
@@ -1,0 +1,66 @@
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+#include <iterator>
+#include <set>
+#include <algorithm>
+#include <vector>
+
+#include "OpenCLContext.h"
+
+using namespace std;
+
+#define SHOW_DEVPROP(name)                               \
+    cout << "    " << left << setw(32) << #name << " = " \
+         << d.getInfo< name >() << endl
+
+
+int main() {
+  std::vector<cl::Platform> platforms;
+  cl::Platform::get(&platforms);
+  cout << "OpenCL devices:" << endl << endl;
+
+  for (int j = 0; j < platforms.size(); j++) {
+    vector<cl::Device> devices;
+    platforms[j].getDevices(CL_DEVICE_TYPE_ALL, &devices);
+    
+    for (int i = 0; i < devices.size(); i++) {
+      cl::Device d = devices[i];
+      cout << "OpenCL Platform " << j << ", Device " << i << ": \"" << d.getInfo<CL_DEVICE_NAME>()
+           << "\"" << endl << "    " << left << setw(32) << "CL_PLATFORM_NAME" << " = "
+           << cl::Platform(d.getInfo<CL_DEVICE_PLATFORM>()).getInfo<CL_PLATFORM_NAME>()
+           << endl
+           << "    " << left << setw(32) << "CL_PLATFORM_NAME" << " = "
+           << platforms[j].getInfo<CL_PLATFORM_VENDOR>()
+           << endl;
+
+      SHOW_DEVPROP(CL_DEVICE_VENDOR);
+      SHOW_DEVPROP(CL_DEVICE_VERSION);
+      SHOW_DEVPROP(CL_DEVICE_MAX_COMPUTE_UNITS);
+      SHOW_DEVPROP(CL_DEVICE_HOST_UNIFIED_MEMORY);
+      SHOW_DEVPROP(CL_DEVICE_GLOBAL_MEM_SIZE);
+      SHOW_DEVPROP(CL_DEVICE_LOCAL_MEM_SIZE);
+      SHOW_DEVPROP(CL_DEVICE_MAX_MEM_ALLOC_SIZE);
+      SHOW_DEVPROP(CL_DEVICE_ADDRESS_BITS);
+      SHOW_DEVPROP(CL_DEVICE_MAX_CLOCK_FREQUENCY);
+      cout << "    " << left << setw(32) << "CL_DEVICE_EXTENSIONS" << " = ";
+      {
+        istringstream iss(d.getInfo<CL_DEVICE_EXTENSIONS>());
+        set<string> extensions;
+
+        extensions.insert(istream_iterator<string>(iss), istream_iterator<string>());
+        size_t w = 40;
+        for (set<string>::iterator s = extensions.begin(); s != extensions.end(); ++s) {
+               
+          w += s->length() + 1;
+          if (w > 80) {
+            cout << endl << setw(w = 8) << "";
+            w += s->length() + 1;
+          }
+          cout << *s << " ";
+        }
+      }
+      cout << endl << endl;
+    }
+  }
+}


### PR DESCRIPTION
With the OpenCL tests running on Travis, the test suite takes longer than 50 minutes (the timeout), so I changed the `ctest` invocation to run the tests in a random order with a ~~30~~ 40 minute timeout. Across multiple invocations, hopefully this will get reasonable coverage.