### PR TITLE
Change functions in `customgbforces.py` to subclasses

### DIFF
--- a/wrappers/python/simtk/openmm/app/charmmpsffile.py
+++ b/wrappers/python/simtk/openmm/app/charmmpsffile.py
@@ -47,7 +47,7 @@ import simtk.unit as u
 from simtk.openmm.app import (forcefield as ff, Topology, element)
 from simtk.openmm.app.amberprmtopfile import HCT, OBC1, OBC2, GBn, GBn2
 from simtk.openmm.app.internal.customgbforces import (GBSAHCTForce,
-                GBSAOBC1Force, GBSAOBC2Force, GBSAGBnForce, GBSAGBn2Force, convertParameters)
+                GBSAOBC1Force, GBSAOBC2Force, GBSAGBnForce, GBSAGBn2Force)
 from simtk.openmm.app.internal.unitcell import computePeriodicBoxVectors
 # CHARMM imports
 from simtk.openmm.app.internal.charmm.topologyobjects import (
@@ -1250,7 +1250,6 @@ class CharmmPsfFile(object):
         if implicitSolvent is not None:
             if verbose: print('Adding GB parameters...')
             gb_parms = self._get_gb_params(implicitSolvent)
-            gb_parms = convertParameters(gb_parms, str(implicitSolvent))
 
             # If implicitSolventKappa is None, compute it from salt
             # concentration

--- a/wrappers/python/simtk/openmm/app/internal/amber_file_parser.py
+++ b/wrappers/python/simtk/openmm/app/internal/amber_file_parser.py
@@ -1054,8 +1054,6 @@ def readAmberSystem(topology, prmtop_filename=None, prmtop_loader=None, shake=No
             if units.is_quantity(cutoff):
                 cutoff = cutoff.value_in_unit(units.nanometers)
         gb_parms = prmtop.getGBParms(gbmodel, elements)
-        if gbmodel != 'OBC2' or implicitSolventKappa != 0:
-            gb_parms = customgb.convertParameters(gb_parms, gbmodel)
         if gbmodel == 'HCT':
             gb = customgb.GBSAHCTForce(solventDielectric, soluteDielectric, 'ACE', cutoff, implicitSolventKappa)
         elif gbmodel == 'OBC1':

--- a/wrappers/python/simtk/openmm/app/internal/customgbforces.py
+++ b/wrappers/python/simtk/openmm/app/internal/customgbforces.py
@@ -328,7 +328,7 @@ class GBSAGBnForce(CustomGBForce):
     def addParticle(self, parameters):
         parameters = list(parameters)
         parameters[0] = strip_unit(parameters[0], u.elementary_charge)
-        parameters[1] = strip_unit(parameters[0], u.nanometer)
+        parameters[1] = strip_unit(parameters[1], u.nanometer)
         if parameters[1] < 0.1 or parameters[1] > 0.2:
             raise ValueError('Radii must be between 1 and 2 Angstroms for neck lookup')
         CustomGBForce.addParticle(self, parameters)
@@ -336,7 +336,7 @@ class GBSAGBnForce(CustomGBForce):
     def setParticleParameters(self, idx, parameters):
         parameters = list(parameters)
         parameters[0] = strip_unit(parameters[0], u.elementary_charge)
-        parameters[1] = strip_unit(parameters[0], u.nanometer)
+        parameters[1] = strip_unit(parameters[1], u.nanometer)
         if parameters[1] < 0.1 or parameters[1] > 0.2:
             raise ValueError('Radii must be between 1 and 2 Angstroms for neck lookup')
         CustomGBForce.setParticleParameters(self, idx, parameters)
@@ -344,7 +344,7 @@ class GBSAGBnForce(CustomGBForce):
 """
 Amber Equivalents: igb = 8
 """
-class GBSAGBn2Force(CustomGBForce):
+class GBSAGBn2Force(GBSAGBnForce):
 
     def __init__(self, solventDielectric=78.5, soluteDielectric=1, SA=None,
                  cutoff=None, kappa=0.0):
@@ -373,22 +373,6 @@ class GBSAGBn2Force(CustomGBForce):
         self.addComputedValue("B", "1/(1/or-tanh(alpha*psi-beta*psi^2+gamma*psi^3)/radius);"
                                      "psi=I*or; radius=or+offset; offset=0.0195141", CustomGBForce.SingleParticle)
         _createEnergyTerms(self, solventDielectric, soluteDielectric, SA, cutoff, kappa, 0.0195141)
-
-    def addParticle(self, parameters):
-        parameters = list(parameters)
-        parameters[0] = strip_unit(parameters[0], u.elementary_charge)
-        parameters[1] = strip_unit(parameters[0], u.nanometer)
-        if parameters[1] < 0.1 or parameters[1] > 0.2:
-            raise ValueError('Radii must be between 1 and 2 Angstroms for neck lookup')
-        CustomGBForce.addParticle(self, parameters)
-
-    def setParticleParameters(self, idx, parameters):
-        parameters = list(parameters)
-        parameters[0] = strip_unit(parameters[0], u.elementary_charge)
-        parameters[1] = strip_unit(parameters[0], u.nanometer)
-        if parameters[1] < 0.1 or parameters[1] > 0.2:
-            raise ValueError('Radii must be between 1 and 2 Angstroms for neck lookup')
-        CustomGBForce.setParticleParameters(self, idx, parameters)
 
 def convertParameters(params, gbmodel):
     """Convert the GB parameters from the file into the values expected by the appropriate CustomGBForce."""

--- a/wrappers/python/simtk/openmm/app/internal/customgbforces.py
+++ b/wrappers/python/simtk/openmm/app/internal/customgbforces.py
@@ -238,8 +238,6 @@ class GBSAHCTForce(CustomGBForce):
     def __init__(self, solventDielectric=78.5, soluteDielectric=1, SA=None,
                  cutoff=None, kappa=0.0):
         CustomGBForce.__init__(self)
-        self.addPerParticleParameter("q")
-        self.add
 
         self.addPerParticleParameter("q")
         self.addPerParticleParameter("or") # Offset radius


### PR DESCRIPTION
This is part of making these classes a little more consistent and isolating the support functionality and parameter definition specific to these models inside these models themselves.  Right now, there is GB-model-specific code scattered in several places that can make it difficult to maintain.

The main thing that needs to happen now is for the radius assignment (that is currently in `charmmpsffile.py`) to be moved to `customgbforces.py`, and possibly correcting the handling in `amber_file_parser.py` to use the "correct" radii rather than the radii in the prmtop file.  That last one requires some discussion, probably.

That can be done either in another PR or added to this one.