### PR TITLE
Prevent Travis from reporting a failed build if the OpenCL platform tests fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
 
 matrix:
   allow_failures:
-      - env: ==CPU_OPENCL==
+      - env: OPENCL=true
   include:
     - sudo: required
       env: ==CPU_OPENCL==

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ matrix:
            -DOPENMM_BUILD_C_AND_FORTRAN_WRAPPERS=OFF
            -DOPENMM_BUILD_EXAMPLES=OFF"
       addons: {apt: {packages: []}}
+      allow_failure: true
 
     - sudo: required
       dist: trusty
@@ -97,10 +98,6 @@ matrix:
            CC=$CCACHE/gcc
            CXX=$CCACHE/g++
            CMAKE_FLAGS=""
-
-matrix:
-  allow_failures:
-      - env: OPENCL=true
 
 before_install:
   - START_TIME=$(date +%s)

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,6 +97,8 @@ matrix:
            CC=$CCACHE/gcc
            CXX=$CCACHE/g++
            CMAKE_FLAGS=""
+  allowfailures:
+    - env: ==CPU_OPENCL==
 
 before_install:
   - START_TIME=$(date +%s)

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ matrix:
            -DOPENMM_BUILD_C_AND_FORTRAN_WRAPPERS=OFF
            -DOPENMM_BUILD_EXAMPLES=OFF"
       addons: {apt: {packages: []}}
-      allow_failure: true
+      allow_failures: on
 
     - sudo: required
       dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ env:
 
 
 matrix:
+  allowfailures:
+      - env: OPENCL=true
   include:
     - sudo: required
       env: ==CPU_OPENCL==
@@ -97,10 +99,6 @@ matrix:
            CC=$CCACHE/gcc
            CXX=$CCACHE/g++
            CMAKE_FLAGS=""
-
-matrix:
-  allowfailures:
-    - env: OPENCL=true
 
 before_install:
   - START_TIME=$(date +%s)

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ env:
 
 
 matrix:
-  allowfailures:
-      - env: OPENCL=true
+  allow_failures:
+      - env: ==CPU_OPENCL==
   include:
     - sudo: required
       env: ==CPU_OPENCL==

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,6 +98,7 @@ matrix:
            CXX=$CCACHE/g++
            CMAKE_FLAGS=""
 
+matrix:
   allow_failures:
       - env: OPENCL=true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ env:
 
 
 matrix:
-  allow_failures:
-      - env: OPENCL=true
   include:
     - sudo: required
       env: ==CPU_OPENCL==
@@ -99,6 +97,9 @@ matrix:
            CC=$CCACHE/gcc
            CXX=$CCACHE/g++
            CMAKE_FLAGS=""
+
+  allow_failures:
+      - env: OPENCL=true
 
 before_install:
   - START_TIME=$(date +%s)

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,8 +97,10 @@ matrix:
            CC=$CCACHE/gcc
            CXX=$CCACHE/g++
            CMAKE_FLAGS=""
+
+matrix:
   allowfailures:
-    - env: ==CPU_OPENCL==
+    - env: OPENCL=true
 
 before_install:
   - START_TIME=$(date +%s)


### PR DESCRIPTION
At the moment, it fails every time and we always ignore it. Once we stop
*expecting* it to fail, we should remove this.