### PR TITLE
Add CONECT bonds for multi-model pdb files 

### DIFF
--- a/wrappers/python/simtk/openmm/app/pdbfile.py
+++ b/wrappers/python/simtk/openmm/app/pdbfile.py
@@ -154,7 +154,7 @@ class PDBFile(object):
         # Add bonds based on CONECT records.
 
         connectBonds = []
-        for connect in pdb.models[0].connects:
+        for connect in pdb.models[-1].connects:
             i = connect[0]
             for j in connect[1:]:
                 if i in atomByNumber and j in atomByNumber:


### PR DESCRIPTION
Same thing as: https://github.com/mdtraj/mdtraj/issues/977 https://github.com/mdtraj/mdtraj/pull/980 - pdbfile reads CONECT bonds from the first model currently, however due to CONECT being at the end of the file `PDBStructure` only reads CONECT data into the last model. 

I have 3 `nosetests` errors/fails locally:
```
======================================================================
ERROR: Tests the switching function option in AmberPrmtopFile
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/rafalpwiewiora/repos/openmm/wrappers/python/tests/TestAmberPrmtopFile.py", line 303, in testSwitchFunction
    switchDistance=0.8*nanometer)
TypeError: createSystem() got an unexpected keyword argument 'switchDistance'

======================================================================
FAIL: Test adding extra particles defined by virtual sites.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/rafalpwiewiora/repos/openmm/wrappers/python/tests/TestModeller.py", line 986, in test_addVirtualSites
    self.assertVecAlmostEqual(p1.value_in_unit(nanometers), p2.value_in_unit(nanometers), 1e-6)
  File "/Users/rafalpwiewiora/repos/openmm/wrappers/python/tests/TestModeller.py", line 1059, in assertVecAlmostEqual
    self.assertTrue(diff < tol)
AssertionError: False is not true

======================================================================
FAIL: Test adding extra particles whose positions are determined based on bonds.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/rafalpwiewiora/repos/openmm/wrappers/python/tests/TestModeller.py", line 1053, in test_multiSiteIon
    self.assertTrue(dist > (expectedDist-0.01)*nanometers and dist < (expectedDist+0.01)*nanometers)
AssertionError: False is not true

----------------------------------------------------------------------
```

but unrelated to the change. 