### PR TITLE
Add residue name and template name matching

### DIFF
--- a/wrappers/python/simtk/openmm/app/forcefield.py
+++ b/wrappers/python/simtk/openmm/app/forcefield.py
@@ -371,7 +371,10 @@ class ForceField(object):
                 matches = None
                 signature = _createResidueSignature([atom.element for atom in res.atoms()])
                 if signature in self._templateSignatures:
-                    for t in self._templateSignatures[signature]:
+		    templates = [t for t in self._templateSignatures[signature] if t.name == res.name]
+		    if templates == []:
+		        templates = self._templateSignatures[signature]
+                    for t in templates:
                         matches = _matchResidue(res, t, bondedToAtom)
                         if matches is not None:
                             template = t


### PR DESCRIPTION
In original version, when a template for a residue is searched, first
match for the elements-bonds graph is selected. This is problematic,
when one has ffxml with separate residues for different isotopologues,
where the elements are the same, but atom masses differ. If a file with
different isotopologues is read in, all of them will be assigned the
same template, which is an undesired behavior.
This commit adds residue name matching. If the name matching fails, the
template matching is not influenced.

	modified:   wrappers/python/simtk/openmm/app/forcefield.py