### PR TITLE
bugfix on the ansiotropic polarizability for Drude force field

### DIFF
--- a/plugins/drude/platforms/cuda/src/kernels/drudeParticleForce.cu
+++ b/plugins/drude/platforms/cuda/src/kernels/drudeParticleForce.cu
@@ -32,7 +32,7 @@ if (k1 != 0) {
 // Compute the second anisotropic force.
 
 if (k2 != 0) {
-    real3 dir = make_real3(pos3.x-pos4.x, pos3.y-pos4.y, pos3.z-pos4.z);
+    real3 dir = make_real3(pos4.x-pos5.x, pos4.y-pos5.y, pos4.z-pos5.z);
     real invDist = RSQRT(dot(dir, dir));
     dir *= invDist;
     real rprime = dot(dir, delta);

--- a/plugins/drude/platforms/opencl/src/kernels/drudeParticleForce.cl
+++ b/plugins/drude/platforms/opencl/src/kernels/drudeParticleForce.cl
@@ -32,7 +32,7 @@ if (k1 != 0) {
 // Compute the second anisotropic force.
 
 if (k2 != 0) {
-    real4 dir = (real4) (pos3.xyz-pos4.xyz, 0);
+    real4 dir = (real4) (pos4.xyz-pos5.xyz, 0);
     real invDist = RSQRT(dot(dir, dir));
     dir *= invDist;
     real rprime = dot(dir, delta);


### PR DESCRIPTION
The anisotropic polarizability in Drude FF is defined using four particles, first anisotropic term aniso12 using particle 1 and 2, and second term aniso34 using particle 3 and 4. There is a bug in the cuda and opencl platforms that the aniso34 are defined wrongly using the direction of particle 2 and particle 3. This bug escapes our previous tests using water and protein systems because of symmetry in the anisotropy definition in Drude protein force field, but surfaces when we compared energies and forces of nucleic acid systems with Drude FF. 

The reference platform is correct.