### PR TITLE
WIP: Debug OpenCL on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ before_install:
     fi
   - if [[ "$OPENCL" == "true" ]]; then
       sudo apt-get -yq update > /dev/null 2>&1 ;
-      sudo apt-get install -qq fglrx=2:8.960-0ubuntu1 opencl-headers;
+      sudo apt-get install fglrx opencl-headers;
     fi
   # Install swig for Python wrappers. However, testing CUDA and OpenCL, we
   # skip the Python wrapper for speed. We're not using anaconda python,


### PR DESCRIPTION
It looks like the test failure in https://github.com/pandegroup/openmm/pull/1153 with OpenCL is caused by the migration of Travis-CI's services to a different cloud, reported https://github.com/travis-ci/travis-ci/issues/5221#issuecomment-162824870