### PR TITLE
PDBFile - change behavior of connectivity to metals to that of PDBxFile

### DIFF
--- a/wrappers/python/simtk/openmm/app/pdbfile.py
+++ b/wrappers/python/simtk/openmm/app/pdbfile.py
@@ -71,7 +71,7 @@ class PDBFile(object):
         """
         
         metalElements = ['Al','As','Ba','Ca','Cd','Ce','Co','Cs','Cu','Dy','Fe','Gd','Hg','Ho','In','Ir','K','Li','Mg',
-        'Mn','Mo','Na','Ni','Pb','Pd','Pt','Rb','Rh','Ru','Sm','Sr','Te','Tl','V','W','Yb','Zn']
+        'Mn','Mo','Na','Ni','Pb','Pd','Pt','Rb','Rh','Sm','Sr','Te','Tl','V','W','Yb','Zn']
         
         top = Topology()
         ## The Topology read from the PDB file

--- a/wrappers/python/simtk/openmm/app/pdbfile.py
+++ b/wrappers/python/simtk/openmm/app/pdbfile.py
@@ -73,6 +73,10 @@ class PDBFile(object):
         metalElements = ['Al','As','Ba','Ca','Cd','Ce','Co','Cs','Cu','Dy','Fe','Gd','Hg','Ho','In','Ir','K','Li','Mg',
         'Mn','Mo','Na','Ni','Pb','Pd','Pt','Rb','Rh','Sm','Sr','Te','Tl','V','W','Yb','Zn']
         
+        standardResidues = ['ALA', 'ASN', 'CYS', 'GLU', 'HIS', 'LEU', 'MET', 'PRO', 'THR', 'TYR',
+                            'ARG', 'ASP', 'GLN', 'GLY', 'ILE', 'LYS', 'PHE', 'SER', 'TRP', 'VAL',
+                            'A', 'G', 'C', 'U', 'I', 'DA', 'DG', 'DC', 'DT', 'DI', 'HOH']
+
         top = Topology()
         ## The Topology read from the PDB file
         self.topology = top
@@ -155,7 +159,7 @@ class PDBFile(object):
         self.topology.createDisulfideBonds(self.positions)
         self._numpyPositions = None
 
-        # Add bonds based on CONECT records. Bonds between metals of element specified in metalElements and standard residues are not added. 
+        # Add bonds based on CONECT records. Bonds between metals of elements specified in metalElements and residues in standardResidues are not added.
 
         connectBonds = []
         for connect in pdb.models[-1].connects:
@@ -165,9 +169,9 @@ class PDBFile(object):
                     if atomByNumber[i].element is not None and atomByNumber[j].element is not None:
                         if atomByNumber[i].element.symbol not in metalElements and atomByNumber[j].element.symbol not in metalElements:
                             connectBonds.append((atomByNumber[i], atomByNumber[j])) 
-                        elif atomByNumber[i].element.symbol in metalElements and atomByNumber[j].residue.name not in top._standardBonds:
+                        elif atomByNumber[i].element.symbol in metalElements and atomByNumber[j].residue.name not in standardResidues:
                             connectBonds.append((atomByNumber[i], atomByNumber[j])) 
-                        elif atomByNumber[j].element.symbol in metalElements and atomByNumber[i].residue.name not in top._standardBonds:
+                        elif atomByNumber[j].element.symbol in metalElements and atomByNumber[i].residue.name not in standardResidues:
                             connectBonds.append((atomByNumber[i], atomByNumber[j]))     
                     else:
                         connectBonds.append((atomByNumber[i], atomByNumber[j]))         

--- a/wrappers/python/simtk/openmm/app/pdbfile.py
+++ b/wrappers/python/simtk/openmm/app/pdbfile.py
@@ -162,7 +162,7 @@ class PDBFile(object):
             i = connect[0]
             for j in connect[1:]:
                 if i in atomByNumber and j in atomByNumber:
-                    if atomByNumber[i].element != None and atomByNumber[j].element != None:
+                    if atomByNumber[i].element is not None and atomByNumber[j].element is not None:
                         if atomByNumber[i].element.symbol in metalElements or atomByNumber[j].element.symbol in metalElements:
                             if atomByNumber[i].residue == atomByNumber[j].residue:
                                 connectBonds.append((atomByNumber[i], atomByNumber[j])) 

--- a/wrappers/python/simtk/openmm/app/pdbfile.py
+++ b/wrappers/python/simtk/openmm/app/pdbfile.py
@@ -59,7 +59,7 @@ class PDBFile(object):
     _residueNameReplacements = {}
     _atomNameReplacements = {}
 
-    def __init__(self, file):
+    def __init__(self, file, removeBondsToMetals=False):
         """Load a PDB file.
 
         The atom positions and Topology can be retrieved by calling getPositions() and getTopology().
@@ -68,6 +68,9 @@ class PDBFile(object):
         ----------
         file : string
             the name of the file to load
+        removeBondsToMetals : bool
+            if True, those inter-residue CONECT bonds that indicate coordination to metals 
+            (cf. metalc connectivity in mmCIF/PDBx) are not added to the topology
         """
         
         metalElements = ['Al','As','Ba','Ca','Cd','Ce','Co','Cs','Cu','Dy','Fe','Gd','Hg','Ho','In','Ir','K','Li','Mg',
@@ -161,7 +164,9 @@ class PDBFile(object):
         for connect in pdb.models[-1].connects:
             i = connect[0]
             for j in connect[1:]:
-                if i in atomByNumber and j in atomByNumber:
+                if i in atomByNumber and j in atomByNumber and not removeBondsToMetals:
+                    connectBonds.append((atomByNumber[i], atomByNumber[j]))  
+                elif i in atomByNumber and j in atomByNumber and removeBondsToMetals:    
                     if atomByNumber[i].element is not None and atomByNumber[j].element is not None:
                         if atomByNumber[i].element.symbol in metalElements or atomByNumber[j].element.symbol in metalElements:
                             if atomByNumber[i].residue == atomByNumber[j].residue:

--- a/wrappers/python/simtk/openmm/app/pdbfile.py
+++ b/wrappers/python/simtk/openmm/app/pdbfile.py
@@ -59,7 +59,7 @@ class PDBFile(object):
     _residueNameReplacements = {}
     _atomNameReplacements = {}
 
-    def __init__(self, file, removeBondsToMetals=False):
+    def __init__(self, file):
         """Load a PDB file.
 
         The atom positions and Topology can be retrieved by calling getPositions() and getTopology().
@@ -68,9 +68,6 @@ class PDBFile(object):
         ----------
         file : string
             the name of the file to load
-        removeBondsToMetals : bool
-            if True, those inter-residue CONECT bonds that indicate coordination to metals 
-            (cf. metalc connectivity in mmCIF/PDBx) are not added to the topology
         """
         
         metalElements = ['Al','As','Ba','Ca','Cd','Ce','Co','Cs','Cu','Dy','Fe','Gd','Hg','Ho','In','Ir','K','Li','Mg',
@@ -158,21 +155,20 @@ class PDBFile(object):
         self.topology.createDisulfideBonds(self.positions)
         self._numpyPositions = None
 
-        # Add bonds based on CONECT records.
+        # Add bonds based on CONECT records. Bonds between metals of element specified in metalElements and standard residues are not added. 
 
         connectBonds = []
         for connect in pdb.models[-1].connects:
             i = connect[0]
             for j in connect[1:]:
-                if i in atomByNumber and j in atomByNumber and not removeBondsToMetals:
-                    connectBonds.append((atomByNumber[i], atomByNumber[j]))  
-                elif i in atomByNumber and j in atomByNumber and removeBondsToMetals:    
+                if i in atomByNumber and j in atomByNumber:    
                     if atomByNumber[i].element is not None and atomByNumber[j].element is not None:
-                        if atomByNumber[i].element.symbol in metalElements or atomByNumber[j].element.symbol in metalElements:
-                            if atomByNumber[i].residue == atomByNumber[j].residue:
-                                connectBonds.append((atomByNumber[i], atomByNumber[j])) 
-                        else:
+                        if atomByNumber[i].element.symbol not in metalElements and atomByNumber[j].element.symbol not in metalElements:
                             connectBonds.append((atomByNumber[i], atomByNumber[j])) 
+                        elif atomByNumber[i].element.symbol in metalElements and atomByNumber[j].residue.name not in top._standardBonds:
+                            connectBonds.append((atomByNumber[i], atomByNumber[j])) 
+                        elif atomByNumber[j].element.symbol in metalElements and atomByNumber[i].residue.name not in top._standardBonds:
+                            connectBonds.append((atomByNumber[i], atomByNumber[j]))     
                     else:
                         connectBonds.append((atomByNumber[i], atomByNumber[j]))         
         if len(connectBonds) > 0:

--- a/wrappers/python/simtk/openmm/app/pdbfile.py
+++ b/wrappers/python/simtk/openmm/app/pdbfile.py
@@ -158,7 +158,7 @@ class PDBFile(object):
         self.topology.createDisulfideBonds(self.positions)
         self._numpyPositions = None
 
-        # Add bonds based on CONECT records. Bonds are not added for elements in metalElements, unless in the same residue. 
+        # Add bonds based on CONECT records.
 
         connectBonds = []
         for connect in pdb.models[-1].connects:

--- a/wrappers/python/simtk/openmm/app/pdbfile.py
+++ b/wrappers/python/simtk/openmm/app/pdbfile.py
@@ -69,6 +69,10 @@ class PDBFile(object):
         file : string
             the name of the file to load
         """
+        
+        metalElements = ['Al','As','Ba','Ca','Cd','Ce','Co','Cs','Cu','Dy','Fe','Gd','Hg','Ho','In','Ir','K','Li','Mg',
+        'Mn','Mo','Na','Ni','Pb','Pd','Pt','Rb','Rh','Ru','Sm','Sr','Te','Tl','V','W','Yb','Zn']
+        
         top = Topology()
         ## The Topology read from the PDB file
         self.topology = top
@@ -151,14 +155,21 @@ class PDBFile(object):
         self.topology.createDisulfideBonds(self.positions)
         self._numpyPositions = None
 
-        # Add bonds based on CONECT records.
+        # Add bonds based on CONECT records. Bonds are not added for elements in metalElements, unless in the same residue. 
 
         connectBonds = []
         for connect in pdb.models[-1].connects:
             i = connect[0]
             for j in connect[1:]:
                 if i in atomByNumber and j in atomByNumber:
-                    connectBonds.append((atomByNumber[i], atomByNumber[j]))
+                    if atomByNumber[i].element != None and atomByNumber[j].element != None:
+                        if atomByNumber[i].element.symbol in metalElements or atomByNumber[j].element.symbol in metalElements:
+                            if atomByNumber[i].residue == atomByNumber[j].residue:
+                                connectBonds.append((atomByNumber[i], atomByNumber[j])) 
+                        else:
+                            connectBonds.append((atomByNumber[i], atomByNumber[j])) 
+                    else:
+                        connectBonds.append((atomByNumber[i], atomByNumber[j]))         
         if len(connectBonds) > 0:
             # Only add bonds that don't already exist.
             existingBonds = set(top.bonds())


### PR DESCRIPTION
Here's the thinking:

1. I scanned the pdbx files of the PDB for all `metalc` bonds. 

2. By looking for bonds with atom.name == residue.name I identified large majority of the metals involved. 

3. Looking at the remaining bonds and checking what atom names started with, removing digits etc. a few further metals were identified. 

4. Wanting to change to coding conditions by element rather than names, I've scanned the whole PDB with both PDBFile and PDBxFile looking for atoms for which topology was returning element as None. Nicely and as you would expect, the only residues for which that happened were `{'ASX', 'GLX', 'UNK', 'UNL', 'UNX'}`. There will be no problems with missing elements. 

5. For final confirmation I had not missed any elements I looked at all elements found in `PDBxFile` topologies for files containing `metalc` sections - all metals were found ok. 

6. For all metal elements identified above, I checked over the PDB whether `PDBxFile` was returning any bonds (i.e. whether those elements were present in `covale` or `modres` sections). That did happen for some of the elements, and looking at the residues and atoms those bonds were to: there wasn't any cases where a rule could be developed for deciding whether the bond was `metalc` or `covale` / `modres` - i.e. same bond pairs are present in both categories. Not clear if this is PDB's mistakes or chemical knowledge was used manually, maybe both. To decide what to do with these I compared the total numbers of bonds these metals had in `metalc` vs `covale` / `modres`:

    metalc:

   ``` 
    {'AG': 52,
     'AU': 147,
     'BE': 123,
     'CR': 27,
     'EU': 212,
     'FE': 43179,
     'GA': 12,
     'HG': 4147,
     'LU': 44,
     'NA': 62969,
     'OS': 7,
     'PR': 89,
     'RE': 14,
     'RU': 75,
     'TB': 55}
   ```

    covale / modres:

   ```
    {'AG': 31,
     'AU': 38,
     'BE': 87,
     'CR': 28,
     'EU': 61,
     'FE': 5,
     'GA': 22,
     'HG': 2,
     'LU': 4,
     'NA': 1,
     'OS': 6,
     'PR': 69,
     'RE': 21,
     'RU': 91,
     'TB': 26}
   ```

    I decided - for Fe, Na, Hg - numbers clearly suggest the covale / modres entries are mistakes in the     pdbx files - keep in the list, for the others: numbers too similar, without having more understanding of these ions / models for them, better to keep the current PDBFile behavior. So:
    ```
['Ag', 'Au', 'Be', 'Cr', 'Eu', 'Ga', 'Lu', 'Os', 'Pr', 'Re', 'Ru', 'Tb']
    ```

    were removed from `metalElements`. 

7. The last issue is deciding what to do with bonds within small-molecule ligands / cofactors that contain any of these metal elements. I was expecting here that `covale` would contain bonds within ligands, but this doesn't seem to be the case. For example, for HEM, the most common metal containing cofactor, PDBxFile scanning over the whole PDB had only 2 files with topologies containing any bonds within HEM, while there are 3756 structures containing HEM. By looking at a few pdbx files I didn't not see any where this connectivity would be written in any other section, though it seems like [chem_comp_bond](http://mmcif.wwpdb.org/dictionaries/mmcif_pdbx_v40.dic/Categories/chem_comp_bond.html)  is meant for this ? Also, I could not find any justification in the PDBx materials for omitting connectivity in small molecules, but this appears to be the what they've done. 

    I run the updated `PDBFile` as in the PR over the whole database to see what kind of ligands had CONECT bonds to these metal elements. The three most common are: HEM (heme) (27% bonds), SF4 (iron - sulfur cluster) (17%), CLA (chlorophyll A) (14%), all others below 5%.  While one could argue the metal - nitrogen bonds in HEM and CLA should not be added (though I wonder whether covalent bonds are the only way of forcing the unusual coordinations there), covalent bonds are probably a good idea for iron-sulfur clusters. 

    As there is big ambiguity here, I think a sane decision is to retain current behavior of `PDBFile` - i.e. adding all CONECT bonds within small molecule ligands / cofactors, and only change the behavior for inter-residue ligation. Hence code still adds the bonds if `atomByNumber[i].residue == atomByNumber[j].residue`. 

I retained the current behavior for atoms where element is None (but as I've shown this only happens within the database for truly unknown atoms). `PDBFile` will add such bonds, the `metalElements` check will only happen if both atoms in the bond have `element != None` to avoid 'Nonetype has no attribute symbol' exceptions. There is a very small amount of cases of `metalc` metal - unknown bonds I saw, but I think caring about not adding those is not worth the extra lines of code, as those topologies are broken anyway. 

Was planning to test this over the PDB by comparing numbers of bonds between `PDBFile` and `PDBxFile`, but the missing connectivity in small molecules situation in PDBx makes that nonsense. 