### PR TITLE
Fixed edge case with 2D and 3D continuous functions

### DIFF
--- a/platforms/cuda/src/CudaExpressionUtilities.cpp
+++ b/platforms/cuda/src/CudaExpressionUtilities.cpp
@@ -174,8 +174,8 @@ void CudaExpressionUtilities::processExpression(stringstream& out, const Express
                     out << "if (x >= " << paramsFloat[2] << " && x <= " << paramsFloat[3] << " && y >= " << paramsFloat[4] << " && y <= " << paramsFloat[5] << ") {\n";
                     out << "x = (x - " << paramsFloat[2] << ")*" << paramsFloat[6] << ";\n";
                     out << "y = (y - " << paramsFloat[4] << ")*" << paramsFloat[7] << ";\n";
-                    out << "int s = min((int) floor(x), " << paramsInt[0] << ");\n";
-                    out << "int t = min((int) floor(y), " << paramsInt[1] << ");\n";
+                    out << "int s = min((int) floor(x), " << paramsInt[0] << "-1);\n";
+                    out << "int t = min((int) floor(y), " << paramsInt[1] << "-1);\n";
                     out << "int coeffIndex = 4*(s+" << paramsInt[0] << "*t);\n";
                     out << "float4 c[4];\n";
                     for (int j = 0; j < 4; j++)
@@ -217,9 +217,9 @@ void CudaExpressionUtilities::processExpression(stringstream& out, const Express
                     out << "x = (x - " << paramsFloat[3] << ")*" << paramsFloat[9] << ";\n";
                     out << "y = (y - " << paramsFloat[5] << ")*" << paramsFloat[10] << ";\n";
                     out << "z = (z - " << paramsFloat[7] << ")*" << paramsFloat[11] << ";\n";
-                    out << "int s = min((int) floor(x), " << paramsInt[0] << ");\n";
-                    out << "int t = min((int) floor(y), " << paramsInt[1] << ");\n";
-                    out << "int u = min((int) floor(z), " << paramsInt[2] << ");\n";
+                    out << "int s = min((int) floor(x), " << paramsInt[0] << "-1);\n";
+                    out << "int t = min((int) floor(y), " << paramsInt[1] << "-1);\n";
+                    out << "int u = min((int) floor(z), " << paramsInt[2] << "-1);\n";
                     out << "int coeffIndex = 16*(s+" << paramsInt[0] << "*(t+" << paramsInt[1] << "*u));\n";
                     out << "float4 c[16];\n";
                     for (int j = 0; j < 16; j++)

--- a/platforms/opencl/src/OpenCLExpressionUtilities.cpp
+++ b/platforms/opencl/src/OpenCLExpressionUtilities.cpp
@@ -174,8 +174,8 @@ void OpenCLExpressionUtilities::processExpression(stringstream& out, const Expre
                     out << "if (x >= " << paramsFloat[2] << " && x <= " << paramsFloat[3] << " && y >= " << paramsFloat[4] << " && y <= " << paramsFloat[5] << ") {\n";
                     out << "x = (x - " << paramsFloat[2] << ")*" << paramsFloat[6] << ";\n";
                     out << "y = (y - " << paramsFloat[4] << ")*" << paramsFloat[7] << ";\n";
-                    out << "int s = min((int) floor(x), " << paramsInt[0] << ");\n";
-                    out << "int t = min((int) floor(y), " << paramsInt[1] << ");\n";
+                    out << "int s = min((int) floor(x), " << paramsInt[0] << "-1);\n";
+                    out << "int t = min((int) floor(y), " << paramsInt[1] << "-1);\n";
                     out << "int coeffIndex = 4*(s+" << paramsInt[0] << "*t);\n";
                     out << "float4 c[4];\n";
                     for (int j = 0; j < 4; j++)
@@ -217,9 +217,9 @@ void OpenCLExpressionUtilities::processExpression(stringstream& out, const Expre
                     out << "x = (x - " << paramsFloat[3] << ")*" << paramsFloat[9] << ";\n";
                     out << "y = (y - " << paramsFloat[5] << ")*" << paramsFloat[10] << ";\n";
                     out << "z = (z - " << paramsFloat[7] << ")*" << paramsFloat[11] << ";\n";
-                    out << "int s = min((int) floor(x), " << paramsInt[0] << ");\n";
-                    out << "int t = min((int) floor(y), " << paramsInt[1] << ");\n";
-                    out << "int u = min((int) floor(z), " << paramsInt[2] << ");\n";
+                    out << "int s = min((int) floor(x), " << paramsInt[0] << "-1);\n";
+                    out << "int t = min((int) floor(y), " << paramsInt[1] << "-1);\n";
+                    out << "int u = min((int) floor(z), " << paramsInt[2] << "-1);\n";
                     out << "int coeffIndex = 16*(s+" << paramsInt[0] << "*(t+" << paramsInt[1] << "*u));\n";
                     out << "float4 c[16];\n";
                     for (int j = 0; j < 16; j++)

--- a/tests/TestCustomCompoundBondForce.h
+++ b/tests/TestCustomCompoundBondForce.h
@@ -171,7 +171,7 @@ void testContinuous2DFunction() {
     const double xmin = 0.4;
     const double xmax = 1.1;
     const double ymin = 0.0;
-    const double ymax = 0.9;
+    const double ymax = 0.95;
     System system;
     system.addParticle(1.0);
     VerletIntegrator integrator(0.01);
@@ -218,7 +218,7 @@ void testContinuous3DFunction() {
     const double ymin = 2.0;
     const double ymax = 2.9;
     const double zmin = 0.2;
-    const double zmax = 1.3;
+    const double zmax = 1.35;
     System system;
     system.addParticle(1.0);
     VerletIntegrator integrator(0.01);


### PR DESCRIPTION
Fixes #1476.  This error occurred when the argument to a tabulated function was *exactly* equal to its upper limit.  In that case, there was an indexing error and coefficients were read from the wrong memory location (often leading to a nan).

This only affected 2D and 3D functions, not 1D ones, and only on the CUDA and OpenCL platforms.  It also only affected continuous functions, not discrete ones.