### PR TITLE
Changed mechanism for setting barostat temperature

### DIFF
--- a/openmmapi/include/openmm/MonteCarloAnisotropicBarostat.h
+++ b/openmmapi/include/openmm/MonteCarloAnisotropicBarostat.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2010-2013 Stanford University and the Authors.      *
+ * Portions copyright (c) 2010-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman, Lee-Ping Wang                                      *
  * Contributors:                                                              *
  *                                                                            *
@@ -82,16 +82,24 @@ public:
         return key;
     }
     /**
+     * This is the name of the parameter which stores the current temperature at which the
+     * system is being maintained (in Kelvin)
+     */
+    static const std::string& Temperature() {
+        static const std::string key = "AnisotropicMonteCarloTemperature";
+        return key;
+    }
+    /**
      * Create a MonteCarloAnisotropicBarostat.
      *
-     * @param defaultPressure   The default pressure acting on each axis (in bar)
-     * @param temperature       the temperature at which the system is being maintained (in Kelvin)
-     * @param scaleX            whether to allow the X dimension of the periodic box to change size
-     * @param scaleY            whether to allow the Y dimension of the periodic box to change size
-     * @param scaleZ            whether to allow the Z dimension of the periodic box to change size
-     * @param frequency         the frequency at which Monte Carlo pressure changes should be attempted (in time steps)
+     * @param defaultPressure     The default pressure acting on each axis (in bar)
+     * @param defaultTemperature  the default temperature at which the system is being maintained (in Kelvin)
+     * @param scaleX              whether to allow the X dimension of the periodic box to change size
+     * @param scaleY              whether to allow the Y dimension of the periodic box to change size
+     * @param scaleZ              whether to allow the Z dimension of the periodic box to change size
+     * @param frequency           the frequency at which Monte Carlo pressure changes should be attempted (in time steps)
      */
-    MonteCarloAnisotropicBarostat(const Vec3& defaultPressure, double temperature, bool scaleX = true, bool scaleY = true, bool scaleZ = true, int frequency = 25);
+    MonteCarloAnisotropicBarostat(const Vec3& defaultPressure, double defaultTemperature, bool scaleX = true, bool scaleY = true, bool scaleZ = true, int frequency = 25);
     /**
      * Get the default pressure (in bar).
      *
@@ -142,18 +150,19 @@ public:
         frequency = freq;
     }
     /**
-     * Get the temperature at which the system is being maintained, measured in Kelvin.
+     * Get the default temperature at which the system is being maintained, measured in Kelvin.
      */
-    double getTemperature() const {
-        return temperature;
+    double getDefaultTemperature() const {
+        return defaultTemperature;
     }
     /**
-     * Set the temperature at which the system is being maintained.
+     * Set the default temperature at which the system is being maintained.  This will affect any new Contexts you create,
+     * but not ones that already exist.
      *
      * @param temp     the system temperature, measured in Kelvin.
      */
-    void setTemperature(double temp) {
-        temperature = temp;
+    void setDefaultTemperature(double temp) {
+        defaultTemperature = temp;
     }
     /**
      * Get the random number seed.  See setRandomNumberSeed() for details.
@@ -188,7 +197,7 @@ protected:
     ForceImpl* createImpl() const;
 private:
     Vec3 defaultPressure;
-    double temperature;
+    double defaultTemperature;
     bool scaleX, scaleY, scaleZ;
     int frequency, randomNumberSeed;
 };

--- a/openmmapi/include/openmm/MonteCarloBarostat.h
+++ b/openmmapi/include/openmm/MonteCarloBarostat.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2010 Stanford University and the Authors.           *
+ * Portions copyright (c) 2010-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -59,13 +59,21 @@ public:
         return key;
     }
     /**
+     * This is the name of the parameter which stores the current temperature at which the
+     * system is being maintained (in Kelvin)
+     */
+    static const std::string& Temperature() {
+        static const std::string key = "MonteCarloTemperature";
+        return key;
+    }
+    /**
      * Create a MonteCarloBarostat.
      *
-     * @param defaultPressure   the default pressure acting on the system (in bar)
-     * @param temperature       the temperature at which the system is being maintained (in Kelvin)
-     * @param frequency         the frequency at which Monte Carlo pressure changes should be attempted (in time steps)
+     * @param defaultPressure     the default pressure acting on the system (in bar)
+     * @param defaultTemperature  the default temperature at which the system is being maintained (in Kelvin)
+     * @param frequency           the frequency at which Monte Carlo pressure changes should be attempted (in time steps)
      */
-    MonteCarloBarostat(double defaultPressure, double temperature, int frequency = 25);
+    MonteCarloBarostat(double defaultPressure, double defaultTemperature, int frequency = 25);
     /**
      * Get the default pressure acting on the system (in bar).
      *
@@ -98,18 +106,19 @@ public:
         frequency = freq;
     }
     /**
-     * Get the temperature at which the system is being maintained, measured in Kelvin.
+     * Get the default temperature at which the system is being maintained, measured in Kelvin.
      */
-    double getTemperature() const {
-        return temperature;
+    double getDefaultTemperature() const {
+        return defaultTemperature;
     }
     /**
-     * Set the temperature at which the system is being maintained.
+     * Set the default temperature at which the system is being maintained.  This will affect any new Contexts you create,
+     * but not ones that already exist.
      *
      * @param temp     the system temperature, measured in Kelvin.
      */
-    void setTemperature(double temp) {
-        temperature = temp;
+    void setDefaultTemperature(double temp) {
+        defaultTemperature = temp;
     }
     /**
      * Get the random number seed.  See setRandomNumberSeed() for details.
@@ -143,7 +152,7 @@ public:
 protected:
     ForceImpl* createImpl() const;
 private:
-    double defaultPressure, temperature;
+    double defaultPressure, defaultTemperature;
     int frequency, randomNumberSeed;
 };
 

--- a/openmmapi/include/openmm/MonteCarloMembraneBarostat.h
+++ b/openmmapi/include/openmm/MonteCarloMembraneBarostat.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2010-2014 Stanford University and the Authors.      *
+ * Portions copyright (c) 2010-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -112,16 +112,24 @@ public:
         return key;
     }
     /**
+     * This is the name of the parameter which stores the current temperature at which the
+     * system is being maintained (in Kelvin)
+     */
+    static const std::string& Temperature() {
+        static const std::string key = "MembraneMonteCarloTemperature";
+        return key;
+    }
+    /**
      * Create a MonteCarloMembraneBarostat.
      *
      * @param defaultPressure        the default pressure acting on the system (in bar)
      * @param defaultSurfaceTension  the default surface tension acting on the system (in bar*nm)
-     * @param temperature            the temperature at which the system is being maintained (in Kelvin)
+     * @param defaultTemperature     the default temperature at which the system is being maintained (in Kelvin)
      * @param xymode                 the mode specifying the behavior of the X and Y axes
      * @param zmode                  the mode specifying the behavior of the Z axis
      * @param frequency              the frequency at which Monte Carlo volume changes should be attempted (in time steps)
      */
-    MonteCarloMembraneBarostat(double defaultPressure, double defaultSurfaceTension, double temperature, XYMode xymode, ZMode zmode, int frequency = 25);
+    MonteCarloMembraneBarostat(double defaultPressure, double defaultSurfaceTension, double defaultTemperature, XYMode xymode, ZMode zmode, int frequency = 25);
     /**
      * Get the default pressure acting on the system (in bar).
      *
@@ -171,18 +179,19 @@ public:
         frequency = freq;
     }
     /**
-     * Get the temperature at which the system is being maintained, measured in Kelvin.
+     * Get the default temperature at which the system is being maintained, measured in Kelvin.
      */
-    double getTemperature() const {
-        return temperature;
+    double getDefaultTemperature() const {
+        return defaultTemperature;
     }
     /**
-     * Set the temperature at which the system is being maintained.
+     * Set the default temperature at which the system is being maintained.  This will affect any new Contexts you create,
+     * but not ones that already exist.
      *
      * @param temp     the system temperature, measured in Kelvin.
      */
-    void setTemperature(double temp) {
-        temperature = temp;
+    void setDefaultTemperature(double temp) {
+        defaultTemperature = temp;
     }
     /**
      * Get the mode specifying the behavior of the X and Y axes.
@@ -240,7 +249,7 @@ public:
 protected:
     ForceImpl* createImpl() const;
 private:
-    double defaultPressure, defaultSurfaceTension, temperature;
+    double defaultPressure, defaultSurfaceTension, defaultTemperature;
     XYMode xymode;
     ZMode zmode;
     int frequency, randomNumberSeed;

--- a/openmmapi/src/MonteCarloAnisotropicBarostat.cpp
+++ b/openmmapi/src/MonteCarloAnisotropicBarostat.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2010 Stanford University and the Authors.           *
+ * Portions copyright (c) 2010-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -34,8 +34,8 @@
 
 using namespace OpenMM;
 
-MonteCarloAnisotropicBarostat::MonteCarloAnisotropicBarostat(const Vec3& defaultPressure, double temperature, bool scaleX, bool scaleY, bool scaleZ, int frequency) :
-        defaultPressure(defaultPressure), temperature(temperature), scaleX(scaleX), scaleY(scaleY), scaleZ(scaleZ), frequency(frequency) {
+MonteCarloAnisotropicBarostat::MonteCarloAnisotropicBarostat(const Vec3& defaultPressure, double defaultTemperature, bool scaleX, bool scaleY, bool scaleZ, int frequency) :
+        defaultPressure(defaultPressure), defaultTemperature(defaultTemperature), scaleX(scaleX), scaleY(scaleY), scaleZ(scaleZ), frequency(frequency) {
     setRandomNumberSeed(0);
 }
 

--- a/openmmapi/src/MonteCarloAnisotropicBarostatImpl.cpp
+++ b/openmmapi/src/MonteCarloAnisotropicBarostatImpl.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2010-2013 Stanford University and the Authors.      *
+ * Portions copyright (c) 2010-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman, Lee-Ping Wang                                      *
  * Contributors:                                                              *
  *                                                                            *
@@ -119,7 +119,7 @@ void MonteCarloAnisotropicBarostatImpl::updateContextState(ContextImpl& context)
     // Compute the energy of the modified system.
     
     double finalEnergy = context.getOwner().getState(State::Energy).getPotentialEnergy();
-    double kT = BOLTZ*owner.getTemperature();
+    double kT = BOLTZ*context.getParameter(MonteCarloAnisotropicBarostat::Temperature());
     double w = finalEnergy-initialEnergy + pressure*deltaVolume - context.getMolecules().size()*kT*std::log(newVolume/volume);
     if (w > 0 && genrand_real2(random) > std::exp(-w/kT)) {
         // Reject the step.
@@ -150,6 +150,7 @@ std::map<std::string, double> MonteCarloAnisotropicBarostatImpl::getDefaultParam
     parameters[MonteCarloAnisotropicBarostat::PressureX()] = getOwner().getDefaultPressure()[0];
     parameters[MonteCarloAnisotropicBarostat::PressureY()] = getOwner().getDefaultPressure()[1];
     parameters[MonteCarloAnisotropicBarostat::PressureZ()] = getOwner().getDefaultPressure()[2];
+    parameters[MonteCarloAnisotropicBarostat::Temperature()] = getOwner().getDefaultTemperature();
     return parameters;
 }
 

--- a/openmmapi/src/MonteCarloBarostat.cpp
+++ b/openmmapi/src/MonteCarloBarostat.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2010 Stanford University and the Authors.           *
+ * Portions copyright (c) 2010-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -34,8 +34,8 @@
 
 using namespace OpenMM;
 
-MonteCarloBarostat::MonteCarloBarostat(double defaultPressure, double temperature, int frequency) :
-        defaultPressure(defaultPressure), temperature(temperature), frequency(frequency) {
+MonteCarloBarostat::MonteCarloBarostat(double defaultPressure, double defaultTemperature, int frequency) :
+        defaultPressure(defaultPressure), defaultTemperature(defaultTemperature), frequency(frequency) {
     setRandomNumberSeed(0);
 }
 

--- a/openmmapi/src/MonteCarloBarostatImpl.cpp
+++ b/openmmapi/src/MonteCarloBarostatImpl.cpp
@@ -89,7 +89,7 @@ void MonteCarloBarostatImpl::updateContextState(ContextImpl& context) {
     
     double finalEnergy = context.getOwner().getState(State::Energy).getPotentialEnergy();
     double pressure = context.getParameter(MonteCarloBarostat::Pressure())*(AVOGADRO*1e-25);
-    double kT = BOLTZ*owner.getTemperature();
+    double kT = BOLTZ*context.getParameter(MonteCarloBarostat::Temperature());
     double w = finalEnergy-initialEnergy + pressure*deltaVolume - context.getMolecules().size()*kT*std::log(newVolume/volume);
     if (w > 0 && genrand_real2(random) > std::exp(-w/kT)) {
         // Reject the step.
@@ -118,6 +118,7 @@ void MonteCarloBarostatImpl::updateContextState(ContextImpl& context) {
 std::map<std::string, double> MonteCarloBarostatImpl::getDefaultParameters() {
     std::map<std::string, double> parameters;
     parameters[MonteCarloBarostat::Pressure()] = getOwner().getDefaultPressure();
+    parameters[MonteCarloBarostat::Temperature()] = getOwner().getDefaultTemperature();
     return parameters;
 }
 

--- a/openmmapi/src/MonteCarloMembraneBarostat.cpp
+++ b/openmmapi/src/MonteCarloMembraneBarostat.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2010-2014 Stanford University and the Authors.      *
+ * Portions copyright (c) 2010-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -34,8 +34,8 @@
 
 using namespace OpenMM;
 
-MonteCarloMembraneBarostat::MonteCarloMembraneBarostat(double defaultPressure, double defaultSurfaceTension, double temperature, XYMode xymode, ZMode zmode, int frequency) :
-        defaultPressure(defaultPressure), defaultSurfaceTension(defaultSurfaceTension), temperature(temperature),
+MonteCarloMembraneBarostat::MonteCarloMembraneBarostat(double defaultPressure, double defaultSurfaceTension, double defaultTemperature, XYMode xymode, ZMode zmode, int frequency) :
+        defaultPressure(defaultPressure), defaultSurfaceTension(defaultSurfaceTension), defaultTemperature(defaultTemperature),
         xymode(xymode), zmode(zmode), frequency(frequency) {
     setRandomNumberSeed(0);
 }

--- a/openmmapi/src/MonteCarloMembraneBarostatImpl.cpp
+++ b/openmmapi/src/MonteCarloMembraneBarostatImpl.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2010-2014 Stanford University and the Authors.      *
+ * Portions copyright (c) 2010-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman, Lee-Ping Wang                                      *
  * Contributors:                                                              *
  *                                                                            *
@@ -120,7 +120,7 @@ void MonteCarloMembraneBarostatImpl::updateContextState(ContextImpl& context) {
     // Compute the energy of the modified system.
     
     double finalEnergy = context.getOwner().getState(State::Energy).getPotentialEnergy();
-    double kT = BOLTZ*owner.getTemperature();
+    double kT = BOLTZ*context.getParameter(MonteCarloMembraneBarostat::Temperature());
     double w = finalEnergy-initialEnergy + pressure*deltaVolume - tension*deltaArea - context.getMolecules().size()*kT*std::log(newVolume/volume);
     if (w > 0 && genrand_real2(random) > std::exp(-w/kT)) {
         // Reject the step.
@@ -150,6 +150,7 @@ std::map<std::string, double> MonteCarloMembraneBarostatImpl::getDefaultParamete
     std::map<std::string, double> parameters;
     parameters[MonteCarloMembraneBarostat::Pressure()] = getOwner().getDefaultPressure();
     parameters[MonteCarloMembraneBarostat::SurfaceTension()] = getOwner().getDefaultSurfaceTension();
+    parameters[MonteCarloMembraneBarostat::Temperature()] = getOwner().getDefaultTemperature();
     return parameters;
 }
 

--- a/platforms/reference/tests/TestReferenceMonteCarloMembraneBarostat.cpp
+++ b/platforms/reference/tests/TestReferenceMonteCarloMembraneBarostat.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2014 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -82,7 +82,7 @@ void testIdealGas(MonteCarloMembraneBarostat::XYMode xymode, MonteCarloMembraneB
     // Test it for three different temperatures.
 
     for (int i = 0; i < 3; i++) {
-        barostat->setTemperature(temp[i]);
+        barostat->setDefaultTemperature(temp[i]);
         LangevinIntegrator integrator(temp[i], 0.1, 0.01);
         Context context(system, integrator, platform);
         context.setPositions(positions);

--- a/serialization/src/MonteCarloAnisotropicBarostatProxy.cpp
+++ b/serialization/src/MonteCarloAnisotropicBarostatProxy.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2010-2014 Stanford University and the Authors.      *
+ * Portions copyright (c) 2010-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -52,7 +52,7 @@ void MonteCarloAnisotropicBarostatProxy::serialize(const void* object, Serializa
     node.setBoolProperty("scalex", force.getScaleX());
     node.setBoolProperty("scaley", force.getScaleY());
     node.setBoolProperty("scalez", force.getScaleZ());
-    node.setDoubleProperty("temperature", force.getTemperature());
+    node.setDoubleProperty("temperature", force.getDefaultTemperature());
     node.setIntProperty("frequency", force.getFrequency());
     node.setIntProperty("randomSeed", force.getRandomNumberSeed());
 }

--- a/serialization/src/MonteCarloBarostatProxy.cpp
+++ b/serialization/src/MonteCarloBarostatProxy.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2010-2014 Stanford University and the Authors.      *
+ * Portions copyright (c) 2010-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -46,7 +46,7 @@ void MonteCarloBarostatProxy::serialize(const void* object, SerializationNode& n
     const MonteCarloBarostat& force = *reinterpret_cast<const MonteCarloBarostat*>(object);
     node.setIntProperty("forceGroup", force.getForceGroup());
     node.setDoubleProperty("pressure", force.getDefaultPressure());
-    node.setDoubleProperty("temperature", force.getTemperature());
+    node.setDoubleProperty("temperature", force.getDefaultTemperature());
     node.setIntProperty("frequency", force.getFrequency());
     node.setIntProperty("randomSeed", force.getRandomNumberSeed());
 }

--- a/serialization/src/MonteCarloMembraneBarostatProxy.cpp
+++ b/serialization/src/MonteCarloMembraneBarostatProxy.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2010-2014 Stanford University and the Authors.      *
+ * Portions copyright (c) 2010-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -47,7 +47,7 @@ void MonteCarloMembraneBarostatProxy::serialize(const void* object, Serializatio
     node.setIntProperty("forceGroup", force.getForceGroup());
     node.setDoubleProperty("pressure", force.getDefaultPressure());
     node.setDoubleProperty("surfaceTension", force.getDefaultSurfaceTension());
-    node.setDoubleProperty("temperature", force.getTemperature());
+    node.setDoubleProperty("temperature", force.getDefaultTemperature());
     node.setIntProperty("xymode", force.getXYMode());
     node.setIntProperty("zmode", force.getZMode());
     node.setIntProperty("frequency", force.getFrequency());

--- a/serialization/tests/TestSerializeMonteCarloAnisotropicBarostat.cpp
+++ b/serialization/tests/TestSerializeMonteCarloAnisotropicBarostat.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2010-2014 Stanford University and the Authors.      *
+ * Portions copyright (c) 2010-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -56,7 +56,7 @@ void testSerialization() {
     MonteCarloAnisotropicBarostat& force2 = *copy;
     ASSERT_EQUAL(force.getForceGroup(), force2.getForceGroup());
     ASSERT_EQUAL_VEC(force.getDefaultPressure(), force2.getDefaultPressure(), 0.0);
-    ASSERT_EQUAL(force.getTemperature(), force2.getTemperature());
+    ASSERT_EQUAL(force.getDefaultTemperature(), force2.getDefaultTemperature());
     ASSERT_EQUAL(force.getScaleX(), force2.getScaleX());
     ASSERT_EQUAL(force.getScaleY(), force2.getScaleY());
     ASSERT_EQUAL(force.getScaleZ(), force2.getScaleZ());

--- a/serialization/tests/TestSerializeMonteCarloBarostat.cpp
+++ b/serialization/tests/TestSerializeMonteCarloBarostat.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2010-2014 Stanford University and the Authors.      *
+ * Portions copyright (c) 2010-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -56,7 +56,7 @@ void testSerialization() {
     MonteCarloBarostat& force2 = *copy;
     ASSERT_EQUAL(force.getForceGroup(), force2.getForceGroup());
     ASSERT_EQUAL(force.getDefaultPressure(), force2.getDefaultPressure());
-    ASSERT_EQUAL(force.getTemperature(), force2.getTemperature());
+    ASSERT_EQUAL(force.getDefaultTemperature(), force2.getDefaultTemperature());
     ASSERT_EQUAL(force.getFrequency(), force2.getFrequency());
     ASSERT_EQUAL(force.getRandomNumberSeed(), force2.getRandomNumberSeed());
 }

--- a/serialization/tests/TestSerializeMonteCarloMembraneBarostat.cpp
+++ b/serialization/tests/TestSerializeMonteCarloMembraneBarostat.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2010-2014 Stanford University and the Authors.      *
+ * Portions copyright (c) 2010-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -57,7 +57,7 @@ void testSerialization() {
     ASSERT_EQUAL(force.getForceGroup(), force2.getForceGroup());
     ASSERT_EQUAL(force.getDefaultPressure(), force2.getDefaultPressure());
     ASSERT_EQUAL(force.getDefaultSurfaceTension(), force2.getDefaultSurfaceTension());
-    ASSERT_EQUAL(force.getTemperature(), force2.getTemperature());
+    ASSERT_EQUAL(force.getDefaultTemperature(), force2.getDefaultTemperature());
     ASSERT_EQUAL(force.getXYMode(), force2.getXYMode());
     ASSERT_EQUAL(force.getZMode(), force2.getZMode());
     ASSERT_EQUAL(force.getFrequency(), force2.getFrequency());

--- a/tests/TestMonteCarloAnisotropicBarostat.h
+++ b/tests/TestMonteCarloAnisotropicBarostat.h
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2015 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman, Lee-Ping Wang                                      *
  * Contributors:                                                              *
  *                                                                            *
@@ -75,7 +75,7 @@ void testIdealGas() {
     // Test it for three different temperatures.
     
     for (int i = 0; i < 3; i++) {
-        barostat->setTemperature(temp[i]);
+        barostat->setDefaultTemperature(temp[i]);
         LangevinIntegrator integrator(temp[i], 0.1, 0.01);
         Context context(system, integrator, platform);
         context.setPositions(positions);
@@ -135,7 +135,7 @@ void testIdealGasAxis(int axis) {
     // Test it for three different temperatures.
     
     for (int i = 0; i < 3; i++) {
-        barostat->setTemperature(temp[i]);
+        barostat->setDefaultTemperature(temp[i]);
         LangevinIntegrator integrator(temp[i], 0.1, 0.01);
         Context context(system, integrator, platform);
         context.setPositions(positions);
@@ -371,7 +371,7 @@ void testEinsteinCrystal() {
             // Create the barostat.
             MonteCarloAnisotropicBarostat* barostat = new MonteCarloAnisotropicBarostat(Vec3(pres3[p], pres3[p], pres3[p]), temp, (a==0||a==3), (a==1||a==3), (a==2||a==3), frequency);
             system.addForce(barostat);
-            barostat->setTemperature(temp);
+            barostat->setDefaultTemperature(temp);
             LangevinIntegrator integrator(temp, 0.1, 0.01);
             Context context(system, integrator, platform);
             context.setPositions(positions);
@@ -417,7 +417,7 @@ void testEinsteinCrystal() {
         // Create the barostat.
         MonteCarloBarostat* barostat = new MonteCarloBarostat(pres3[p], temp, frequency);
         system.addForce(barostat);
-        barostat->setTemperature(temp);
+        barostat->setDefaultTemperature(temp);
         LangevinIntegrator integrator(temp, 0.1, 0.001);
         Context context(system, integrator, platform);
         context.setPositions(positions);

--- a/tests/TestMonteCarloBarostat.h
+++ b/tests/TestMonteCarloBarostat.h
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2015 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -111,7 +111,7 @@ void testIdealGas() {
     // Test it for three different temperatures.
 
     for (int i = 0; i < 3; i++) {
-        barostat->setTemperature(temp[i]);
+        barostat->setDefaultTemperature(temp[i]);
         LangevinIntegrator integrator(temp[i], 0.1, 0.01);
         Context context(system, integrator, platform);
         context.setPositions(positions);


### PR DESCRIPTION
This addresses at least part of #1440.  The barostats now have a "default temperature" attribute instead of "temperature", and they define a context parameter for changing the temperature in the middle of a simulation.

Note that this breaks backward compatibility!  Hopefully it will affect very few people, but it's still important to be aware of.