### PR TITLE
Fix #1213 addInteractionGroup should accept `set` values as parameters

### DIFF
--- a/wrappers/python/src/swig_doxygen/swigInputConfig.py
+++ b/wrappers/python/src/swig_doxygen/swigInputConfig.py
@@ -144,6 +144,12 @@ STEAL_OWNERSHIP = {("Platform", "registerPlatform") : [0],
                    ("CompoundIntegrator", "addIntegrator") : [0],
 }
 
+
+REQUIRE_ORDERED_SET = {("CustomNonbondedForce", "addInteractionGroup") : [0, 1],
+                       ("CustomNonbondedForce", "setInteractionGroupParameters") : [1, 2],
+}
+
+
 # This is a list of units to attach to return values and method args.
 # Indexed by (ClassName, MethodsName)
 UNITS = {


### PR DESCRIPTION
apparently SWIG typemaps maps Python's list but not set with std::set. Instead, Python's `set` is mapped with `std::unordered_set`.

The original code of `swigInputBuilder.py` is kindly in a mess. Too much lines in a single method `writeMethods` which causes debug becomes difficult. Also there are a lot of warnings about [PEP8](https://www.python.org/dev/peps/pep-0008/).

A refactoring in the future may be a good idea. :)