### PR TITLE
Update travis to use CUDA 7.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,7 +125,7 @@ before_install:
 
   - if [[ "$CUDA" == "true" ]]; then
       wget "http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1404/x86_64/cuda-repo-ubuntu1404_${CUDA_VERSION}_amd64.deb";
-      sudo dpkg -i cuda-repo-ubuntu1204_${CUDA_VERSION}_amd64.deb;
+      sudo dpkg -i cuda-repo-ubuntu1404_${CUDA_VERSION}_amd64.deb;
       sudo apt-get update -qq;
       export CUDA_APT=${CUDA_VERSION%-*};
       export CUDA_APT=${CUDA_APT/./-};

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,11 @@ matrix:
       addons: {apt: {packages: []}}
 
     - sudo: required
+      dist: trusty
       env: ==CUDA_COMPILE==
            CUDA=true
            OPENCL=false
-           CUDA_VERSION="7.0-28"
+           CUDA_VERSION="7.5-18"
            CC=$CCACHE/gcc
            CXX=$CCACHE/g++
            CMAKE_FLAGS="
@@ -51,7 +52,7 @@ matrix:
              -DOPENMM_BUILD_SERIALIZATION_TESTS=OFF
              -DOPENMM_BUILD_C_AND_FORTRAN_WRAPPERS=OFF
              -DOPENMM_BUILD_EXAMPLES=OFF
-             -DOPENCL_LIBRARY=/usr/local/cuda-7.0/lib64/libOpenCL.so"
+             -DOPENCL_LIBRARY=/usr/local/cuda-7.5/lib64/libOpenCL.so"
       addons: {apt: {packages: []}}
 
     - language: objective-c
@@ -75,7 +76,7 @@ matrix:
 
     - sudo: false
       python: 2.7_with_system_site_packages
-      env: ==PYTNON_2==
+      env: ==PYTHON_2==
            OPENCL=false
            CUDA=false
            CC=$CCACHE/clang
@@ -118,7 +119,7 @@ before_install:
     fi
 
   - if [[ "$CUDA" == "true" ]]; then
-      wget "http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1204/x86_64/cuda-repo-ubuntu1204_${CUDA_VERSION}_amd64.deb";
+      wget "http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1404/x86_64/cuda-repo-ubuntu1404_${CUDA_VERSION}_amd64.deb";
       sudo dpkg -i cuda-repo-ubuntu1204_${CUDA_VERSION}_amd64.deb;
       sudo apt-get update -qq;
       export CUDA_APT=${CUDA_VERSION%-*};

--- a/.travis.yml
+++ b/.travis.yml
@@ -140,6 +140,7 @@ script:
   - cmake . $CMAKE_FLAGS -DCMAKE_INSTALL_PREFIX=$HOME/OpenMM
   # DEBUG
   - cat CMakeCache.txt
+  - ls -l /usr/local/
   - make -j2 install
   - if [[ "$OPENCL" == "true" ]]; then ./TestOpenCLDeviceQuery; fi
   - if [[ "$OPENCL" == "false" && "$CUDA" == "false" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -138,9 +138,6 @@ before_install:
 
 script:
   - cmake . $CMAKE_FLAGS -DCMAKE_INSTALL_PREFIX=$HOME/OpenMM
-  # DEBUG
-  - cat CMakeCache.txt
-  - ls -l /usr/local/
   - make -j2 install
   - if [[ "$OPENCL" == "true" ]]; then ./TestOpenCLDeviceQuery; fi
   - if [[ "$OPENCL" == "false" && "$CUDA" == "false" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,12 @@ matrix:
              -DOPENMM_BUILD_SERIALIZATION_TESTS=OFF
              -DOPENMM_BUILD_C_AND_FORTRAN_WRAPPERS=OFF
              -DOPENMM_BUILD_EXAMPLES=OFF
-             -DOPENCL_LIBRARY=/usr/local/cuda-7.5/lib64/libOpenCL.so"
+             -DOPENCL_LIBRARY=/usr/local/cuda-7.5/lib64/libOpenCL.so
+             -DCUDA_CUDART_LIBRARY=/usr/local/cuda-7.5/lib64/libcudart.so
+             -DCUDA_NVCC_EXECUTABLE=/usr/local/cuda-7.5/bin/nvcc
+             -DCUDA_SDK_ROOT_DIR=/usr/local/cuda-7.5/
+             -DCUDA_TOOLKIT_INCLUDE=/usr/local/cuda-7.5/include
+             -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda-7.5/"
       addons: {apt: {packages: []}}
 
     - language: objective-c
@@ -133,6 +138,8 @@ before_install:
 
 script:
   - cmake . $CMAKE_FLAGS -DCMAKE_INSTALL_PREFIX=$HOME/OpenMM
+  # DEBUG
+  - cat CMakeCache.txt
   - make -j2 install
   - if [[ "$OPENCL" == "true" ]]; then ./TestOpenCLDeviceQuery; fi
   - if [[ "$OPENCL" == "false" && "$CUDA" == "false" ]]; then


### PR DESCRIPTION
cc: #1282 #1357 

This requires updating from the travis `precise` (ubuntu 12.04) build environment to `trusty` (ubuntu 14.04) since the CUDA 7.5 distribution is not available via the same mechanism for 12.04:
https://docs.travis-ci.com/user/trusty-ci-environment/