### PR TITLE
Fix travis following migration to legacy precise infrastructure.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,6 +100,7 @@ before_install:
       sudo easy_install pytest;
     fi
   - if [[ "$OPENCL" == "true" ]]; then
+      sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc) main universe restricted multiverse";
       sudo apt-get -yq update > /dev/null 2>&1 ;
       sudo apt-get install -qq fglrx=2:8.960-0ubuntu1 opencl-headers;
     fi


### PR DESCRIPTION
Addresses #1313.

A change in the way travis-ci handled the Legacy Precise infrastructure meant that restricted ubuntu packages (such as `fglrx`) were not available unless the `restricted` repository was explicitly added.