### PR TITLE
Create alternative constructor for Simulation from XML files

### DIFF
--- a/wrappers/python/simtk/openmm/app/simulation.py
+++ b/wrappers/python/simtk/openmm/app/simulation.py
@@ -95,17 +95,17 @@ class Simulation(object):
         self.reporters = []
         if platform is None:
             ## The Context containing the current state of the simulation
-            self.context = mm.Context(system, integrator)
+            self.context = mm.Context(self.system, self.integrator)
         elif platformProperties is None:
-            self.context = mm.Context(system, integrator, platform)
+            self.context = mm.Context(self.system, self.integrator, platform)
         else:
-            self.context = mm.Context(system, integrator, platform, platformProperties)
+            self.context = mm.Context(self.system, self.integrator, platform, platformProperties)
         if state is not None:
             with open(state, 'r') as f:
                 self.context.setState(mm.XmlSerializer.deserialize(f.read()))
         ## Determines whether or not we are using PBC. If no Topology is provided, take it from the System
         if topology is None:
-            self._usesPBC = system.usesPeriodicBoundaryConditions()
+            self._usesPBC = self.system.usesPeriodicBoundaryConditions()
         else:
             self._usesPBC = topology.getUnitCellDimensions() is not None
 

--- a/wrappers/python/simtk/openmm/app/simulation.py
+++ b/wrappers/python/simtk/openmm/app/simulation.py
@@ -36,6 +36,10 @@ import simtk.openmm as mm
 import simtk.unit as unit
 import sys
 from datetime import datetime, timedelta
+try:
+    string_types = (unicode, str)
+except NameError:
+    string_types = (str,)
 
 class Simulation(object):
     """Simulation provides a simplified API for running simulations with OpenMM and reporting results.
@@ -52,29 +56,39 @@ class Simulation(object):
     simulation.reporters.append(PDBReporter('output.pdb', 1000))
     """
 
-    def __init__(self, topology, system, integrator, platform=None, platformProperties=None):
+    def __init__(self, topology, system, integrator, platform=None, platformProperties=None, state=None):
         """Create a Simulation.
 
         Parameters
         ----------
         topology : Topology
             A Topology describing the the system to simulate
-        system : System
-            The OpenMM System object to simulate
-        integrator : Integrator
-            The OpenMM Integrator to use for simulating the System
+        system : System or XML file name
+            The OpenMM System object to simulate (or the name of an XML file
+            with a serialized System)
+        integrator : Integrator or XML file name
+            The OpenMM Integrator to use for simulating the System (or the name
+            of an XML file with a serialized System)
         platform : Platform=None
             If not None, the OpenMM Platform to use
         platformProperties : map=None
             If not None, a set of platform-specific properties to pass to the
             Context's constructor
+        state : XML file name
+            The name of an XML file containing a serialized State
         """
-        ## The Topology describing the system being simulated
-        self.topology = topology
         ## The System being simulated
-        self.system = system
+        if isinstance(system, string_types):
+            with open(system, 'r') as f:
+                self.system = mm.XmlSerializer.deserialize(f.read())
+        else:
+            self.system = system
         ## The Integrator used to advance the simulation
-        self.integrator = integrator
+        if isinstance(integrator, string_types):
+            with open(integrator, 'r') as f:
+                self.integrator = mm.XmlSerializer.deserialize(f.read())
+        else:
+            self.integrator = integrator
         ## The index of the current time step
         self.currentStep = 0
         ## A list of reporters to invoke during the simulation
@@ -86,6 +100,34 @@ class Simulation(object):
             self.context = mm.Context(system, integrator, platform)
         else:
             self.context = mm.Context(system, integrator, platform, platformProperties)
+        if state is not None:
+            with open(state, 'r') as f:
+                self.context.setState(mm.XmlSerializer.deserialize(f.read()))
+        ## Determines whether or not we are using PBC. If no Topology is provided, take it from the System
+        if topology is None:
+            self._usesPBC = system.usesPeriodicBoundaryConditions()
+        else:
+            self._usesPBC = topology.getUnitCellDimensions() is not None
+
+    @classmethod
+    def fromXmlFiles(cls, system, integrator, state=None, platform=None, platformProperties=None):
+        """ Initialize a Simulation object from a set of XML files
+
+        Parameters
+        ----------
+        system : str (or mm.System)
+            XML file name containing a serialized OpenMM System object
+        integrator : str (or mm.Integrator)
+            XML file name containing a serialized OpenMM Integrator subclass
+        state : str, optional
+            XML file name containing a serialized OpenMM State
+        platform : Platform=None
+            If not None, the OpenMM Platform to use
+        platformProperties : map=None
+            If not None, a set of platform-specific properties to pass to the
+            Context's constructor
+        """
+        return cls(None, system, integrator, platform, platformProperties, state=state)
 
     def minimizeEnergy(self, tolerance=10*unit.kilojoule/unit.mole, maxIterations=0):
         """Perform a local energy minimization on the system.
@@ -186,7 +228,8 @@ class Simulation(object):
                             getForces = True
                         if next[4]:
                             getEnergy = True
-                state = self.context.getState(getPositions=getPositions, getVelocities=getVelocities, getForces=getForces, getEnergy=getEnergy, getParameters=True, enforcePeriodicBox=(self.topology.getUnitCellDimensions() is not None))
+                state = self.context.getState(getPositions=getPositions, getVelocities=getVelocities, getForces=getForces,
+                                              getEnergy=getEnergy, getParameters=True, enforcePeriodicBox=self._usesPBC)
                 for reporter, next in zip(self.reporters, nextReport):
                     if next[0] == nextSteps:
                         reporter.report(self, state)

--- a/wrappers/python/tests/TestSimulation.py
+++ b/wrappers/python/tests/TestSimulation.py
@@ -63,7 +63,7 @@ class TestSimulation(unittest.TestCase):
             f.write(XmlSerializer.serialize(state))
 
         # Now create a Simulation
-        sim = Simulation.fromXmlFiles(systemfn, integratorfn, state=statefn)
+        sim = Simulation(pdb.topology, systemfn, integratorfn, state=statefn)
 
     def testSaveState(self):
         """Test that saving States works correctly."""

--- a/wrappers/python/tests/TestSimulation.py
+++ b/wrappers/python/tests/TestSimulation.py
@@ -42,6 +42,29 @@ class TestSimulation(unittest.TestCase):
         self.assertEqual(initialState.getVelocities(), state.getVelocities())
 
 
+    def testLoadFromXML(self):
+        """ Test creating a Simulation from XML files """
+        pdb = PDBFile('systems/alanine-dipeptide-implicit.pdb')
+        ff = ForceField('amber99sb.xml', 'tip3p.xml')
+        system = ff.createSystem(pdb.topology)
+        integrator = VerletIntegrator(0.001*picoseconds)
+        context = Context(system, integrator)
+        context.setPositions(pdb.positions)
+        state = context.getState(getPositions=True, getForces=True,
+                                 getVelocities=True, getEnergy=True)
+        systemfn = tempfile.mktemp()
+        integratorfn = tempfile.mktemp()
+        statefn = tempfile.mktemp()
+        with open(systemfn, 'w') as f:
+            f.write(XmlSerializer.serialize(system))
+        with open(integratorfn, 'w') as f:
+            f.write(XmlSerializer.serialize(integrator))
+        with open(statefn, 'w') as f:
+            f.write(XmlSerializer.serialize(state))
+
+        # Now create a Simulation
+        sim = Simulation.fromXmlFiles(systemfn, integratorfn, state=statefn)
+
     def testSaveState(self):
         """Test that saving States works correctly."""
         pdb = PDBFile('systems/alanine-dipeptide-implicit.pdb')


### PR DESCRIPTION
This replaces #872.

The actual changes are actually pretty small.  `Simulation` now accepts `None` for its topology argument, and falls back to `system.usesPeriodicBoundaryConditions` to determine the value of `enforceBox` in `Context.getState` calls.  It also accepts either a `System` or `str` input for its `system` and `Integrator` or `str` for its `integrator` arguments.  A string is interpreted as a XML file name in both cases.

The only reason I bothered with an alternate constructor is because `topology` is a *required* positional argument to the `Simulation` initializer, and the `fromXmlFiles` constructor is a clearer API for instantiating a `Simulation` from XML files (even if you can do the exact same thing with the standard constructor).

The `State` XML file is optional.

What do people think?