### PR TITLE
Update README.md badges and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 Introduction
 ------------
 
-[OpenMM](https://simtk.org/home/openmm) is a toolkit for molecular simulation. It can be used either as a stand-alone application for running simulations, or as a library you call from your own code. It
+[OpenMM](http://openmm.org) is a toolkit for molecular simulation. It can be used either as a stand-alone application for running simulations, or as a library you call from your own code. It
 provides a combination of extreme flexibility (through custom forces and integrators), openness, and high performance (especially on recent GPUs) that make it truly unique among simulation codes.  
 
 Getting Help
 ------------
 
-Need Help? Check out the [documentation](https://simtk.org/docman/?group_id=161) and [discussion forums](https://simtk.org/forums/viewforum.php?f=161).
+Need Help? Check out the [documentation](http://docs.openmm.org/) and [discussion forums](https://simtk.org/forums/viewforum.php?f=161).
 
 [C++ API Reference](https://simtk.org/api_docs/openmm/api6_0/c++/)
 
@@ -17,7 +17,8 @@ Need Help? Check out the [documentation](https://simtk.org/docman/?group_id=161)
 
 Badges
 ------
-* Travis CI `linux` integration tests: [![Build Status](https://travis-ci.org/pandegroup/openmm.png?branch=master)](https://travis-ci.org/pandegroup/openmm)
-* Anaconda Cloud `openmm` conda release: ![Binstar `openmm` conda release](https://binstar.org/omnia/openmm/badges/version.svg)
-* Anaconda Cloud `openmm-dev` conda package: ![Binstar `openmm-dev` conda package](https://binstar.org/omnia/openmm-dev/badges/version.svg)
-
+* Travis CI `linux` and `osx` integration tests:
+  * GitHub master [![Build Status](https://travis-ci.org/pandegroup/openmm.png?branch=master)](https://travis-ci.org/pandegroup/openmm)
+  * `openmm-dev` recipe [![Build Status](https://travis-ci.org/omnia-md/conda-dev-recipes.svg?branch=master)](https://travis-ci.org/omnia-md/conda-dev-recipes)
+* Anaconda Cloud `openmm` conda release: [![Binstar `openmm` conda release](https://anaconda.org/omnia/openmm/badges/version.svg)](https://anaconda.org/omnia/openmm)
+* Anaconda Cloud `openmm-dev` conda package: [![Binstar `openmm-dev` conda package](https://anaconda.org/omnia/openmm-dev/badges/version.svg)](https://anaconda.org/omnia/openmm-dev)

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Getting Help
 
 Need Help? Check out the [documentation](http://docs.openmm.org/) and [discussion forums](https://simtk.org/forums/viewforum.php?f=161).
 
-[C++ API Reference](https://simtk.org/api_docs/openmm/api6_0/c++/)
+[C++ API Reference](http://docs.openmm.org/6.3.0/api-c++/namespaceOpenMM.html)
 
-[Python API Reference](https://simtk.org/api_docs/openmm/api6_0/python/)
+[Python API Reference](http://docs.openmm.org/6.3.0/api-python/annotated.html)
 
 Badges
 ------


### PR DESCRIPTION
* Update OpenMM URL to http://openmm.org
* Update docs URL to http://docs.openmm.org (previously they pointed to 6.0 docs)
* Update badges

Has anyone else noticed that the anaconda badge points to 6.2.dev0?  I fear the anaconda precedence thing might be accidentally thinking that 6.2.dev0 is the latest version---maybe we should delete just that version from anaconda cloud (but keep other actual releases)?