### PR TITLE
Python 3 does not have dict.itervalues

### DIFF
--- a/wrappers/python/simtk/openmm/app/forcefield.py
+++ b/wrappers/python/simtk/openmm/app/forcefield.py
@@ -778,7 +778,7 @@ def _findAtomMatches(atoms, template, bondedTo, externalBonds, matches, hasMatch
 def _findMatchErrors(forcefield, res):
     """Try to guess why a residue failed to match any template and return an error message."""
     residueCounts = _countResidueAtoms([atom.element for atom in res.atoms()])
-    numResidueAtoms = sum(residueCounts.itervalues())
+    numResidueAtoms = sum(residueCounts.values())
     numResidueHeavyAtoms = sum(residueCounts[element] for element in residueCounts if element not in (None, elem.hydrogen))
 
     # Loop over templates and see how closely each one might match.
@@ -797,7 +797,7 @@ def _findMatchErrors(forcefield, res):
 
         # If there are too many missing atoms, discard this template.
 
-        numTemplateAtoms = sum(templateCounts.itervalues())
+        numTemplateAtoms = sum(templateCounts.values())
         numTemplateHeavyAtoms = sum(templateCounts[element] for element in templateCounts if element not in (None, elem.hydrogen))
         if numTemplateAtoms > numBestMatchAtoms:
             continue


### PR DESCRIPTION
Really we should move to using six and importing the iterator versions of dict
methods and range/zip from there, but for now just use "values" since using a
raw list doesn't seem like it will cause memory or performance problems here.

This fixes an `AttributeError` I got working with Python 3.