### PR TITLE
Fixed bug in selecting device index

### DIFF
--- a/platforms/cuda/src/CudaPlatform.cpp
+++ b/platforms/cuda/src/CudaPlatform.cpp
@@ -191,7 +191,7 @@ CudaPlatform::PlatformData::PlatformData(ContextImpl* context, const System& sys
     try {
         for (int i = 0; i < (int) devices.size(); i++) {
             if (devices[i].length() > 0) {
-                unsigned int deviceIndex;
+                int deviceIndex;
                 stringstream(devices[i]) >> deviceIndex;
                 contexts.push_back(new CudaContext(system, deviceIndex, blocking, precisionProperty, compilerProperty, tempProperty, hostCompilerProperty, *this));
             }

--- a/platforms/opencl/src/OpenCLPlatform.cpp
+++ b/platforms/opencl/src/OpenCLPlatform.cpp
@@ -183,7 +183,7 @@ OpenCLPlatform::PlatformData::PlatformData(const System& system, const string& p
     try {
         for (int i = 0; i < (int) devices.size(); i++) {
             if (devices[i].length() > 0) {
-                unsigned int deviceIndex;
+                int deviceIndex;
                 stringstream(devices[i]) >> deviceIndex;
                 contexts.push_back(new OpenCLContext(system, platformIndex, deviceIndex, precisionProperty, *this));
             }


### PR DESCRIPTION
Specifying -1 as the device index for a test case was being interpreted as 0 instead of as "pick fastest device".