### PR TITLE
Fixed error with PME when particles are exactly on top of each other

### DIFF
--- a/platforms/cuda/src/kernels/coulombLennardJones.cu
+++ b/platforms/cuda/src/kernels/coulombLennardJones.cu
@@ -25,6 +25,8 @@
             tempForce = -prefactor*(erfAlphaR-alphaR*expAlphaRSqr*TWO_OVER_SQRT_PI);
             tempEnergy += -prefactor*erfAlphaR;
         }
+        else
+            includeInteraction = false;
     }
     else {
 #if HAS_LENNARD_JONES

--- a/platforms/opencl/src/kernels/coulombLennardJones.cl
+++ b/platforms/opencl/src/kernels/coulombLennardJones.cl
@@ -30,6 +30,8 @@
             tempForce = -prefactor*(erfAlphaR-alphaR*expAlphaRSqr*TWO_OVER_SQRT_PI);
             tempEnergy += -prefactor*erfAlphaR;
         }
+        else
+            includeInteraction = false;
     }
     else {
 #if HAS_LENNARD_JONES


### PR DESCRIPTION
When you used PME, and when two particles whose interaction was excluded had *exactly* the same position, this caused the force to be nan.  The main situation where this could come up is with Drude particles.