### PR TITLE
Renamed enums that caused Fortran compiler errors

### DIFF
--- a/openmmapi/include/openmm/CustomIntegrator.h
+++ b/openmmapi/include/openmm/CustomIntegrator.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2011-2012 Stanford University and the Authors.      *
+ * Portions copyright (c) 2011-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -266,15 +266,15 @@ public:
         /**
          * Begin an "if" block.
          */
-        BeginIfBlock = 6,
+        IfBlockStart = 6,
         /**
          * Begin a while" block.
          */
-        BeginWhileBlock = 7,
+        WhileBlockStart = 7,
         /**
          * End an "if" or "while" block.
          */
-        EndBlock = 8
+        BlockEnd = 8
     };
     /**
      * Create a CustomIntegrator.

--- a/openmmapi/src/CustomIntegrator.cpp
+++ b/openmmapi/src/CustomIntegrator.cpp
@@ -248,21 +248,21 @@ int CustomIntegrator::addUpdateContextState() {
 int CustomIntegrator::beginIfBlock(const string& expression) {
     if (owner != NULL)
         throw OpenMMException("The integrator cannot be modified after it is bound to a context");
-    computations.push_back(ComputationInfo(BeginIfBlock, "", expression));
+    computations.push_back(ComputationInfo(IfBlockStart, "", expression));
     return computations.size()-1;
 }
 
 int CustomIntegrator::beginWhileBlock(const string& expression) {
     if (owner != NULL)
         throw OpenMMException("The integrator cannot be modified after it is bound to a context");
-    computations.push_back(ComputationInfo(BeginWhileBlock, "", expression));
+    computations.push_back(ComputationInfo(WhileBlockStart, "", expression));
     return computations.size()-1;
 }
 
 int CustomIntegrator::endBlock() {
     if (owner != NULL)
         throw OpenMMException("The integrator cannot be modified after it is bound to a context");
-    computations.push_back(ComputationInfo(EndBlock, "", ""));
+    computations.push_back(ComputationInfo(BlockEnd, "", ""));
     return computations.size()-1;
 }
 

--- a/openmmapi/src/CustomIntegratorUtilities.cpp
+++ b/openmmapi/src/CustomIntegratorUtilities.cpp
@@ -87,7 +87,7 @@ void CustomIntegratorUtilities::analyzeComputations(const ContextImpl& context, 
     for (int step = 0; step < numSteps; step++) {
         string expression;
         integrator.getComputationStep(step, stepType[step], stepVariable[step], expression);
-        if (stepType[step] == CustomIntegrator::BeginIfBlock || stepType[step] == CustomIntegrator::BeginWhileBlock) {
+        if (stepType[step] == CustomIntegrator::IfBlockStart || stepType[step] == CustomIntegrator::WhileBlockStart) {
             // This step involves a condition.
 
             string lhs, rhs;
@@ -158,9 +158,9 @@ void CustomIntegratorUtilities::analyzeComputations(const ContextImpl& context, 
     vector<int> blockStart;
     blockEnd.resize(numSteps, -1);
     for (int step = 0; step < numSteps; step++) {
-        if (stepType[step] == CustomIntegrator::BeginIfBlock || stepType[step] == CustomIntegrator::BeginWhileBlock)
+        if (stepType[step] == CustomIntegrator::IfBlockStart || stepType[step] == CustomIntegrator::WhileBlockStart)
             blockStart.push_back(step);
-        else if (stepType[step] == CustomIntegrator::EndBlock) {
+        else if (stepType[step] == CustomIntegrator::BlockEnd) {
             if (blockStart.size() == 0) {
                 stringstream error("CustomIntegrator: Unexpected end of block at computation ");
                 error << step;
@@ -207,7 +207,7 @@ void CustomIntegratorUtilities::enumeratePaths(int firstStep, vector<int> steps,
             jumps[step] = -1;
             step = nextStep;
         }
-        else if (stepType[step] == CustomIntegrator::BeginIfBlock) {
+        else if (stepType[step] == CustomIntegrator::IfBlockStart) {
             // Consider skipping the block.
 
             enumeratePaths(blockEnd[step]+1, steps, jumps, blockEnd, stepType, needsForces, needsEnergy, invalidatesForces, forceGroup, computeBoth);
@@ -216,7 +216,7 @@ void CustomIntegratorUtilities::enumeratePaths(int firstStep, vector<int> steps,
 
             step++;
         }
-        else if (stepType[step] == CustomIntegrator::BeginWhileBlock && jumps[step] != -2) {
+        else if (stepType[step] == CustomIntegrator::WhileBlockStart && jumps[step] != -2) {
             // Consider skipping the block.
 
             enumeratePaths(blockEnd[step]+1, steps, jumps, blockEnd, stepType, needsForces, needsEnergy, invalidatesForces, forceGroup, computeBoth);

--- a/platforms/cuda/src/CudaKernels.cpp
+++ b/platforms/cuda/src/CudaKernels.cpp
@@ -6236,9 +6236,9 @@ void CudaIntegrateCustomStepKernel::prepareForComputation(ContextImpl& context, 
         for (int step = 0; step < numSteps; step++) {
             string expr;
             integrator.getComputationStep(step, stepType[step], variable[step], expr);
-            if (stepType[step] == CustomIntegrator::BeginWhileBlock)
+            if (stepType[step] == CustomIntegrator::WhileBlockStart)
                 blockEnd[blockEnd[step]] = step; // Record where to branch back to.
-            if (stepType[step] == CustomIntegrator::ComputeGlobal || stepType[step] == CustomIntegrator::BeginIfBlock || stepType[step] == CustomIntegrator::BeginWhileBlock)
+            if (stepType[step] == CustomIntegrator::ComputeGlobal || stepType[step] == CustomIntegrator::IfBlockStart || stepType[step] == CustomIntegrator::WhileBlockStart)
                 for (int i = 0; i < (int) expression[step].size(); i++)
                     globalExpressions[step].push_back(expression[step][i].createCompiledExpression());
         }
@@ -6685,15 +6685,15 @@ void CudaIntegrateCustomStepKernel::execute(ContextImpl& context, CustomIntegrat
         else if (stepType[step] == CustomIntegrator::ConstrainVelocities) {
             cu.getIntegrationUtilities().applyVelocityConstraints(integrator.getConstraintTolerance());
         }
-        else if (stepType[step] == CustomIntegrator::BeginIfBlock) {
+        else if (stepType[step] == CustomIntegrator::IfBlockStart) {
             if (!evaluateCondition(step))
                 nextStep = blockEnd[step]+1;
         }
-        else if (stepType[step] == CustomIntegrator::BeginWhileBlock) {
+        else if (stepType[step] == CustomIntegrator::WhileBlockStart) {
             if (!evaluateCondition(step))
                 nextStep = blockEnd[step]+1;
         }
-        else if (stepType[step] == CustomIntegrator::EndBlock) {
+        else if (stepType[step] == CustomIntegrator::BlockEnd) {
             if (blockEnd[step] != -1)
                 nextStep = blockEnd[step]; // Return to the start of a while block.
         }

--- a/platforms/opencl/src/OpenCLKernels.cpp
+++ b/platforms/opencl/src/OpenCLKernels.cpp
@@ -6513,9 +6513,9 @@ void OpenCLIntegrateCustomStepKernel::prepareForComputation(ContextImpl& context
         for (int step = 0; step < numSteps; step++) {
             string expr;
             integrator.getComputationStep(step, stepType[step], variable[step], expr);
-            if (stepType[step] == CustomIntegrator::BeginWhileBlock)
+            if (stepType[step] == CustomIntegrator::WhileBlockStart)
                 blockEnd[blockEnd[step]] = step; // Record where to branch back to.
-            if (stepType[step] == CustomIntegrator::ComputeGlobal || stepType[step] == CustomIntegrator::BeginIfBlock || stepType[step] == CustomIntegrator::BeginWhileBlock)
+            if (stepType[step] == CustomIntegrator::ComputeGlobal || stepType[step] == CustomIntegrator::IfBlockStart || stepType[step] == CustomIntegrator::WhileBlockStart)
                 for (int i = 0; i < (int) expression[step].size(); i++)
                     globalExpressions[step].push_back(expression[step][i].createCompiledExpression());
         }
@@ -6961,15 +6961,15 @@ void OpenCLIntegrateCustomStepKernel::execute(ContextImpl& context, CustomIntegr
         else if (stepType[step] == CustomIntegrator::ConstrainVelocities) {
             cl.getIntegrationUtilities().applyVelocityConstraints(integrator.getConstraintTolerance());
         }
-        else if (stepType[step] == CustomIntegrator::BeginIfBlock) {
+        else if (stepType[step] == CustomIntegrator::IfBlockStart) {
             if (!evaluateCondition(step))
                 nextStep = blockEnd[step]+1;
         }
-        else if (stepType[step] == CustomIntegrator::BeginWhileBlock) {
+        else if (stepType[step] == CustomIntegrator::WhileBlockStart) {
             if (!evaluateCondition(step))
                 nextStep = blockEnd[step]+1;
         }
-        else if (stepType[step] == CustomIntegrator::EndBlock) {
+        else if (stepType[step] == CustomIntegrator::BlockEnd) {
             if (blockEnd[step] != -1)
                 nextStep = blockEnd[step]; // Return to the start of a while block.
         }

--- a/platforms/reference/src/SimTKReference/ReferenceCustomDynamics.cpp
+++ b/platforms/reference/src/SimTKReference/ReferenceCustomDynamics.cpp
@@ -107,7 +107,7 @@ void ReferenceCustomDynamics::update(ContextImpl& context, int numberOfAtoms, ve
         for (int i = 0; i < numSteps; i++) {
             for (int j = 0; j < (int) expressions[i].size(); j++)
                 stepExpressions[i].push_back(expressions[i][j].createProgram());
-            if (stepType[i] == CustomIntegrator::BeginWhileBlock)
+            if (stepType[i] == CustomIntegrator::WhileBlockStart)
                 blockEnd[blockEnd[i]] = i; // Record where to branch back to.
         }
 
@@ -213,17 +213,17 @@ void ReferenceCustomDynamics::update(ContextImpl& context, int numberOfAtoms, ve
                 globals.insert(context.getParameters().begin(), context.getParameters().end());
                 break;
             }
-            case CustomIntegrator::BeginIfBlock: {
+            case CustomIntegrator::IfBlockStart: {
                 if (!evaluateCondition(step, globals))
                     nextStep = blockEnd[step]+1;
                 break;
             }
-            case CustomIntegrator::BeginWhileBlock: {
+            case CustomIntegrator::WhileBlockStart: {
                 if (!evaluateCondition(step, globals))
                     nextStep = blockEnd[step]+1;
                 break;
             }
-            case CustomIntegrator::EndBlock: {
+            case CustomIntegrator::BlockEnd: {
                 if (blockEnd[step] != -1)
                     nextStep = blockEnd[step]; // Return to the start of a while block.
                 break;


### PR DESCRIPTION
Fixes #1410.  For the benefit of Fortran, we can't have a method and an enum value whose names differ only in case.