### PR TITLE
Also build the HTML user guide in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -148,7 +148,8 @@ script:
   - python devtools/run-ctest.py --start-time $START_TIME
 
   - if [[ ! -z "${DOCS_DEPLOY}" && "${DOCS_DEPLOY}" = "true" ]]; then
-      pip install sphinx sphinxcontrib-lunrsearch sphinxcontrib-autodoc_doxygen;
+      pip install sphinx sphinxcontrib-bibtex sphinxcontrib-lunrsearch sphinxcontrib-autodoc_doxygen;
+      make sphinxhtml;
       make C++ApiDocs PythonApiDocs;
       mkdir -p api-docs;
       mv api-python api-docs;

--- a/.travis.yml
+++ b/.travis.yml
@@ -152,6 +152,8 @@ script:
       make sphinxhtml;
       make C++ApiDocs PythonApiDocs;
       mkdir -p api-docs;
+      mv sphinx-docs/userguide api-docs;
+      mv sphinx-docs/developerguide api-docs;
       mv api-python api-docs;
       mv api-c++ api-docs;
     fi

--- a/docs-source/usersguide/application.rst
+++ b/docs-source/usersguide/application.rst
@@ -2747,10 +2747,12 @@ modified residues, covalently-bound ligands, or unnatural amino acids or bases.
 To register a new residue template generator named :code:`generator`, simply call the
 :meth:`registerTemplateGenerator` method on an existing :class:`ForceField` object:
 ::
+
     forcefield.registerTemplateGenerator(generator)
 
 This :code:`generator` function must conform to the following API:
 ::
+
     def generator(forcefield, residue):
         """
         Parameters


### PR DESCRIPTION
I just found I missed that I had added some syntax errors to the user guide because none of the travis branches are building/testing the guide.

This PR also builds the user guide in the same branch that the API docs are built, but the user guide currently isn't deployed anywhere.  Do we also want to push that to the S3 docs?