### PR TITLE
Fix push of dev user and developer guide HTMLs to S3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -152,8 +152,8 @@ script:
       make sphinxhtml;
       make C++ApiDocs PythonApiDocs;
       mkdir -p api-docs;
-      mv sphinx-docs/userguide api-docs;
-      mv sphinx-docs/developerguide api-docs;
+      mv /home/travis/build/pandegroup/openmm/sphinx-docs/sphinx-docs/userguide api-docs;
+      mv /home/travis/build/pandegroup/openmm/sphinx-docs/sphinx-docs/developerguide api-docs;
       mv api-python api-docs;
       mv api-c++ api-docs;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -152,8 +152,8 @@ script:
       make sphinxhtml;
       make C++ApiDocs PythonApiDocs;
       mkdir -p api-docs;
-      mv /home/travis/build/pandegroup/openmm/sphinx-docs/sphinx-docs/userguide api-docs;
-      mv /home/travis/build/pandegroup/openmm/sphinx-docs/sphinx-docs/developerguide api-docs;
+      mv sphinx-docs/userguide/html api-docs/userguide;
+      mv sphinx-docs/developerguide/html api-docs/developerguide;
       mv api-python api-docs;
       mv api-c++ api-docs;
     fi


### PR DESCRIPTION
I think the HTML user and dev guides were not being correctly moved into the directory uploaded to S3.