### PR TITLE
Fix thread synchronization in customCentroidBond.cl

### DIFF
--- a/platforms/opencl/src/kernels/customCentroidBond.cl
+++ b/platforms/opencl/src/kernels/customCentroidBond.cl
@@ -8,7 +8,7 @@ __kernel void computeGroupCenters(__global const real4* restrict posq, __global 
     __local volatile real3 temp[64];
     for (int group = get_group_id(0); group < NUM_GROUPS; group += get_num_groups(0)) {
         // The threads in this block work together to compute the center one group.
-        
+
         int firstIndex = groupOffsets[group];
         int lastIndex = groupOffsets[group+1];
         real3 center = (real3) 0;
@@ -20,44 +20,48 @@ __kernel void computeGroupCenters(__global const real4* restrict posq, __global 
             center.y += weight*pos.y;
             center.z += weight*pos.z;
         }
-        
+
         // Sum the values.
-        
+
         int thread = get_local_id(0);
         temp[thread].x = center.x;
         temp[thread].y = center.y;
         temp[thread].z = center.z;
+
         barrier(CLK_LOCAL_MEM_FENCE);
         if (thread < 32) {
             temp[thread].x += temp[thread+32].x;
             temp[thread].y += temp[thread+32].y;
             temp[thread].z += temp[thread+32].z;
-            SYNC_WARPS;
-            if (thread < 16) {
-                temp[thread].x += temp[thread+16].x;
-                temp[thread].y += temp[thread+16].y;
-                temp[thread].z += temp[thread+16].z;
-                SYNC_WARPS;
-            }
-            if (thread < 8) {
-                temp[thread].x += temp[thread+8].x;
-                temp[thread].y += temp[thread+8].y;
-                temp[thread].z += temp[thread+8].z;
-                SYNC_WARPS;
-            }
-            if (thread < 4) {
-                temp[thread].x += temp[thread+4].x;
-                temp[thread].y += temp[thread+4].y;
-                temp[thread].z += temp[thread+4].z;
-                SYNC_WARPS;
-            }
-            if (thread < 2) {
-                temp[thread].x += temp[thread+2].x;
-                temp[thread].y += temp[thread+2].y;
-                temp[thread].z += temp[thread+2].z;
-                SYNC_WARPS;
-            }
         }
+
+        SYNC_WARPS;
+        if (thread < 16) {
+            temp[thread].x += temp[thread+16].x;
+            temp[thread].y += temp[thread+16].y;
+            temp[thread].z += temp[thread+16].z;
+        }
+        SYNC_WARPS;
+        if (thread < 8) {
+            temp[thread].x += temp[thread+8].x;
+            temp[thread].y += temp[thread+8].y;
+            temp[thread].z += temp[thread+8].z;
+        }
+
+        SYNC_WARPS;
+        if (thread < 4) {
+            temp[thread].x += temp[thread+4].x;
+            temp[thread].y += temp[thread+4].y;
+            temp[thread].z += temp[thread+4].z;
+        }
+        SYNC_WARPS;
+        if (thread < 2) {
+            temp[thread].x += temp[thread+2].x;
+            temp[thread].y += temp[thread+2].y;
+            temp[thread].z += temp[thread+2].z;
+        }
+
+        SYNC_WARPS;
         if (thread == 0)
             centerPositions[group] = (real4) (temp[0].x+temp[1].x, temp[0].y+temp[1].y, temp[0].z+temp[1].z, 0);
     }


### PR DESCRIPTION
This fixes the `TestOpenCLCustomCentroidBondForce` failures on the CPU OpenCL device I reported in https://github.com/pandegroup/openmm/pull/1208#issuecomment-150995439

Based on my undersanding of the [spec](https://www.khronos.org/registry/cl/sdk/1.0/docs/man/xhtml/barrier.html), and [some forum answers](https://software.intel.com/en-us/forums/opencl/topic/413956), the SYNC_WARPS barrier can't be in a conditional that's hit by only a subset of the threads.
