### PR TITLE
Energy derivatives with respect to global parameters

### DIFF
--- a/docs-source/usersguide/theory.rst
+++ b/docs-source/usersguide/theory.rst
@@ -1086,6 +1086,24 @@ is exactly equivalent to
 The definition of an intermediate value may itself involve other intermediate
 values.  All uses of a value must appear *before* that value’s definition.
 
+Parameter Derivatives
+*********************
+
+Many custom forces have the ability to compute derivatives of the potential energy
+with respect to global parameters.  To use this feature, first define a global
+parameter that the energy depends on.  Then instruct the custom force to compute
+the derivative with respect to that parameter by calling :meth:`addEnergyParameterDerivative()`
+on it.  Whenever forces and energies are computed, the specified derivative will
+then also be computed at the same time.  You can query it by calling :meth:`getState()`
+on a :class:`Context`, just as you would query forces or energies.
+
+An important application of this feature is to use it in combination with a
+:class:`CustomIntegrator` (described in section :ref:`custom-integrator`\ ).  The
+derivative can appear directly in expressions that define the integration
+algorithm.  This can be used to implement algorithms such as lambda-dynamics,
+where a global parameter is integrated as a dynamic variable.
+
+
 Integrators
 ###########
 
@@ -1234,6 +1252,8 @@ the fixed step size Langevin integrator for the reasons given above.
 Furthermore, because Langevin dynamics involves a random force, it can never be
 symplectic and therefore the fixed step size Verlet integrator’s advantages do
 not apply to the Langevin integrator.
+
+.. _custom-integrator:
 
 CustomIntegrator
 ****************

--- a/libraries/lepton/include/lepton/CustomFunction.h
+++ b/libraries/lepton/include/lepton/CustomFunction.h
@@ -48,7 +48,7 @@ public:
     virtual ~CustomFunction() {
     }
     /**
-     * Get the number of arguments this function exprects.
+     * Get the number of arguments this function expects.
      */
     virtual int getNumArguments() const = 0;
     /**

--- a/libraries/lepton/src/ParsedExpression.cpp
+++ b/libraries/lepton/src/ParsedExpression.cpp
@@ -109,7 +109,7 @@ ExpressionTreeNode ParsedExpression::precalculateConstantSubexpressions(const Ex
     for (int i = 0; i < (int) children.size(); i++)
         children[i] = precalculateConstantSubexpressions(node.getChildren()[i]);
     ExpressionTreeNode result = ExpressionTreeNode(node.getOperation().clone(), children);
-    if (node.getOperation().getId() == Operation::VARIABLE)
+    if (node.getOperation().getId() == Operation::VARIABLE || node.getOperation().getId() == Operation::CUSTOM)
         return result;
     for (int i = 0; i < (int) children.size(); i++)
         if (children[i].getOperation().getId() != Operation::CONSTANT)

--- a/olla/include/openmm/kernels.h
+++ b/olla/include/openmm/kernels.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2015 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -172,6 +172,12 @@ public:
      * @param forces  on exit, this contains the forces
      */
     virtual void getForces(ContextImpl& context, std::vector<Vec3>& forces) = 0;
+    /**
+     * Get the current derivatives of the energy with respect to context parameters.
+     *
+     * @param derivs  on exit, this contains the derivatives
+     */
+    virtual void getEnergyParameterDerivatives(ContextImpl& context, std::map<std::string, double>& derivs) = 0;
     /**
      * Get the current periodic box vectors.
      *

--- a/openmmapi/include/openmm/CustomAngleForce.h
+++ b/openmmapi/include/openmm/CustomAngleForce.h
@@ -63,6 +63,10 @@ namespace OpenMM {
  * force->addPerAngleParameter("k");
  * force->addPerAngleParameter("theta0");
  * </pre></tt>
+ * 
+ * This class also has the ability to compute derivatives of the potential energy with respect to global parameters.
+ * Call addEnergyParameterDerivative() to request that the derivative with respect to a particular parameter be
+ * computed.  You can then query its value in a Context by calling getState() on it.
  *
  * Expressions may involve the operators + (add), - (subtract), * (multiply), / (divide), and ^ (power), and the following
  * functions: sqrt, exp, log, sin, cos, sec, csc, tan, cot, asin, acos, atan, sinh, cosh, tanh, erf, erfc, min, max, abs, floor, ceil, step, delta, select.  All trigonometric functions
@@ -96,6 +100,13 @@ public:
      */
     int getNumGlobalParameters() const {
         return globalParameters.size();
+    }
+    /**
+     * Get the number of global parameters with respect to which the derivative of the energy
+     * should be computed.
+     */
+    int getNumEnergyParameterDerivatives() const {
+        return energyParameterDerivatives.size();
     }
     /**
      * Get the algebraic expression that gives the interaction energy for each angle
@@ -163,6 +174,21 @@ public:
      */
     void setGlobalParameterDefaultValue(int index, double defaultValue);
     /**
+     * Request that this Force compute the derivative of its energy with respect to a global parameter.
+     * The parameter must have already been added with addGlobalParameter().
+     *
+     * @param name             the name of the parameter
+     */
+    void addEnergyParameterDerivative(const std::string& name);
+    /**
+     * Get the name of a global parameter with respect to which this Force should compute the
+     * derivative of the energy.
+     *
+     * @param index     the index of the parameter derivative, between 0 and getNumEnergyParameterDerivatives()
+     * @return the parameter name
+     */
+    const std::string& getEnergyParameterDerivativeName(int index) const;
+    /**
      * Add an angle term to the force field.
      *
      * @param particle1     the index of the first particle connected by the angle
@@ -225,6 +251,7 @@ private:
     std::vector<AngleParameterInfo> parameters;
     std::vector<GlobalParameterInfo> globalParameters;
     std::vector<AngleInfo> angles;
+    std::vector<int> energyParameterDerivatives;
     bool usePeriodic;
 };
 

--- a/openmmapi/include/openmm/CustomBondForce.h
+++ b/openmmapi/include/openmm/CustomBondForce.h
@@ -63,6 +63,10 @@ namespace OpenMM {
  * force->addPerBondParameter("k");
  * force->addPerBondParameter("r0");
  * </pre></tt>
+ * 
+ * This class also has the ability to compute derivatives of the potential energy with respect to global parameters.
+ * Call addEnergyParameterDerivative() to request that the derivative with respect to a particular parameter be
+ * computed.  You can then query its value in a Context by calling getState() on it.
  *
  * Expressions may involve the operators + (add), - (subtract), * (multiply), / (divide), and ^ (power), and the following
  * functions: sqrt, exp, log, sin, cos, sec, csc, tan, cot, asin, acos, atan, sinh, cosh, tanh, erf, erfc, min, max, abs, floor, ceil, step, delta, select.  All trigonometric functions
@@ -96,6 +100,13 @@ public:
      */
     int getNumGlobalParameters() const {
         return globalParameters.size();
+    }
+    /**
+     * Get the number of global parameters with respect to which the derivative of the energy
+     * should be computed.
+     */
+    int getNumEnergyParameterDerivatives() const {
+        return energyParameterDerivatives.size();
     }
     /**
      * Get the algebraic expression that gives the interaction energy for each bond
@@ -163,6 +174,21 @@ public:
      */
     void setGlobalParameterDefaultValue(int index, double defaultValue);
     /**
+     * Request that this Force compute the derivative of its energy with respect to a global parameter.
+     * The parameter must have already been added with addGlobalParameter().
+     *
+     * @param name             the name of the parameter
+     */
+    void addEnergyParameterDerivative(const std::string& name);
+    /**
+     * Get the name of a global parameter with respect to which this Force should compute the
+     * derivative of the energy.
+     *
+     * @param index     the index of the parameter derivative, between 0 and getNumEnergyParameterDerivatives()
+     * @return the parameter name
+     */
+    const std::string& getEnergyParameterDerivativeName(int index) const;
+    /**
      * Add a bond term to the force field.
      *
      * @param particle1     the index of the first particle connected by the bond
@@ -222,6 +248,7 @@ private:
     std::vector<BondParameterInfo> parameters;
     std::vector<GlobalParameterInfo> globalParameters;
     std::vector<BondInfo> bonds;
+    std::vector<int> energyParameterDerivatives;
     bool usePeriodic;
 };
 

--- a/openmmapi/include/openmm/CustomCentroidBondForce.h
+++ b/openmmapi/include/openmm/CustomCentroidBondForce.h
@@ -98,6 +98,10 @@ namespace OpenMM {
  * bondParameters.push_back(k);
  * force->addBond(bondGroups, bondParameters);
  * </pre></tt>
+ * 
+ * This class also has the ability to compute derivatives of the potential energy with respect to global parameters.
+ * Call addEnergyParameterDerivative() to request that the derivative with respect to a particular parameter be
+ * computed.  You can then query its value in a Context by calling getState() on it.
  *
  * Expressions may involve the operators + (add), - (subtract), * (multiply), / (divide), and ^ (power), and the following
  * functions: sqrt, exp, log, sin, cos, sec, csc, tan, cot, asin, acos, atan, sinh, cosh, tanh, erf, erfc, min, max, abs, floor, ceil, step, delta, select.  All trigonometric functions
@@ -149,6 +153,13 @@ public:
      */
     int getNumGlobalParameters() const {
         return globalParameters.size();
+    }
+    /**
+     * Get the number of global parameters with respect to which the derivative of the energy
+     * should be computed.
+     */
+    int getNumEnergyParameterDerivatives() const {
+        return energyParameterDerivatives.size();
     }
     /**
      * Get the number of tabulated functions that have been defined.
@@ -229,6 +240,21 @@ public:
      * @param defaultValue   the default value of the parameter
      */
     void setGlobalParameterDefaultValue(int index, double defaultValue);
+    /**
+     * Request that this Force compute the derivative of its energy with respect to a global parameter.
+     * The parameter must have already been added with addGlobalParameter().
+     *
+     * @param name             the name of the parameter
+     */
+    void addEnergyParameterDerivative(const std::string& name);
+    /**
+     * Get the name of a global parameter with respect to which this Force should compute the
+     * derivative of the energy.
+     *
+     * @param index     the index of the parameter derivative, between 0 and getNumEnergyParameterDerivatives()
+     * @return the parameter name
+     */
+    const std::string& getEnergyParameterDerivativeName(int index) const;
     /**
      * Add a particle group.
      *
@@ -351,6 +377,7 @@ private:
     std::vector<GroupInfo> groups;
     std::vector<BondInfo> bonds;
     std::vector<FunctionInfo> functions;
+    std::vector<int> energyParameterDerivatives;
     bool usePeriodic;
 };
 

--- a/openmmapi/include/openmm/CustomCompoundBondForce.h
+++ b/openmmapi/include/openmm/CustomCompoundBondForce.h
@@ -87,6 +87,10 @@ namespace OpenMM {
  * force->addPerBondParameter("theta0");
  * force->addPerBondParameter("r0");
  * </pre></tt>
+ * 
+ * This class also has the ability to compute derivatives of the potential energy with respect to global parameters.
+ * Call addEnergyParameterDerivative() to request that the derivative with respect to a particular parameter be
+ * computed.  You can then query its value in a Context by calling getState() on it.
  *
  * Expressions may involve the operators + (add), - (subtract), * (multiply), / (divide), and ^ (power), and the following
  * functions: sqrt, exp, log, sin, cos, sec, csc, tan, cot, asin, acos, atan, sinh, cosh, tanh, erf, erfc, min, max, abs, floor, ceil, step, delta, select.  All trigonometric functions
@@ -132,6 +136,13 @@ public:
      */
     int getNumGlobalParameters() const {
         return globalParameters.size();
+    }
+    /**
+     * Get the number of global parameters with respect to which the derivative of the energy
+     * should be computed.
+     */
+    int getNumEnergyParameterDerivatives() const {
+        return energyParameterDerivatives.size();
     }
     /**
      * Get the number of tabulated functions that have been defined.
@@ -212,6 +223,21 @@ public:
      * @param defaultValue   the default value of the parameter
      */
     void setGlobalParameterDefaultValue(int index, double defaultValue);
+    /**
+     * Request that this Force compute the derivative of its energy with respect to a global parameter.
+     * The parameter must have already been added with addGlobalParameter().
+     *
+     * @param name             the name of the parameter
+     */
+    void addEnergyParameterDerivative(const std::string& name);
+    /**
+     * Get the name of a global parameter with respect to which this Force should compute the
+     * derivative of the energy.
+     *
+     * @param index     the index of the parameter derivative, between 0 and getNumEnergyParameterDerivatives()
+     * @return the parameter name
+     */
+    const std::string& getEnergyParameterDerivativeName(int index) const;
     /**
      * Add a bond to the force
      *
@@ -323,6 +349,7 @@ private:
     std::vector<GlobalParameterInfo> globalParameters;
     std::vector<BondInfo> bonds;
     std::vector<FunctionInfo> functions;
+    std::vector<int> energyParameterDerivatives;
     bool usePeriodic;
 };
 

--- a/openmmapi/include/openmm/CustomGBForce.h
+++ b/openmmapi/include/openmm/CustomGBForce.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2014 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -127,6 +127,10 @@ namespace OpenMM {
  * omitted from calculations.  This is most often used for particles that are bonded to each other.  Even if you specify exclusions,
  * however, you can use the computation type ParticlePairNoExclusions to indicate that exclusions should not be applied to a
  * particular piece of the computation.
+ * 
+ * This class also has the ability to compute derivatives of the potential energy with respect to global parameters.
+ * Call addEnergyParameterDerivative() to request that the derivative with respect to a particular parameter be
+ * computed.  You can then query its value in a Context by calling getState() on it.
  *
  * Expressions may involve the operators + (add), - (subtract), * (multiply), / (divide), and ^ (power), and the following
  * functions: sqrt, exp, log, sin, cos, sec, csc, tan, cot, asin, acos, atan, sinh, cosh, tanh, erf, erfc, min, max, abs, floor, ceil, step, delta, select.  All trigonometric functions
@@ -206,6 +210,13 @@ public:
      */
     int getNumGlobalParameters() const {
         return globalParameters.size();
+    }
+    /**
+     * Get the number of global parameters with respect to which the derivative of the energy
+     * should be computed.
+     */
+    int getNumEnergyParameterDerivatives() const {
+        return energyParameterDerivatives.size();
     }
     /**
      * Get the number of tabulated functions that have been defined.
@@ -312,6 +323,21 @@ public:
      * @param defaultValue  the default value of the parameter
      */
     void setGlobalParameterDefaultValue(int index, double defaultValue);
+    /**
+     * Request that this Force compute the derivative of its energy with respect to a global parameter.
+     * The parameter must have already been added with addGlobalParameter().
+     *
+     * @param name             the name of the parameter
+     */
+    void addEnergyParameterDerivative(const std::string& name);
+    /**
+     * Get the name of a global parameter with respect to which this Force should compute the
+     * derivative of the energy.
+     *
+     * @param index     the index of the parameter derivative, between 0 and getNumEnergyParameterDerivatives()
+     * @return the parameter name
+     */
+    const std::string& getEnergyParameterDerivativeName(int index) const;
     /**
      * Add the nonbonded force parameters for a particle.  This should be called once for each particle
      * in the System.  When it is called for the i'th time, it specifies the parameters for the i'th particle.
@@ -550,6 +576,7 @@ private:
     std::vector<FunctionInfo> functions;
     std::vector<ComputationInfo> computedValues;
     std::vector<ComputationInfo> energyTerms;
+    std::vector<int> energyParameterDerivatives;
 };
 
 /**

--- a/openmmapi/include/openmm/CustomIntegrator.h
+++ b/openmmapi/include/openmm/CustomIntegrator.h
@@ -201,6 +201,16 @@ namespace OpenMM {
  * only involve global variables, not per-DOF ones.  It may use any of the
  * following comparison operators: =, <. >, !=, <=, >=.  Blocks may be nested
  * inside each other.
+ * 
+ * Another feature of CustomIntegrator is that it can use derivatives of the
+ * potential energy with respect to context parameters.  These derivatives are
+ * typically computed by custom forces, and are only computed if a Force object
+ * has been specifically told to compute them by calling addEnergyParameterDerivative()
+ * on it.  CustomIntegrator provides a deriv() function for accessing these
+ * derivatives in global or per-DOF expressions.  For example, "deriv(energy, lambda)"
+ * is the derivative of the total potentially energy with respect to the parameter
+ * lambda.  You can also restrict it to a single force group by specifying a different
+ * variable for the first argument, such as "deriv(energy1, lambda)".
  *
  * An Integrator has one other job in addition to evolving the equations of motion:
  * it defines how to compute the kinetic energy of the system.  Depending on the

--- a/openmmapi/include/openmm/CustomNonbondedForce.h
+++ b/openmmapi/include/openmm/CustomNonbondedForce.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2014 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -118,6 +118,10 @@ namespace OpenMM {
  * at the start of the simulation.  Furthermore, that precomputation must be repeated every time a global parameter changes
  * (or when you modify per-particle parameters by calling updateParametersInContext()).  This means that if parameters change
  * frequently, the long range correction can be very slow.  For this reason, it is disabled by default.
+ * 
+ * This class also has the ability to compute derivatives of the potential energy with respect to global parameters.
+ * Call addEnergyParameterDerivative() to request that the derivative with respect to a particular parameter be
+ * computed.  You can then query its value in a Context by calling getState() on it.
  *
  * Expressions may involve the operators + (add), - (subtract), * (multiply), / (divide), and ^ (power), and the following
  * functions: sqrt, exp, log, sin, cos, sec, csc, tan, cot, asin, acos, atan, sinh, cosh, tanh, erf, erfc, min, max, abs, floor, ceil, step, delta, select.  All trigonometric functions
@@ -203,6 +207,13 @@ public:
      */
     int getNumInteractionGroups() const {
         return interactionGroups.size();
+    }
+    /**
+     * Get the number of global parameters with respect to which the derivative of the energy
+     * should be computed.
+     */
+    int getNumEnergyParameterDerivatives() const {
+        return energyParameterDerivatives.size();
     }
     /**
      * Get the algebraic expression that gives the interaction energy between two particles
@@ -321,6 +332,21 @@ public:
      * @param defaultValue   the default value of the parameter
      */
     void setGlobalParameterDefaultValue(int index, double defaultValue);
+    /**
+     * Request that this Force compute the derivative of its energy with respect to a global parameter.
+     * The parameter must have already been added with addGlobalParameter().
+     *
+     * @param name             the name of the parameter
+     */
+    void addEnergyParameterDerivative(const std::string& name);
+    /**
+     * Get the name of a global parameter with respect to which this Force should compute the
+     * derivative of the energy.
+     *
+     * @param index     the index of the parameter derivative, between 0 and getNumEnergyParameterDerivatives()
+     * @return the parameter name
+     */
+    const std::string& getEnergyParameterDerivativeName(int index) const;
     /**
      * Add the nonbonded force parameters for a particle.  This should be called once for each particle
      * in the System.  When it is called for the i'th time, it specifies the parameters for the i'th particle.
@@ -494,6 +520,7 @@ private:
     std::vector<ExclusionInfo> exclusions;
     std::vector<FunctionInfo> functions;
     std::vector<InteractionGroupInfo> interactionGroups;
+    std::vector<int> energyParameterDerivatives;
 };
 
 /**

--- a/openmmapi/include/openmm/CustomTorsionForce.h
+++ b/openmmapi/include/openmm/CustomTorsionForce.h
@@ -63,6 +63,10 @@ namespace OpenMM {
  * force->addPerTorsionParameter("k");
  * force->addPerTorsionParameter("theta0");
  * </pre></tt>
+ * 
+ * This class also has the ability to compute derivatives of the potential energy with respect to global parameters.
+ * Call addEnergyParameterDerivative() to request that the derivative with respect to a particular parameter be
+ * computed.  You can then query its value in a Context by calling getState() on it.
  *
  * Expressions may involve the operators + (add), - (subtract), * (multiply), / (divide), and ^ (power), and the following
  * functions: sqrt, exp, log, sin, cos, sec, csc, tan, cot, asin, acos, atan, sinh, cosh, tanh, erf, erfc, min, max, abs, floor, ceil, step, delta, select.  All trigonometric functions
@@ -96,6 +100,13 @@ public:
      */
     int getNumGlobalParameters() const {
         return globalParameters.size();
+    }
+    /**
+     * Get the number of global parameters with respect to which the derivative of the energy
+     * should be computed.
+     */
+    int getNumEnergyParameterDerivatives() const {
+        return energyParameterDerivatives.size();
     }
     /**
      * Get the algebraic expression that gives the interaction energy for each torsion
@@ -163,6 +174,21 @@ public:
      */
     void setGlobalParameterDefaultValue(int index, double defaultValue);
     /**
+     * Request that this Force compute the derivative of its energy with respect to a global parameter.
+     * The parameter must have already been added with addGlobalParameter().
+     *
+     * @param name             the name of the parameter
+     */
+    void addEnergyParameterDerivative(const std::string& name);
+    /**
+     * Get the name of a global parameter with respect to which this Force should compute the
+     * derivative of the energy.
+     *
+     * @param index     the index of the parameter derivative, between 0 and getNumEnergyParameterDerivatives()
+     * @return the parameter name
+     */
+    const std::string& getEnergyParameterDerivativeName(int index) const;
+    /**
      * Add a torsion term to the force field.
      *
      * @param particle1     the index of the first particle connected by the torsion
@@ -228,6 +254,7 @@ private:
     std::vector<TorsionParameterInfo> parameters;
     std::vector<GlobalParameterInfo> globalParameters;
     std::vector<TorsionInfo> torsions;
+    std::vector<int> energyParameterDerivatives;
     bool usePeriodic;
 };
 

--- a/openmmapi/include/openmm/State.h
+++ b/openmmapi/include/openmm/State.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008 Stanford University and the Authors.           *
+ * Portions copyright (c) 2008-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -58,7 +58,7 @@ public:
      * This is an enumeration of the types of data which may be stored in a State.  When you create
      * a State, use these values to specify which data types it should contain.
      */
-    enum DataType {Positions=1, Velocities=2, Forces=4, Energy=8, Parameters=16};
+    enum DataType {Positions=1, Velocities=2, Forces=4, Energy=8, Parameters=16, ParameterDerivatives=32};
     /**
      * Construct an empty State containing no data.  This exists so State objects can be used in STL containers.
      */
@@ -109,6 +109,17 @@ public:
      */
     const std::map<std::string, double>& getParameters() const;
     /**
+     * Get a map containing derivatives of the potential energy with respect to context parameters.
+     * In most cases derivatives are only calculated if the corresponding Force objects have been
+     * specifically told to compute them.  Otherwise, the values in the map will be zero.  Likewise,
+     * if multiple Forces depend on the same parameter but only some have been told to compute
+     * derivatives with respect to it, the returned value will include only the contributions from
+     * the Forces that were told to compute it.
+     * 
+     * If this State does not contain parameter derivatives, this will throw an exception.
+     */
+    const std::map<std::string, double>& getEnergyParameterDerivatives() const;
+    /**
      * Get which data types are stored in this State.  The return value is a sum of DataType flags.
      */
     int getDataTypes() const;
@@ -118,6 +129,7 @@ private:
     void setVelocities(const std::vector<Vec3>& vel);
     void setForces(const std::vector<Vec3>& force);
     void setParameters(const std::map<std::string, double>& params);
+    void setEnergyParameterDerivatives(const std::map<std::string, double>& derivs);
     void setEnergy(double ke, double pe);
     void setPeriodicBoxVectors(const Vec3& a, const Vec3& b, const Vec3& c);
     int types;
@@ -126,7 +138,7 @@ private:
     std::vector<Vec3> velocities;
     std::vector<Vec3> forces;
     Vec3 periodicBoxVectors[3];
-    std::map<std::string, double> parameters;
+    std::map<std::string, double> parameters, energyParameterDerivatives;
 };
 
 /**
@@ -142,6 +154,7 @@ public:
     void setVelocities(const std::vector<Vec3>& vel);
     void setForces(const std::vector<Vec3>& force);
     void setParameters(const std::map<std::string, double>& params);
+    void setEnergyParameterDerivatives(const std::map<std::string, double>& params);
     void setEnergy(double ke, double pe);
     void setPeriodicBoxVectors(const Vec3& a, const Vec3& b, const Vec3& c);
 private:

--- a/openmmapi/include/openmm/internal/ContextImpl.h
+++ b/openmmapi/include/openmm/internal/ContextImpl.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2013 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -138,6 +138,10 @@ public:
      * @param value the value of the parameter
      */
     void setParameter(std::string name, double value);
+    /**
+     * Get the derivatives of the energy with respect to parameters.
+     */
+    void getEnergyParameterDerivatives(std::map<std::string, double>& derivs);
     /**
      * Get the vectors defining the axes of the periodic box (measured in nm).  They will affect
      * any Force that uses periodic boundary conditions.

--- a/openmmapi/include/openmm/internal/CustomIntegratorUtilities.h
+++ b/openmmapi/include/openmm/internal/CustomIntegratorUtilities.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2015 Stanford University and the Authors.           *
+ * Portions copyright (c) 2015-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -34,8 +34,10 @@
 
 #include "openmm/CustomIntegrator.h"
 #include "openmm/internal/ContextImpl.h"
+#include "lepton/CustomFunction.h"
 #include "lepton/ParsedExpression.h"
 #include <map>
+#include <string>
 #include <vector>
 
 namespace OpenMM {
@@ -48,6 +50,7 @@ class System;
 
 class OPENMM_EXPORT CustomIntegratorUtilities {
 public:
+    class DerivFunction;
     enum Comparison {
         EQUAL = 0, LESS_THAN = 1, GREATER_THAN = 2, NOT_EQUAL = 3, LESS_THAN_OR_EQUAL = 4, GREATER_THAN_OR_EQUAL = 5
     };
@@ -82,6 +85,28 @@ private:
             const std::vector<bool>& invalidatesForces, const std::vector<int>& forceGroup, std::vector<bool>& computeBoth);
     static void analyzeForceComputationsForPath(std::vector<int>& steps, const std::vector<bool>& needsForces, const std::vector<bool>& needsEnergy,
             const std::vector<bool>& invalidatesForces, const std::vector<int>& forceGroup, std::vector<bool>& computeBoth);
+    static void validateDerivatives(const Lepton::ExpressionTreeNode& node, const std::vector<std::string>& derivNames);
+};
+
+/**
+ * This class is used to implement the deriv() function when it appears in expressions.
+ */
+class CustomIntegratorUtilities::DerivFunction : public Lepton::CustomFunction {
+public:
+    DerivFunction() {
+    }
+    int getNumArguments() const {
+        return 2;
+    }
+    double evaluate(const double* arguments) const {
+        return 0.0;
+    }
+    double evaluateDerivative(const double* arguments, const int* derivOrder) const {
+        return 0.0;
+    }
+    CustomFunction* clone() const {
+        return new DerivFunction();
+    }
 };
 
 } // namespace OpenMM

--- a/openmmapi/include/openmm/internal/CustomNonbondedForceImpl.h
+++ b/openmmapi/include/openmm/internal/CustomNonbondedForceImpl.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2014 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -63,9 +63,10 @@ public:
     void updateParametersInContext(ContextImpl& context);
     /**
      * Compute the coefficient which, when divided by the periodic box volume, gives the
-     * long range correction to the energy.
+     * long range correction to the energy.  If the Force computes parameter derivatives,
+     * also compute the corresponding derivatives of the correction.
      */
-    static double calcLongRangeCorrection(const CustomNonbondedForce& force, const Context& context);
+    static void calcLongRangeCorrection(const CustomNonbondedForce& force, const Context& context, double& coefficient, std::vector<double>& derivatives);
 private:
     static double integrateInteraction(Lepton::CompiledExpression& expression, const std::vector<double>& params1, const std::vector<double>& params2,
             const CustomNonbondedForce& force, const Context& context);

--- a/openmmapi/src/Context.cpp
+++ b/openmmapi/src/Context.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2015 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -84,8 +84,9 @@ State Context::getState(int types, bool enforcePeriodicBox, int groups) const {
     builder.setPeriodicBoxVectors(periodicBoxSize[0], periodicBoxSize[1], periodicBoxSize[2]);
     bool includeForces = types&State::Forces;
     bool includeEnergy = types&State::Energy;
-    if (includeForces || includeEnergy) {
-        double energy = impl->calcForcesAndEnergy(includeForces || includeEnergy, includeEnergy, groups);
+    bool includeParameterDerivs = types&State::ParameterDerivatives;
+    if (includeForces || includeEnergy || includeParameterDerivs) {
+        double energy = impl->calcForcesAndEnergy(includeForces || includeEnergy || includeParameterDerivs, includeEnergy, groups);
         if (includeEnergy)
             builder.setEnergy(impl->calcKineticEnergy(), energy);
         if (includeForces) {
@@ -99,6 +100,11 @@ State Context::getState(int types, bool enforcePeriodicBox, int groups) const {
         for (map<string, double>::const_iterator iter = impl->parameters.begin(); iter != impl->parameters.end(); iter++)
             params[iter->first] = iter->second;
         builder.setParameters(params);
+    }
+    if (types&State::ParameterDerivatives) {
+        map<string, double> derivs;
+        impl->getEnergyParameterDerivatives(derivs);
+        builder.setEnergyParameterDerivatives(derivs);
     }
     if (types&State::Positions) {
         vector<Vec3> positions;

--- a/openmmapi/src/ContextImpl.cpp
+++ b/openmmapi/src/ContextImpl.cpp
@@ -240,6 +240,10 @@ void ContextImpl::setParameter(std::string name, double value) {
     integrator.stateChanged(State::Parameters);
 }
 
+void ContextImpl::getEnergyParameterDerivatives(std::map<std::string, double>& derivs) {
+    updateStateDataKernel.getAs<UpdateStateDataKernel>().getEnergyParameterDerivatives(*this, derivs);
+}
+
 void ContextImpl::getPeriodicBoxVectors(Vec3& a, Vec3& b, Vec3& c) {
     updateStateDataKernel.getAs<UpdateStateDataKernel>().getPeriodicBoxVectors(*this, a, b, c);
 }

--- a/openmmapi/src/CustomAngleForce.cpp
+++ b/openmmapi/src/CustomAngleForce.cpp
@@ -95,6 +95,20 @@ void CustomAngleForce::setGlobalParameterDefaultValue(int index, double defaultV
     globalParameters[index].defaultValue = defaultValue;
 }
 
+void CustomAngleForce::addEnergyParameterDerivative(const string& name) {
+    for (int i = 0; i < globalParameters.size(); i++)
+        if (name == globalParameters[i].name) {
+            energyParameterDerivatives.push_back(i);
+            return;
+        }
+    throw OpenMMException(string("addEnergyParameterDerivative: Unknown global parameter '"+name+"'"));
+}
+
+const string& CustomAngleForce::getEnergyParameterDerivativeName(int index) const {
+    ASSERT_VALID_INDEX(index, energyParameterDerivatives);
+    return globalParameters[energyParameterDerivatives[index]].name;
+}
+
 int CustomAngleForce::addAngle(int particle1, int particle2, int particle3, const vector<double>& parameters) {
     angles.push_back(AngleInfo(particle1, particle2, particle3, parameters));
     return angles.size()-1;

--- a/openmmapi/src/CustomBondForce.cpp
+++ b/openmmapi/src/CustomBondForce.cpp
@@ -95,6 +95,20 @@ void CustomBondForce::setGlobalParameterDefaultValue(int index, double defaultVa
     globalParameters[index].defaultValue = defaultValue;
 }
 
+void CustomBondForce::addEnergyParameterDerivative(const string& name) {
+    for (int i = 0; i < globalParameters.size(); i++)
+        if (name == globalParameters[i].name) {
+            energyParameterDerivatives.push_back(i);
+            return;
+        }
+    throw OpenMMException(string("addEnergyParameterDerivative: Unknown global parameter '"+name+"'"));
+}
+
+const string& CustomBondForce::getEnergyParameterDerivativeName(int index) const {
+    ASSERT_VALID_INDEX(index, energyParameterDerivatives);
+    return globalParameters[energyParameterDerivatives[index]].name;
+}
+
 int CustomBondForce::addBond(int particle1, int particle2, const vector<double>& parameters) {
     bonds.push_back(BondInfo(particle1, particle2, parameters));
     return bonds.size()-1;

--- a/openmmapi/src/CustomCentroidBondForce.cpp
+++ b/openmmapi/src/CustomCentroidBondForce.cpp
@@ -104,6 +104,20 @@ void CustomCentroidBondForce::setGlobalParameterDefaultValue(int index, double d
     globalParameters[index].defaultValue = defaultValue;
 }
 
+void CustomCentroidBondForce::addEnergyParameterDerivative(const string& name) {
+    for (int i = 0; i < globalParameters.size(); i++)
+        if (name == globalParameters[i].name) {
+            energyParameterDerivatives.push_back(i);
+            return;
+        }
+    throw OpenMMException(string("addEnergyParameterDerivative: Unknown global parameter '"+name+"'"));
+}
+
+const string& CustomCentroidBondForce::getEnergyParameterDerivativeName(int index) const {
+    ASSERT_VALID_INDEX(index, energyParameterDerivatives);
+    return globalParameters[energyParameterDerivatives[index]].name;
+}
+
 int CustomCentroidBondForce::addGroup(const vector<int>& particles, const vector<double>& weights) {
     if (particles.size() != weights.size() && weights.size() > 0)
         throw OpenMMException("CustomCentroidBondForce: wrong number of weights specified for a group.");

--- a/openmmapi/src/CustomCompoundBondForce.cpp
+++ b/openmmapi/src/CustomCompoundBondForce.cpp
@@ -105,6 +105,20 @@ void CustomCompoundBondForce::setGlobalParameterDefaultValue(int index, double d
     globalParameters[index].defaultValue = defaultValue;
 }
 
+void CustomCompoundBondForce::addEnergyParameterDerivative(const string& name) {
+    for (int i = 0; i < globalParameters.size(); i++)
+        if (name == globalParameters[i].name) {
+            energyParameterDerivatives.push_back(i);
+            return;
+        }
+    throw OpenMMException(string("addEnergyParameterDerivative: Unknown global parameter '"+name+"'"));
+}
+
+const string& CustomCompoundBondForce::getEnergyParameterDerivativeName(int index) const {
+    ASSERT_VALID_INDEX(index, energyParameterDerivatives);
+    return globalParameters[energyParameterDerivatives[index]].name;
+}
+
 int CustomCompoundBondForce::addBond(const vector<int>& particles, const vector<double>& parameters) {
     if (particles.size() != particlesPerBond)
         throw OpenMMException("CustomCompoundBondForce: wrong number of particles specified for a bond.");

--- a/openmmapi/src/CustomGBForce.cpp
+++ b/openmmapi/src/CustomGBForce.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2014 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -109,6 +109,20 @@ double CustomGBForce::getGlobalParameterDefaultValue(int index) const {
 void CustomGBForce::setGlobalParameterDefaultValue(int index, double defaultValue) {
     ASSERT_VALID_INDEX(index, globalParameters);
     globalParameters[index].defaultValue = defaultValue;
+}
+
+void CustomGBForce::addEnergyParameterDerivative(const string& name) {
+    for (int i = 0; i < globalParameters.size(); i++)
+        if (name == globalParameters[i].name) {
+            energyParameterDerivatives.push_back(i);
+            return;
+        }
+    throw OpenMMException(string("addEnergyParameterDerivative: Unknown global parameter '"+name+"'"));
+}
+
+const string& CustomGBForce::getEnergyParameterDerivativeName(int index) const {
+    ASSERT_VALID_INDEX(index, energyParameterDerivatives);
+    return globalParameters[energyParameterDerivatives[index]].name;
 }
 
 int CustomGBForce::addParticle(const vector<double>& parameters) {

--- a/openmmapi/src/CustomIntegratorUtilities.cpp
+++ b/openmmapi/src/CustomIntegratorUtilities.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2015 Stanford University and the Authors.           *
+ * Portions copyright (c) 2015-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -34,6 +34,7 @@
 #include "openmm/internal/ForceImpl.h"
 #include "lepton/Operation.h"
 #include "lepton/Parser.h"
+#include <algorithm>
 #include <set>
 #include <sstream>
 
@@ -81,6 +82,9 @@ void CustomIntegratorUtilities::analyzeComputations(const ContextImpl& context, 
     forceGroup.resize(numSteps, -2);
     vector<CustomIntegrator::ComputationType> stepType(numSteps);
     vector<string> stepVariable(numSteps);
+    map<string, Lepton::CustomFunction*> customFunctions;
+    DerivFunction derivFunction;
+    customFunctions["deriv"] = &derivFunction;
 
     // Parse the expressions.
 
@@ -92,11 +96,11 @@ void CustomIntegratorUtilities::analyzeComputations(const ContextImpl& context, 
 
             string lhs, rhs;
             parseCondition(expression, lhs, rhs, comparisons[step]);
-            expressions[step].push_back(Lepton::Parser::parse(lhs).optimize());
-            expressions[step].push_back(Lepton::Parser::parse(rhs).optimize());
+            expressions[step].push_back(Lepton::Parser::parse(lhs, customFunctions).optimize());
+            expressions[step].push_back(Lepton::Parser::parse(rhs, customFunctions).optimize());
         }
         else if (expression.size() > 0)
-            expressions[step].push_back(Lepton::Parser::parse(expression).optimize());
+            expressions[step].push_back(Lepton::Parser::parse(expression, customFunctions).optimize());
     }
 
     // Identify which steps invalidate the forces.
@@ -191,6 +195,14 @@ void CustomIntegratorUtilities::analyzeComputations(const ContextImpl& context, 
     vector<int> jumps(numSteps, -1);
     vector<int> stepsInPath;
     enumeratePaths(0, stepsInPath, jumps, blockEnd, stepType, needsForces, needsEnergy, invalidatesForces, forceGroup, computeBoth);
+    
+    // Make sure calls to deriv() all valid.
+    
+    vector<string> derivNames = energyGroupName;
+    derivNames.push_back("energy");
+    for (int i = 0; i < expressions.size(); i++)
+        for (int j = 0; j < expressions[i].size(); j++)
+            validateDerivatives(expressions[i][j].getRootNode(), derivNames);
 }
 
 void CustomIntegratorUtilities::enumeratePaths(int firstStep, vector<int> steps, vector<int> jumps, const vector<int>& blockEnd,
@@ -263,5 +275,20 @@ void CustomIntegratorUtilities::analyzeForceComputationsForPath(vector<int>& ste
             candidatePoints.push_back(step);
             currentGroup = forceGroup[step];
         }
+    }
+}
+
+void CustomIntegratorUtilities::validateDerivatives(const Lepton::ExpressionTreeNode& node, const vector<string>& derivNames) {
+    const Lepton::Operation& op = node.getOperation();
+    if (op.getId() == Lepton::Operation::CUSTOM && op.getName() == "deriv") {
+        const Lepton::Operation& child = node.getChildren()[0].getOperation();
+        if (child.getId() != Lepton::Operation::VARIABLE || find(derivNames.begin(), derivNames.end(), child.getName()) == derivNames.end())
+            throw OpenMMException("The first argument to deriv() must be an energy variable");
+        if (node.getChildren()[1].getOperation().getId() != Lepton::Operation::VARIABLE)
+            throw OpenMMException("The second argument to deriv() must be a context parameter");
+    }
+    else {
+        for (int i = 0; i < node.getChildren().size(); i++)
+            validateDerivatives(node.getChildren()[i], derivNames);
     }
 }

--- a/openmmapi/src/CustomNonbondedForce.cpp
+++ b/openmmapi/src/CustomNonbondedForce.cpp
@@ -61,6 +61,7 @@ CustomNonbondedForce::CustomNonbondedForce(const CustomNonbondedForce& rhs) {
     useLongRangeCorrection = rhs.useLongRangeCorrection;
     parameters = rhs.parameters;
     globalParameters = rhs.globalParameters;
+    energyParameterDerivatives = rhs.energyParameterDerivatives;
     particles = rhs.particles;
     exclusions = rhs.exclusions;
     interactionGroups = rhs.interactionGroups;
@@ -159,6 +160,20 @@ double CustomNonbondedForce::getGlobalParameterDefaultValue(int index) const {
 void CustomNonbondedForce::setGlobalParameterDefaultValue(int index, double defaultValue) {
     ASSERT_VALID_INDEX(index, globalParameters);
     globalParameters[index].defaultValue = defaultValue;
+}
+
+void CustomNonbondedForce::addEnergyParameterDerivative(const string& name) {
+    for (int i = 0; i < globalParameters.size(); i++)
+        if (name == globalParameters[i].name) {
+            energyParameterDerivatives.push_back(i);
+            return;
+        }
+    throw OpenMMException(string("addEnergyParameterDerivative: Unknown global parameter '"+name+"'"));
+}
+
+const string& CustomNonbondedForce::getEnergyParameterDerivativeName(int index) const {
+    ASSERT_VALID_INDEX(index, energyParameterDerivatives);
+    return globalParameters[energyParameterDerivatives[index]].name;
 }
 
 int CustomNonbondedForce::addParticle(const vector<double>& parameters) {

--- a/openmmapi/src/CustomNonbondedForceImpl.cpp
+++ b/openmmapi/src/CustomNonbondedForceImpl.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2014 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -157,16 +157,11 @@ void CustomNonbondedForceImpl::updateParametersInContext(ContextImpl& context) {
     kernel.getAs<CalcCustomNonbondedForceKernel>().copyParametersToContext(context, owner);
 }
 
-double CustomNonbondedForceImpl::calcLongRangeCorrection(const CustomNonbondedForce& force, const Context& context) {
-    if (force.getNonbondedMethod() == CustomNonbondedForce::NoCutoff || force.getNonbondedMethod() == CustomNonbondedForce::CutoffNonPeriodic)
-        return 0.0;
-    
-    // Parse the energy expression.
-    
-    map<string, Lepton::CustomFunction*> functions;
-    for (int i = 0; i < force.getNumFunctions(); i++)
-        functions[force.getTabulatedFunctionName(i)] = createReferenceTabulatedFunction(force.getTabulatedFunction(i));
-    Lepton::CompiledExpression expression = Lepton::Parser::parse(force.getEnergyFunction(), functions).createCompiledExpression();
+void CustomNonbondedForceImpl::calcLongRangeCorrection(const CustomNonbondedForce& force, const Context& context, double& coefficient, vector<double>& derivatives) {
+    if (force.getNonbondedMethod() == CustomNonbondedForce::NoCutoff || force.getNonbondedMethod() == CustomNonbondedForce::CutoffNonPeriodic) {
+        coefficient = 0.0;
+        return;
+    }
     
     // Identify all particle classes (defined by parameters), and record the class of each particle.
     
@@ -223,17 +218,35 @@ double CustomNonbondedForceImpl::calcLongRangeCorrection(const CustomNonbondedFo
                 }
         }
     }
-
-    // Loop over all pairs of classes to compute the coefficient.
-
+    
+    // Compute the coefficient.
+    
+    map<string, Lepton::CustomFunction*> functions;
+    for (int i = 0; i < force.getNumFunctions(); i++)
+        functions[force.getTabulatedFunctionName(i)] = createReferenceTabulatedFunction(force.getTabulatedFunction(i));
+    double nPart = (double) numParticles;
+    double numInteractions = (nPart*(nPart+1))/2;
+    Lepton::CompiledExpression expression = Lepton::Parser::parse(force.getEnergyFunction(), functions).createCompiledExpression();
     double sum = 0;
     for (int i = 0; i < numClasses; i++)
         for (int j = i; j < numClasses; j++)
             sum += interactionCount[make_pair(i, j)]*integrateInteraction(expression, classes[i], classes[j], force, context);
-    double nPart = (double) numParticles;
-    double numInteractions = (nPart*(nPart+1))/2;
     sum /= numInteractions;
-    return 2*M_PI*nPart*nPart*sum;
+    coefficient = 2*M_PI*nPart*nPart*sum;
+    
+    // Now do the same for parameter derivatives.
+    
+    int numDerivs = force.getNumEnergyParameterDerivatives();
+    derivatives.resize(numDerivs);
+    for (int k = 0; k < numDerivs; k++) {
+        expression = Lepton::Parser::parse(force.getEnergyFunction(), functions).differentiate(force.getEnergyParameterDerivativeName(k)).createCompiledExpression();
+        sum = 0;
+        for (int i = 0; i < numClasses; i++)
+            for (int j = i; j < numClasses; j++)
+                sum += interactionCount[make_pair(i, j)]*integrateInteraction(expression, classes[i], classes[j], force, context);
+        sum /= numInteractions;
+        derivatives[k] = 2*M_PI*nPart*nPart*sum;
+    }
 }
 
 double CustomNonbondedForceImpl::integrateInteraction(Lepton::CompiledExpression& expression, const vector<double>& params1, const vector<double>& params2,

--- a/openmmapi/src/CustomTorsionForce.cpp
+++ b/openmmapi/src/CustomTorsionForce.cpp
@@ -95,6 +95,20 @@ void CustomTorsionForce::setGlobalParameterDefaultValue(int index, double defaul
     globalParameters[index].defaultValue = defaultValue;
 }
 
+void CustomTorsionForce::addEnergyParameterDerivative(const string& name) {
+    for (int i = 0; i < globalParameters.size(); i++)
+        if (name == globalParameters[i].name) {
+            energyParameterDerivatives.push_back(i);
+            return;
+        }
+    throw OpenMMException(string("addEnergyParameterDerivative: Unknown global parameter '"+name+"'"));
+}
+
+const string& CustomTorsionForce::getEnergyParameterDerivativeName(int index) const {
+    ASSERT_VALID_INDEX(index, energyParameterDerivatives);
+    return globalParameters[energyParameterDerivatives[index]].name;
+}
+
 int CustomTorsionForce::addTorsion(int particle1, int particle2, int particle3, int particle4, const vector<double>& parameters) {
     torsions.push_back(TorsionInfo(particle1, particle2, particle3, particle4, parameters));
     return torsions.size()-1;

--- a/openmmapi/src/State.cpp
+++ b/openmmapi/src/State.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008 Stanford University and the Authors.           *
+ * Portions copyright (c) 2008-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -76,6 +76,11 @@ const map<string, double>& State::getParameters() const {
         throw OpenMMException("Invoked getParameters() on a State which does not contain parameters.");
     return parameters;
 }
+const map<string, double>& State::getEnergyParameterDerivatives() const {
+    if ((types&ParameterDerivatives) == 0)
+        throw OpenMMException("Invoked getEnergyParameterDerivatives() on a State which does not contain parameter derivatives.");
+    return energyParameterDerivatives;
+}
 int State::getDataTypes() const {
     return types;
 }
@@ -101,6 +106,11 @@ void State::setForces(const std::vector<Vec3>& force) {
 void State::setParameters(const std::map<std::string, double>& params) {
     parameters = params;
     types |= Parameters;
+}
+
+void State::setEnergyParameterDerivatives(const std::map<std::string, double>& derivs) {
+    energyParameterDerivatives = derivs;
+    types |= ParameterDerivatives;
 }
 
 void State::setEnergy(double kinetic, double potential) {
@@ -136,6 +146,10 @@ void State::StateBuilder::setForces(const std::vector<Vec3>& force) {
 
 void State::StateBuilder::setParameters(const std::map<std::string, double>& params) {
     state.setParameters(params);
+}
+
+void State::StateBuilder::setEnergyParameterDerivatives(const std::map<std::string, double>& derivs) {
+    state.setEnergyParameterDerivatives(derivs);
 }
 
 void State::StateBuilder::setEnergy(double ke, double pe) {

--- a/platforms/cpu/include/CpuKernels.h
+++ b/platforms/cpu/include/CpuKernels.h
@@ -313,7 +313,7 @@ private:
     CustomNonbondedForce* forceCopy;
     std::map<std::string, double> globalParamValues;
     std::vector<std::set<int> > exclusions;
-    std::vector<std::string> parameterNames, globalParameterNames;
+    std::vector<std::string> parameterNames, globalParameterNames, energyParamDerivNames;
     std::vector<std::pair<std::set<int>, std::set<int> > > interactionGroups;
     std::vector<double> longRangeCoefficientDerivs;
     NonbondedMethod nonbondedMethod;

--- a/platforms/cpu/include/CpuKernels.h
+++ b/platforms/cpu/include/CpuKernels.h
@@ -398,7 +398,7 @@ private:
     RealOpenMM nonbondedCutoff;
     CpuCustomGBForce* ixn;
     std::vector<std::set<int> > exclusions;
-    std::vector<std::string> particleParameterNames, globalParameterNames, valueNames;
+    std::vector<std::string> particleParameterNames, globalParameterNames, energyParamDerivNames, valueNames;
     std::vector<OpenMM::CustomGBForce::ComputationType> valueTypes;
     std::vector<OpenMM::CustomGBForce::ComputationType> energyTypes;
     NonbondedMethod nonbondedMethod;

--- a/platforms/cpu/include/CpuKernels.h
+++ b/platforms/cpu/include/CpuKernels.h
@@ -315,6 +315,7 @@ private:
     std::vector<std::set<int> > exclusions;
     std::vector<std::string> parameterNames, globalParameterNames;
     std::vector<std::pair<std::set<int>, std::set<int> > > interactionGroups;
+    std::vector<double> longRangeCoefficientDerivs;
     NonbondedMethod nonbondedMethod;
     CpuCustomNonbondedForce* nonbonded;
 };

--- a/platforms/cpu/src/CpuBondForce.cpp
+++ b/platforms/cpu/src/CpuBondForce.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2014 Stanford University and the Authors.           *
+ * Portions copyright (c) 2014-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -196,7 +196,7 @@ void CpuBondForce::calculateForce(vector<RealVec>& atomCoordinates, RealOpenMM**
     
     for (int i = 0; i < extraBonds.size(); i++) {
         int bond = extraBonds[i];
-        referenceBondIxn.calculateBondIxn(bondAtoms[bond], atomCoordinates, parameters[bond], forces, totalEnergy);
+        referenceBondIxn.calculateBondIxn(bondAtoms[bond], atomCoordinates, parameters[bond], forces, totalEnergy, NULL);
     }
 
     // Compute the total energy.
@@ -212,6 +212,6 @@ void CpuBondForce::threadComputeForce(ThreadPool& threads, int threadIndex, vect
     int numBonds = bonds.size();
     for (int i = 0; i < numBonds; i++) {
         int bond = bonds[i];
-        referenceBondIxn.calculateBondIxn(bondAtoms[bond], atomCoordinates, parameters[bond], forces, totalEnergy);
+        referenceBondIxn.calculateBondIxn(bondAtoms[bond], atomCoordinates, parameters[bond], forces, totalEnergy, NULL);
     }
 }

--- a/platforms/cpu/src/CpuCustomGBForce.cpp
+++ b/platforms/cpu/src/CpuCustomGBForce.cpp
@@ -231,7 +231,7 @@ void CpuCustomGBForce::calculateIxn(int numberOfAtoms, float* posq, RealOpenMM**
     }
     if (hasParamDerivs)
         for (int i = 0; i < threads.getNumThreads(); i++)
-            for (int j = 0; j < threadData[j]->energyParamDerivs.size(); j++)
+            for (int j = 0; j < threadData[i]->energyParamDerivs.size(); j++)
                 energyParamDerivs[j] += threadData[i]->energyParamDerivs[j];
 }
 

--- a/platforms/cpu/src/CpuCustomGBForce.cpp
+++ b/platforms/cpu/src/CpuCustomGBForce.cpp
@@ -47,13 +47,16 @@ CpuCustomGBForce::ThreadData::ThreadData(int numAtoms, int numThreads, int threa
                       const vector<Lepton::CompiledExpression>& valueExpressions,
                       const vector<vector<Lepton::CompiledExpression> >& valueDerivExpressions,
                       const vector<vector<Lepton::CompiledExpression> >& valueGradientExpressions,
+                      const vector<vector<Lepton::CompiledExpression> >& valueParamDerivExpressions,
                       const vector<string>& valueNames,
                       const vector<Lepton::CompiledExpression>& energyExpressions,
                       const vector<vector<Lepton::CompiledExpression> >& energyDerivExpressions,
                       const vector<vector<Lepton::CompiledExpression> >& energyGradientExpressions,
+                      const vector<vector<Lepton::CompiledExpression> >& energyParamDerivExpressions,
                       const vector<string>& parameterNames) :
             valueExpressions(valueExpressions), valueDerivExpressions(valueDerivExpressions), valueGradientExpressions(valueGradientExpressions),
-            energyExpressions(energyExpressions), energyDerivExpressions(energyDerivExpressions), energyGradientExpressions(energyGradientExpressions) {
+            valueParamDerivExpressions(valueParamDerivExpressions), energyExpressions(energyExpressions), energyDerivExpressions(energyDerivExpressions),
+            energyGradientExpressions(energyGradientExpressions), energyParamDerivExpressions(energyParamDerivExpressions) {
     firstAtom = (threadIndex*(long long) numAtoms)/numThreads;
     lastAtom = ((threadIndex+1)*(long long) numAtoms)/numThreads;
     for (int i = 0; i < (int) valueExpressions.size(); i++)
@@ -64,6 +67,9 @@ CpuCustomGBForce::ThreadData::ThreadData(int numAtoms, int numThreads, int threa
     for (int i = 0; i < (int) valueGradientExpressions.size(); i++)
         for (int j = 0; j < (int) valueGradientExpressions[i].size(); j++)
             expressionSet.registerExpression(this->valueGradientExpressions[i][j]);
+    for (int i = 0; i < (int) valueParamDerivExpressions.size(); i++)
+        for (int j = 0; j < (int) valueParamDerivExpressions[i].size(); j++)
+            expressionSet.registerExpression(this->valueParamDerivExpressions[i][j]);
     for (int i = 0; i < (int) energyExpressions.size(); i++)
         expressionSet.registerExpression(this->energyExpressions[i]);
     for (int i = 0; i < (int) energyDerivExpressions.size(); i++)
@@ -72,6 +78,9 @@ CpuCustomGBForce::ThreadData::ThreadData(int numAtoms, int numThreads, int threa
     for (int i = 0; i < (int) energyGradientExpressions.size(); i++)
         for (int j = 0; j < (int) energyGradientExpressions[i].size(); j++)
             expressionSet.registerExpression(this->energyGradientExpressions[i][j]);
+    for (int i = 0; i < (int) energyParamDerivExpressions.size(); i++)
+        for (int j = 0; j < (int) energyParamDerivExpressions[i].size(); j++)
+            expressionSet.registerExpression(this->energyParamDerivExpressions[i][j]);
     xindex = expressionSet.getVariableIndex("x");
     yindex = expressionSet.getVariableIndex("y");
     zindex = expressionSet.getVariableIndex("z");
@@ -101,30 +110,37 @@ CpuCustomGBForce::ThreadData::ThreadData(int numAtoms, int numThreads, int threa
     dVdZ.resize(valueDerivExpressions.size());
     dVdR1.resize(valueDerivExpressions.size());
     dVdR2.resize(valueDerivExpressions.size());
+    dValue0dParam.resize(valueParamDerivExpressions[0].size(), vector<float>(numAtoms));
+    energyParamDerivs.resize(valueParamDerivExpressions[0].size());
 }
 
 CpuCustomGBForce::CpuCustomGBForce(int numAtoms, const std::vector<std::set<int> >& exclusions,
                      const vector<Lepton::CompiledExpression>& valueExpressions,
                      const vector<vector<Lepton::CompiledExpression> >& valueDerivExpressions,
                      const vector<vector<Lepton::CompiledExpression> >& valueGradientExpressions,
+                     const vector<vector<Lepton::CompiledExpression> >& valueParamDerivExpressions,
                      const vector<string>& valueNames,
                      const vector<CustomGBForce::ComputationType>& valueTypes,
                      const vector<Lepton::CompiledExpression>& energyExpressions,
                      const vector<vector<Lepton::CompiledExpression> >& energyDerivExpressions,
                      const vector<vector<Lepton::CompiledExpression> >& energyGradientExpressions,
+                     const vector<vector<Lepton::CompiledExpression> >& energyParamDerivExpressions,
                      const vector<CustomGBForce::ComputationType>& energyTypes,
                      const vector<string>& parameterNames, ThreadPool& threads) :
-            exclusions(exclusions), cutoff(false), periodic(false), valueNames(valueNames), valueTypes(valueTypes),
-            energyTypes(energyTypes), paramNames(parameterNames), threads(threads) {
+            exclusions(exclusions), cutoff(false), periodic(false), valueTypes(valueTypes), energyTypes(energyTypes), numValues(valueNames.size()),
+            numParams(parameterNames.size()), threads(threads) {
     for (int i = 0; i < threads.getNumThreads(); i++)
-        threadData.push_back(new ThreadData(numAtoms, threads.getNumThreads(), i, valueExpressions, valueDerivExpressions, valueGradientExpressions, valueNames,
-                      energyExpressions, energyDerivExpressions, energyGradientExpressions, parameterNames));
-    values.resize(valueNames.size());
-    dEdV.resize(valueNames.size());
+        threadData.push_back(new ThreadData(numAtoms, threads.getNumThreads(), i, valueExpressions, valueDerivExpressions, valueGradientExpressions,
+                valueParamDerivExpressions, valueNames, energyExpressions, energyDerivExpressions, energyGradientExpressions, energyParamDerivExpressions, parameterNames));
+    values.resize(numValues);
+    dEdV.resize(numValues);
     for (int i = 0; i < (int) values.size(); i++) {
         values[i].resize(numAtoms);
         dEdV[i].resize(numAtoms);
     }
+    dValuedParam.resize(numValues);
+    for (int i = 0; i < numValues; i++)
+        dValuedParam[i].resize(valueParamDerivExpressions[0].size(), vector<float>(numAtoms));
 }
 
 CpuCustomGBForce::~CpuCustomGBForce() {
@@ -153,7 +169,7 @@ void CpuCustomGBForce::setPeriodic(RealVec& boxSize) {
 
 void CpuCustomGBForce::calculateIxn(int numberOfAtoms, float* posq, RealOpenMM** atomParameters,
                                            map<string, double>& globalParameters, vector<AlignedArray<float> >& threadForce,
-                                           bool includeForce, bool includeEnergy, double& totalEnergy) {
+                                           bool includeForce, bool includeEnergy, double& totalEnergy, double* energyParamDerivs) {
     // Record the parameters for the threads.
     
     this->numberOfAtoms = numberOfAtoms;
@@ -173,12 +189,20 @@ void CpuCustomGBForce::calculateIxn(int numberOfAtoms, float* posq, RealOpenMM**
     gmx_atomic_set(&counter, 0);
     threads.execute(task);
     threads.waitForThreads();
+
+    // Sum derivatives of the first computed value with respect to global parameters.
+
+    bool hasParamDerivs = (threadData[0]->dValue0dParam.size() > 0);
+    if (hasParamDerivs) {
+        threads.resumeThreads();
+        threads.waitForThreads();
+    }
     
     // Calculate the remaining computed values.
     
     threads.resumeThreads();
     threads.waitForThreads();
-
+    
     // Calculate the energy terms.
 
     for (int i = 0; i < (int) threadData[0]->energyExpressions.size(); i++) {
@@ -205,6 +229,10 @@ void CpuCustomGBForce::calculateIxn(int numberOfAtoms, float* posq, RealOpenMM**
         for (int i = 0; i < numThreads; i++)
             totalEnergy += threadEnergy[i];
     }
+    if (hasParamDerivs)
+        for (int i = 0; i < threads.getNumThreads(); i++)
+            for (int j = 0; j < threadData[j]->energyParamDerivs.size(); j++)
+                energyParamDerivs[j] += threadData[i]->energyParamDerivs[j];
 }
 
 void CpuCustomGBForce::threadComputeForce(ThreadPool& threads, int threadIndex) {
@@ -224,11 +252,28 @@ void CpuCustomGBForce::threadComputeForce(ThreadPool& threads, int threadIndex) 
 
     for (int i = 0; i < (int) data.value0.size(); i++)
         data.value0[i] = 0.0f;
+    for (int i = 0; i < (int) data.dValue0dParam.size(); i++)
+        for (int j = 0; j < (int) data.dValue0dParam[i].size(); j++)
+            data.dValue0dParam[i][j] = 0.0;
     if (valueTypes[0] == CustomGBForce::ParticlePair)
         calculateParticlePairValue(0, data, numberOfAtoms, posq, atomParameters, true, boxSize, invBoxSize);
     else
         calculateParticlePairValue(0, data, numberOfAtoms, posq, atomParameters, false, boxSize, invBoxSize);
     threads.syncThreads();
+    
+    // Sum derivatives of the first computed value with respect to global parameters.
+    
+    bool hasParamDerivs = (data.dValue0dParam.size() > 0);
+    if (hasParamDerivs) {
+        for (int j = 0; j < data.dValue0dParam.size(); j++)
+            for (int k = data.firstAtom; k < data.lastAtom; k++) {
+                float sum = 0.0f;
+                for (int m = 0; m < threadData.size(); m++)
+                    sum += threadData[m]->dValue0dParam[j][k];
+                dValuedParam[0][j][k] = sum;
+            }
+        threads.syncThreads();
+    }
 
     // Sum the first computed value and calculate the remaining ones.
 
@@ -241,11 +286,23 @@ void CpuCustomGBForce::threadComputeForce(ThreadPool& threads, int threadIndex) 
         data.expressionSet.setVariable(data.xindex, posq[4*atom]);
         data.expressionSet.setVariable(data.yindex, posq[4*atom+1]);
         data.expressionSet.setVariable(data.zindex, posq[4*atom+2]);
-        for (int j = 0; j < (int) paramNames.size(); j++)
+        for (int j = 0; j < numParams; j++)
             data.expressionSet.setVariable(data.paramIndex[j], atomParameters[atom][j]);
         for (int i = 1; i < numValues; i++) {
             data.expressionSet.setVariable(data.valueIndex[i-1], values[i-1][atom]);
             values[i][atom] = (float) data.valueExpressions[i].evaluate();
+
+            // Calculate derivatives with respect to parameters.
+
+            if (hasParamDerivs) {
+                for (int j = 0; j < data.valueParamDerivExpressions[i].size(); j++)
+                    dValuedParam[i][j][atom] = data.valueParamDerivExpressions[i][j].evaluate();
+                for (int j = 0; j < i; j++) {
+                    float dVdV = data.valueDerivExpressions[i][j].evaluate();
+                    for (int k = 0; k < data.valueParamDerivExpressions[i].size(); k++)
+                        dValuedParam[i][k][atom] += dVdV*dValuedParam[j][k][atom];
+                }
+            }
         }
     }
     threads.syncThreads();
@@ -254,7 +311,9 @@ void CpuCustomGBForce::threadComputeForce(ThreadPool& threads, int threadIndex) 
 
     for (int i = 0; i < (int) data.dEdV.size(); i++)
         for (int j = 0; j < (int) data.dEdV[i].size(); j++)
-            data.dEdV[i][j] = 0.0;
+            data.dEdV[i][j] = 0.0f;
+    for (int i = 0; i < (int) data.energyParamDerivs.size(); i++)
+        data.energyParamDerivs[i] = 0.0f;
     for (int termIndex = 0; termIndex < (int) data.energyExpressions.size(); termIndex++) {
         if (energyTypes[termIndex] == CustomGBForce::SingleParticle)
             calculateSingleParticleEnergyTerm(termIndex, data, numberOfAtoms, posq, atomParameters, forces, energy);
@@ -339,7 +398,7 @@ void CpuCustomGBForce::calculateOnePairValue(int index, int atom1, int atom2, Th
     if (cutoff && r2 >= cutoffDistance2)
         return;
     float r = sqrtf(r2);
-    for (int i = 0; i < (int) paramNames.size(); i++) {
+    for (int i = 0; i < numParams; i++) {
         data.expressionSet.setVariable(data.particleParamIndex[i*2], atomParameters[atom1][i]);
         data.expressionSet.setVariable(data.particleParamIndex[i*2+1], atomParameters[atom2][i]);
     }
@@ -349,6 +408,11 @@ void CpuCustomGBForce::calculateOnePairValue(int index, int atom1, int atom2, Th
         data.expressionSet.setVariable(data.particleValueIndex[i*2+1], values[i][atom2]);
     }
     valueArray[atom1] += (float) data.valueExpressions[index].evaluate();
+    
+    // Calculate derivatives with respect to parameters.
+    
+    for (int i = 0; i < data.valueParamDerivExpressions[index].size(); i++)
+        data.dValue0dParam[i][atom1] += data.valueParamDerivExpressions[index][i].evaluate();
 }
 
 void CpuCustomGBForce::calculateSingleParticleEnergyTerm(int index, ThreadData& data, int numAtoms, float* posq,
@@ -357,17 +421,22 @@ void CpuCustomGBForce::calculateSingleParticleEnergyTerm(int index, ThreadData& 
         data.expressionSet.setVariable(data.xindex, posq[4*i]);
         data.expressionSet.setVariable(data.yindex, posq[4*i+1]);
         data.expressionSet.setVariable(data.zindex, posq[4*i+2]);
-        for (int j = 0; j < (int) paramNames.size(); j++)
+        for (int j = 0; j < numParams; j++)
             data.expressionSet.setVariable(data.paramIndex[j], atomParameters[i][j]);
-        for (int j = 0; j < (int) valueNames.size(); j++)
+        for (int j = 0; j < (int) values.size(); j++)
             data.expressionSet.setVariable(data.valueIndex[j], values[j][i]);
         if (includeEnergy)
             totalEnergy += (float) data.energyExpressions[index].evaluate();
-        for (int j = 0; j < (int) valueNames.size(); j++)
+        for (int j = 0; j < (int) values.size(); j++)
             data.dEdV[j][i] += (float) data.energyDerivExpressions[index][j].evaluate();
         forces[4*i+0] -= (float) data.energyGradientExpressions[index][0].evaluate();
         forces[4*i+1] -= (float) data.energyGradientExpressions[index][1].evaluate();
         forces[4*i+2] -= (float) data.energyGradientExpressions[index][2].evaluate();
+        
+        // Compute derivatives with respect to parameters.
+        
+        for (int k = 0; k < data.energyParamDerivExpressions[index].size(); k++)
+            data.energyParamDerivs[k] += data.energyParamDerivExpressions[index][k].evaluate();
     }
 }
 
@@ -428,12 +497,12 @@ void CpuCustomGBForce::calculateOnePairEnergyTerm(int index, int atom1, int atom
 
     // Record variables for evaluating expressions.
 
-    for (int i = 0; i < (int) paramNames.size(); i++) {
+    for (int i = 0; i < numParams; i++) {
         data.expressionSet.setVariable(data.particleParamIndex[i*2], atomParameters[atom1][i]);
         data.expressionSet.setVariable(data.particleParamIndex[i*2+1], atomParameters[atom2][i]);
     }
     data.expressionSet.setVariable(data.rindex, r);
-    for (int i = 0; i < (int) valueNames.size(); i++) {
+    for (int i = 0; i < (int) values.size(); i++) {
         data.expressionSet.setVariable(data.particleValueIndex[i*2], values[i][atom1]);
         data.expressionSet.setVariable(data.particleValueIndex[i*2+1], values[i][atom2]);
     }
@@ -447,10 +516,15 @@ void CpuCustomGBForce::calculateOnePairEnergyTerm(int index, int atom1, int atom
     fvec4 result = deltaR*dEdR;
     (fvec4(forces+4*atom1)-result).store(forces+4*atom1);
     (fvec4(forces+4*atom2)+result).store(forces+4*atom2);
-    for (int i = 0; i < (int) valueNames.size(); i++) {
+    for (int i = 0; i < (int) values.size(); i++) {
         data.dEdV[i][atom1] += (float) data.energyDerivExpressions[index][2*i+1].evaluate();
         data.dEdV[i][atom2] += (float) data.energyDerivExpressions[index][2*i+2].evaluate();
     }
+        
+    // Compute derivatives with respect to parameters.
+
+    for (int i = 0; i < data.energyParamDerivExpressions[index].size(); i++)
+        data.energyParamDerivs[i] += data.energyParamDerivExpressions[index][i].evaluate();
 }
 
 void CpuCustomGBForce::calculateChainRuleForces(ThreadData& data, int numAtoms, float* posq, RealOpenMM** atomParameters,
@@ -500,9 +574,9 @@ void CpuCustomGBForce::calculateChainRuleForces(ThreadData& data, int numAtoms, 
         data.expressionSet.setVariable(data.xindex, posq[4*i]);
         data.expressionSet.setVariable(data.yindex, posq[4*i+1]);
         data.expressionSet.setVariable(data.zindex, posq[4*i+2]);
-        for (int j = 0; j < (int) paramNames.size(); j++)
+        for (int j = 0; j < numParams; j++)
             data.expressionSet.setVariable(data.paramIndex[j], atomParameters[i][j]);
-        for (int j = 1; j < (int) valueNames.size(); j++) {
+        for (int j = 1; j < (int) values.size(); j++) {
             data.expressionSet.setVariable(data.valueIndex[j-1], values[j-1][i]);
             data.dVdX[j] = 0.0;
             data.dVdY[j] = 0.0;
@@ -521,6 +595,13 @@ void CpuCustomGBForce::calculateChainRuleForces(ThreadData& data, int numAtoms, 
             forces[4*i+2] -= dEdV[j][i]*data.dVdZ[j];
         }
     }
+        
+    // Compute chain rule terms for derivatives with respect to parameters.
+
+    for (int i = data.firstAtom; i < data.lastAtom; i++)
+        for (int j = 0; j < data.valueIndex.size(); j++)
+            for (int k = 0; k < dValuedParam[j].size(); k++)
+                data.energyParamDerivs[k] += dEdV[j][i]*dValuedParam[j][k][i];
 }
 
 void CpuCustomGBForce::calculateOnePairChainRule(int atom1, int atom2, ThreadData& data, float* posq, RealOpenMM** atomParameters,
@@ -538,7 +619,7 @@ void CpuCustomGBForce::calculateOnePairChainRule(int atom1, int atom2, ThreadDat
 
     // Record variables for evaluating expressions.
 
-    for (int i = 0; i < (int) paramNames.size(); i++) {
+    for (int i = 0; i < numParams; i++) {
         data.expressionSet.setVariable(data.particleParamIndex[i*2], atomParameters[atom1][i]);
         data.expressionSet.setVariable(data.particleParamIndex[i*2+1], atomParameters[atom2][i]);
         data.expressionSet.setVariable(data.paramIndex[i], atomParameters[atom1][i]);
@@ -562,7 +643,7 @@ void CpuCustomGBForce::calculateOnePairChainRule(int atom1, int atom2, ThreadDat
         f1 -= deltaR*(dEdV[0][atom1]*data.dVdR1[0]);
         f2 -= deltaR*(dEdV[0][atom1]*data.dVdR2[0]);
     }
-    for (int i = 1; i < (int) valueNames.size(); i++) {
+    for (int i = 1; i < (int) values.size(); i++) {
         data.expressionSet.setVariable(data.valueIndex[i], values[i][atom1]);
         data.dVdR1[i] = 0.0;
         data.dVdR2[i] = 0.0;

--- a/platforms/cpu/src/CpuCustomNonbondedForce.cpp
+++ b/platforms/cpu/src/CpuCustomNonbondedForce.cpp
@@ -43,25 +43,30 @@ public:
     CpuCustomNonbondedForce& owner;
 };
 
-CpuCustomNonbondedForce::ThreadData::ThreadData(const Lepton::CompiledExpression& energyExpression, const Lepton::CompiledExpression& forceExpression, const vector<string>& parameterNames) :
-            energyExpression(energyExpression), forceExpression(forceExpression) {
-    energyR = ReferenceForce::getVariablePointer(this->energyExpression, "r");
-    forceR = ReferenceForce::getVariablePointer(this->forceExpression, "r");
+CpuCustomNonbondedForce::ThreadData::ThreadData(const Lepton::CompiledExpression& energyExpression, const Lepton::CompiledExpression& forceExpression,
+            const vector<string>& parameterNames, const std::vector<Lepton::CompiledExpression> energyParamDerivExpressions) :
+            energyExpression(energyExpression), forceExpression(forceExpression), energyParamDerivExpressions(energyParamDerivExpressions) {
+    expressionSet.registerExpression(this->energyExpression);
+    expressionSet.registerExpression(this->forceExpression);
+    for (int i = 0; i < this->energyParamDerivExpressions.size(); i++)
+        expressionSet.registerExpression(this->energyParamDerivExpressions[i]);
+    rIndex = expressionSet.getVariableIndex("r");
     for (int i = 0; i < (int) parameterNames.size(); i++) {
         for (int j = 1; j < 3; j++) {
             stringstream name;
             name << parameterNames[i] << j;
-            energyParticleParams.push_back(ReferenceForce::getVariablePointer(this->energyExpression, name.str()));
-            forceParticleParams.push_back(ReferenceForce::getVariablePointer(this->forceExpression, name.str()));
+            particleParamIndex.push_back(expressionSet.getVariableIndex(name.str()));
         }
     }
+    energyParamDerivs.resize(energyParamDerivExpressions.size());
 }
 
 CpuCustomNonbondedForce::CpuCustomNonbondedForce(const Lepton::CompiledExpression& energyExpression,
-            const Lepton::CompiledExpression& forceExpression, const vector<string>& parameterNames, const vector<set<int> >& exclusions,ThreadPool& threads) :
+            const Lepton::CompiledExpression& forceExpression, const vector<string>& parameterNames, const vector<set<int> >& exclusions,
+            const std::vector<Lepton::CompiledExpression> energyParamDerivExpressions, ThreadPool& threads) :
             cutoff(false), useSwitch(false), periodic(false), paramNames(parameterNames), exclusions(exclusions), threads(threads) {
     for (int i = 0; i < threads.getNumThreads(); i++)
-        threadData.push_back(new ThreadData(energyExpression, forceExpression, parameterNames));
+        threadData.push_back(new ThreadData(energyExpression, forceExpression, parameterNames, energyParamDerivExpressions));
 }
 
 CpuCustomNonbondedForce::~CpuCustomNonbondedForce() {
@@ -120,7 +125,7 @@ void CpuCustomNonbondedForce::setPeriodic(RealVec* periodicBoxVectors) {
 
 void CpuCustomNonbondedForce::calculatePairIxn(int numberOfAtoms, float* posq, vector<RealVec>& atomCoordinates, RealOpenMM** atomParameters,
                                              RealOpenMM* fixedParameters, const map<string, double>& globalParameters,
-                                             vector<AlignedArray<float> >& threadForce, bool includeForce, bool includeEnergy, double& totalEnergy) {
+                                             vector<AlignedArray<float> >& threadForce, bool includeForce, bool includeEnergy, double& totalEnergy, double* energyParamDerivs) {
     // Record the parameters for the threads.
     
     this->numberOfAtoms = numberOfAtoms;
@@ -144,11 +149,18 @@ void CpuCustomNonbondedForce::calculatePairIxn(int numberOfAtoms, float* posq, v
     
     // Combine the energies from all the threads.
     
+    int numThreads = threads.getNumThreads();
     if (includeEnergy) {
-        int numThreads = threads.getNumThreads();
         for (int i = 0; i < numThreads; i++)
             totalEnergy += threadEnergy[i];
     }
+
+    // Combine the energy derivatives from all threads.
+    
+    int numDerivs = threadData[0]->energyParamDerivs.size();
+    for (int i = 0; i < numThreads; i++)
+        for (int j = 0; j < numDerivs; j++)
+            energyParamDerivs[j] += threadData[i]->energyParamDerivs[j];
 }
 
 void CpuCustomNonbondedForce::threadComputeForce(ThreadPool& threads, int threadIndex) {
@@ -159,10 +171,10 @@ void CpuCustomNonbondedForce::threadComputeForce(ThreadPool& threads, int thread
     double& energy = threadEnergy[threadIndex];
     float* forces = &(*threadForce)[threadIndex][0];
     ThreadData& data = *threadData[threadIndex];
-    for (map<string, double>::const_iterator iter = globalParameters->begin(); iter != globalParameters->end(); ++iter) {
-        ReferenceForce::setVariable(ReferenceForce::getVariablePointer(data.energyExpression, iter->first), iter->second);
-        ReferenceForce::setVariable(ReferenceForce::getVariablePointer(data.forceExpression, iter->first), iter->second);
-    }
+    for (map<string, double>::const_iterator iter = globalParameters->begin(); iter != globalParameters->end(); ++iter)
+        data.expressionSet.setVariable(data.expressionSet.getVariableIndex(iter->first), iter->second);
+    for (int i = 0; i < data.energyParamDerivs.size(); i++)
+        data.energyParamDerivs[i] = 0.0;
     fvec4 boxSize(periodicBoxVectors[0][0], periodicBoxVectors[1][1], periodicBoxVectors[2][2], 0);
     fvec4 invBoxSize(recipBoxSize[0], recipBoxSize[1], recipBoxSize[2], 0);
     if (groupInteractions.size() > 0) {
@@ -175,10 +187,8 @@ void CpuCustomNonbondedForce::threadComputeForce(ThreadPool& threads, int thread
             int atom1 = groupInteractions[i].first;
             int atom2 = groupInteractions[i].second;
             for (int j = 0; j < (int) paramNames.size(); j++) {
-                ReferenceForce::setVariable(data.energyParticleParams[j*2], atomParameters[atom1][j]);
-                ReferenceForce::setVariable(data.energyParticleParams[j*2+1], atomParameters[atom2][j]);
-                ReferenceForce::setVariable(data.forceParticleParams[j*2], atomParameters[atom1][j]);
-                ReferenceForce::setVariable(data.forceParticleParams[j*2+1], atomParameters[atom2][j]);
+                data.expressionSet.setVariable(data.particleParamIndex[j*2], atomParameters[atom1][j]);
+                data.expressionSet.setVariable(data.particleParamIndex[j*2+1], atomParameters[atom2][j]);
             }
             calculateOneIxn(atom1, atom2, data, forces, energy, boxSize, invBoxSize);
         }
@@ -196,17 +206,13 @@ void CpuCustomNonbondedForce::threadComputeForce(ThreadPool& threads, int thread
             const vector<char>& exclusions = neighborList->getBlockExclusions(blockIndex);
             for (int i = 0; i < (int) neighbors.size(); i++) {
                 int first = neighbors[i];
-                for (int j = 0; j < (int) paramNames.size(); j++) {
-                    ReferenceForce::setVariable(data.energyParticleParams[j*2], atomParameters[first][j]);
-                    ReferenceForce::setVariable(data.forceParticleParams[j*2], atomParameters[first][j]);
-                }
+                for (int j = 0; j < (int) paramNames.size(); j++)
+                    data.expressionSet.setVariable(data.particleParamIndex[j*2], atomParameters[first][j]);
                 for (int k = 0; k < blockSize; k++) {
                     if ((exclusions[i] & (1<<k)) == 0) {
                         int second = blockAtom[k];
-                        for (int j = 0; j < (int) paramNames.size(); j++) {
-                            ReferenceForce::setVariable(data.energyParticleParams[j*2+1], atomParameters[second][j]);
-                            ReferenceForce::setVariable(data.forceParticleParams[j*2+1], atomParameters[second][j]);
-                        }
+                        for (int j = 0; j < (int) paramNames.size(); j++)
+                            data.expressionSet.setVariable(data.particleParamIndex[j*2+1], atomParameters[second][j]);
                         calculateOneIxn(first, second, data, forces, energy, boxSize, invBoxSize);
                     }
                 }
@@ -223,10 +229,8 @@ void CpuCustomNonbondedForce::threadComputeForce(ThreadPool& threads, int thread
             for (int jj = ii+1; jj < numberOfAtoms; jj++) {
                 if (exclusions[jj].find(ii) == exclusions[jj].end()) {
                     for (int j = 0; j < (int) paramNames.size(); j++) {
-                        ReferenceForce::setVariable(data.energyParticleParams[j*2], atomParameters[ii][j]);
-                        ReferenceForce::setVariable(data.energyParticleParams[j*2+1], atomParameters[jj][j]);
-                        ReferenceForce::setVariable(data.forceParticleParams[j*2], atomParameters[ii][j]);
-                        ReferenceForce::setVariable(data.forceParticleParams[j*2+1], atomParameters[jj][j]);
+                        data.expressionSet.setVariable(data.particleParamIndex[j*2], atomParameters[ii][j]);
+                        data.expressionSet.setVariable(data.particleParamIndex[j*2+1], atomParameters[jj][j]);
                     }
                     calculateOneIxn(ii, jj, data, forces, energy, boxSize, invBoxSize);
                 }
@@ -250,15 +254,15 @@ void CpuCustomNonbondedForce::calculateOneIxn(int ii, int jj, ThreadData& data,
 
     // accumulate forces
 
-    ReferenceForce::setVariable(data.energyR, r);
-    ReferenceForce::setVariable(data.forceR, r);
+    data.expressionSet.setVariable(data.rIndex, r);
     double dEdR = (includeForce ? data.forceExpression.evaluate()/r : 0.0);
     double energy = (includeEnergy ? data.energyExpression.evaluate() : 0.0);
+    double switchValue = 1.0;
     if (useSwitch) {
         if (r > switchingDistance) {
-            RealOpenMM t = (r-switchingDistance)/(cutoffDistance-switchingDistance);
-            RealOpenMM switchValue = 1+t*t*t*(-10+t*(15-t*6));
-            RealOpenMM switchDeriv = t*t*(-30+t*(60-t*30))/(cutoffDistance-switchingDistance);
+            double t = (r-switchingDistance)/(cutoffDistance-switchingDistance);
+            switchValue = 1+t*t*t*(-10+t*(15-t*6));
+            double switchDeriv = t*t*(-30+t*(60-t*30))/(cutoffDistance-switchingDistance);
             dEdR = switchValue*dEdR + energy*switchDeriv/r;
             energy *= switchValue;
         }
@@ -270,6 +274,11 @@ void CpuCustomNonbondedForce::calculateOneIxn(int ii, int jj, ThreadData& data,
     // accumulate energies
 
     totalEnergy += energy;
+    
+    // Accumulate energy derivatives.
+
+    for (int i = 0; i < data.energyParamDerivExpressions.size(); i++)
+        data.energyParamDerivs[i] += switchValue*data.energyParamDerivExpressions[i].evaluate();
 }
 
 void CpuCustomNonbondedForce::getDeltaR(const fvec4& posI, const fvec4& posJ, fvec4& deltaR, float& r2, const fvec4& boxSize, const fvec4& invBoxSize) const {

--- a/platforms/cpu/src/CpuKernels.cpp
+++ b/platforms/cpu/src/CpuKernels.cpp
@@ -880,7 +880,7 @@ double CpuCalcCustomNonbondedForceKernel::execute(ContextImpl& context, bool inc
     // Add in the long range correction.
     
     if (!hasInitializedLongRangeCorrection || (globalParamsChanged && forceCopy != NULL)) {
-        longRangeCoefficient = CustomNonbondedForceImpl::calcLongRangeCorrection(*forceCopy, context.getOwner());
+        CustomNonbondedForceImpl::calcLongRangeCorrection(*forceCopy, context.getOwner(), longRangeCoefficient, longRangeCoefficientDerivs);
         hasInitializedLongRangeCorrection = true;
     }
     energy += longRangeCoefficient/(boxVectors[0][0]*boxVectors[1][1]*boxVectors[2][2]);
@@ -905,7 +905,7 @@ void CpuCalcCustomNonbondedForceKernel::copyParametersToContext(ContextImpl& con
     // If necessary, recompute the long range correction.
     
     if (forceCopy != NULL) {
-        longRangeCoefficient = CustomNonbondedForceImpl::calcLongRangeCorrection(force, context.getOwner());
+        CustomNonbondedForceImpl::calcLongRangeCorrection(force, context.getOwner(), longRangeCoefficient, longRangeCoefficientDerivs);
         hasInitializedLongRangeCorrection = true;
         *forceCopy = force;
     }

--- a/platforms/cuda/include/CudaBondedUtilities.h
+++ b/platforms/cuda/include/CudaBondedUtilities.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2011-2015 Stanford University and the Authors.      *
+ * Portions copyright (c) 2011-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -101,6 +101,15 @@ public:
      */
     std::string addArgument(CUdeviceptr data, const std::string& type);
     /**
+     * Register that the interaction kernel will be computing the derivative of the potential energy
+     * with respect to a parameter.
+     * 
+     * @param param   the name of the parameter
+     * @return the variable that will be used to accumulate the derivative.  Any code you pass to addInteraction() should
+     * add its contributions to this variable.
+     */
+    std::string addEnergyParameterDerivative(const std::string& param);
+    /**
      * Add some Cuda code that should be included in the program, before the start of the kernel.
      * This can be used, for example, to define functions that will be called by the kernel.
      * 
@@ -129,6 +138,7 @@ private:
     std::vector<std::string> argTypes;
     std::vector<std::vector<CudaArray*> > atomIndices;
     std::vector<std::string> prefixCode;
+    std::vector<std::string> energyParameterDerivatives;
     std::vector<void*> kernelArgs;
     int numForceBuffers, maxBonds, allGroups;
     bool hasInitializedKernels, hasInteractions;

--- a/platforms/cuda/include/CudaContext.h
+++ b/platforms/cuda/include/CudaContext.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2009-2015 Stanford University and the Authors.      *
+ * Portions copyright (c) 2009-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -176,6 +176,12 @@ public:
      */
     CudaArray& getEnergyBuffer() {
         return *energyBuffer;
+    }
+    /**
+     * Get the array which contains the buffer in which derivatives of the energy with respect to parameters are computed.
+     */
+    CudaArray& getEnergyParamDerivBuffer() {
+        return *energyParamDerivBuffer;
     }
     /**
      * Get a pointer to a block of pinned memory that can be used for efficient transfers between host and device.
@@ -545,6 +551,27 @@ public:
         return postComputations;
     }
     /**
+     * Get the names of all parameters with respect to which energy derivatives are computed.
+     */
+    const std::vector<std::string>& getEnergyParamDerivNames() const {
+        return energyParamDerivNames;
+    }
+    /**
+     * Get a workspace data structure used for accumulating the values of derivatives of the energy
+     * with respect to parameters.
+     */
+    std::map<std::string, double>& getEnergyParamDerivWorkspace() {
+        return energyParamDerivWorkspace;
+    }
+    /**
+     * Register that the derivative of potential energy with respect to a context parameter
+     * will need to be calculated.  If this is called multiple times for a single parameter,
+     * it is only added to the list once.
+     * 
+     * @param param    the name of the parameter to add
+     */
+    void addEnergyParameterDerivative(const std::string& param);
+    /**
      * Mark that the current molecule definitions (and hence the atom order) may be invalid.
      * This should be called whenever force field parameters change.  It will cause the definitions
      * and order to be revalidated.
@@ -609,7 +636,10 @@ private:
     CudaArray* velm;
     CudaArray* force;
     CudaArray* energyBuffer;
+    CudaArray* energyParamDerivBuffer;
     CudaArray* atomIndexDevice;
+    std::vector<std::string> energyParamDerivNames;
+    std::map<std::string, double> energyParamDerivWorkspace;
     std::vector<int> atomIndex;
     std::vector<CUdeviceptr> autoclearBuffers;
     std::vector<int> autoclearBufferSizes;

--- a/platforms/cuda/include/CudaKernels.h
+++ b/platforms/cuda/include/CudaKernels.h
@@ -164,6 +164,12 @@ public:
      */
     void getForces(ContextImpl& context, std::vector<Vec3>& forces);
     /**
+     * Get the current derivatives of the energy with respect to context parameters.
+     *
+     * @param derivs  on exit, this contains the derivatives
+     */
+    void getEnergyParameterDerivatives(ContextImpl& context, std::map<std::string, double>& derivs);
+    /**
      * Get the current periodic box vectors.
      *
      * @param a      on exit, this contains the vector defining the first edge of the periodic box

--- a/platforms/cuda/include/CudaKernels.h
+++ b/platforms/cuda/include/CudaKernels.h
@@ -979,6 +979,7 @@ public:
 
 private:
     int numGroups, numBonds;
+    bool needEnergyParamDerivs;
     CudaContext& cu;
     CudaParameterSet* params;
     CudaArray* globals;

--- a/platforms/cuda/include/CudaKernels.h
+++ b/platforms/cuda/include/CudaKernels.h
@@ -826,13 +826,15 @@ public:
     void copyParametersToContext(ContextImpl& context, const CustomGBForce& force);
 private:
     double cutoff;
-    bool hasInitializedKernels, needParameterGradient;
+    bool hasInitializedKernels, needParameterGradient, needEnergyParamDerivs;
     int maxTiles, numComputedValues;
     CudaContext& cu;
     CudaParameterSet* params;
     CudaParameterSet* computedValues;
     CudaParameterSet* energyDerivs;
     CudaParameterSet* energyDerivChain;
+    std::vector<CudaParameterSet*> dValuedParam;
+    std::vector<CudaArray*> dValue0dParam;
     CudaArray* longEnergyDerivs;
     CudaArray* globals;
     CudaArray* valueBuffers;

--- a/platforms/cuda/include/CudaKernels.h
+++ b/platforms/cuda/include/CudaKernels.h
@@ -735,6 +735,7 @@ private:
     std::vector<float> globalParamValues;
     std::vector<CudaArray*> tabulatedFunctions;
     double longRangeCoefficient;
+    std::vector<double> longRangeCoefficientDerivs;
     bool hasInitializedLongRangeCorrection, hasInitializedKernel;
     int numGroupThreadBlocks;
     CustomNonbondedForce* forceCopy;

--- a/platforms/cuda/include/CudaNonbondedUtilities.h
+++ b/platforms/cuda/include/CudaNonbondedUtilities.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2009-2013 Stanford University and the Authors.      *
+ * Portions copyright (c) 2009-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -88,6 +88,15 @@ public:
      * Add an array (other than a per-atom parameter) that should be passed as an argument to the default interaction kernel.
      */
     void addArgument(const ParameterInfo& parameter);
+    /**
+     * Register that the interaction kernel will be computing the derivative of the potential energy
+     * with respect to a parameter.
+     * 
+     * @param param   the name of the parameter
+     * @return the variable that will be used to accumulate the derivative.  Any code you pass to addInteraction() should
+     * add its contributions to this variable.
+     */
+    std::string addEnergyParameterDerivative(const std::string& param);
     /**
      * Specify the list of exclusions that an interaction outside the default kernel will depend on.
      * 
@@ -275,6 +284,7 @@ private:
     std::vector<std::vector<int> > atomExclusions;
     std::vector<ParameterInfo> parameters;
     std::vector<ParameterInfo> arguments;
+    std::vector<std::string> energyParameterDerivatives;
     std::map<int, double> groupCutoff;
     std::map<int, std::string> groupKernelSource;
     double lastCutoff;

--- a/platforms/cuda/src/CudaContext.cpp
+++ b/platforms/cuda/src/CudaContext.cpp
@@ -76,7 +76,7 @@ bool CudaContext::hasInitializedCuda = false;
 CudaContext::CudaContext(const System& system, int deviceIndex, bool useBlockingSync, const string& precision, const string& compiler,
         const string& tempDir, const std::string& hostCompiler, CudaPlatform::PlatformData& platformData) : system(system), currentStream(0),
         time(0.0), platformData(platformData), stepCount(0), computeForceCount(0), stepsSinceReorder(99999), contextIsValid(false), atomsWereReordered(false), hasCompilerKernel(false),
-        pinnedBuffer(NULL), posq(NULL), posqCorrection(NULL), velm(NULL), force(NULL), energyBuffer(NULL), atomIndexDevice(NULL), integration(NULL), expression(NULL), bonded(NULL), nonbonded(NULL), thread(NULL) {
+        pinnedBuffer(NULL), posq(NULL), posqCorrection(NULL), velm(NULL), force(NULL), energyBuffer(NULL), energyParamDerivBuffer(NULL), atomIndexDevice(NULL), integration(NULL), expression(NULL), bonded(NULL), nonbonded(NULL), thread(NULL) {
     this->compiler = "\""+compiler+"\"";
     if (platformData.context != NULL) {
         try {
@@ -339,6 +339,8 @@ CudaContext::~CudaContext() {
         delete force;
     if (energyBuffer != NULL)
         delete energyBuffer;
+    if (energyParamDerivBuffer != NULL)
+        delete energyParamDerivBuffer;
     if (atomIndexDevice != NULL)
         delete atomIndexDevice;
     if (integration != NULL)
@@ -390,6 +392,14 @@ void CudaContext::initialize() {
     force = CudaArray::create<long long>(*this, paddedNumAtoms*3, "force");
     addAutoclearBuffer(force->getDevicePointer(), force->getSize()*force->getElementSize());
     addAutoclearBuffer(energyBuffer->getDevicePointer(), energyBuffer->getSize()*energyBuffer->getElementSize());
+    int numEnergyParamDerivs = energyParamDerivNames.size();
+    if (numEnergyParamDerivs > 0) {
+        if (useDoublePrecision || useMixedPrecision)
+            energyParamDerivBuffer = CudaArray::create<double>(*this, numEnergyParamDerivs*numEnergyBuffers, "energyParamDerivBuffer");
+        else
+            energyParamDerivBuffer = CudaArray::create<float>(*this, numEnergyParamDerivs*numEnergyBuffers, "energyParamDerivBuffer");
+        addAutoclearBuffer(*energyParamDerivBuffer);
+    }
     atomIndexDevice = CudaArray::create<int>(*this, paddedNumAtoms, "atomIndex");
     atomIndex.resize(paddedNumAtoms);
     for (int i = 0; i < paddedNumAtoms; ++i)
@@ -1309,6 +1319,15 @@ void CudaContext::addPreComputation(ForcePreComputation* computation) {
 
 void CudaContext::addPostComputation(ForcePostComputation* computation) {
     postComputations.push_back(computation);
+}
+
+void CudaContext::addEnergyParameterDerivative(const string& param) {
+    // See if this parameter has already been registered.
+    
+    for (int i = 0; i < energyParamDerivNames.size(); i++)
+        if (param == energyParamDerivNames[i])
+            return;
+    energyParamDerivNames.push_back(param);
 }
 
 struct CudaContext::WorkThread::ThreadData {

--- a/platforms/cuda/src/CudaKernels.cpp
+++ b/platforms/cuda/src/CudaKernels.cpp
@@ -2540,13 +2540,13 @@ double CudaCalcCustomNonbondedForceKernel::execute(ContextImpl& context, bool in
         if (changed) {
             globals->upload(globalParamValues);
             if (forceCopy != NULL) {
-                longRangeCoefficient = CustomNonbondedForceImpl::calcLongRangeCorrection(*forceCopy, context.getOwner());
+                CustomNonbondedForceImpl::calcLongRangeCorrection(*forceCopy, context.getOwner(), longRangeCoefficient, longRangeCoefficientDerivs);
                 hasInitializedLongRangeCorrection = true;
             }
         }
     }
     if (!hasInitializedLongRangeCorrection) {
-        longRangeCoefficient = CustomNonbondedForceImpl::calcLongRangeCorrection(*forceCopy, context.getOwner());
+        CustomNonbondedForceImpl::calcLongRangeCorrection(*forceCopy, context.getOwner(), longRangeCoefficient, longRangeCoefficientDerivs);
         hasInitializedLongRangeCorrection = true;
     }
     if (interactionGroupData != NULL) {
@@ -2596,7 +2596,7 @@ void CudaCalcCustomNonbondedForceKernel::copyParametersToContext(ContextImpl& co
     // If necessary, recompute the long range correction.
     
     if (forceCopy != NULL) {
-        longRangeCoefficient = CustomNonbondedForceImpl::calcLongRangeCorrection(force, context.getOwner());
+        CustomNonbondedForceImpl::calcLongRangeCorrection(force, context.getOwner(), longRangeCoefficient, longRangeCoefficientDerivs);
         hasInitializedLongRangeCorrection = true;
         *forceCopy = force;
     }

--- a/platforms/cuda/src/CudaKernels.cpp
+++ b/platforms/cuda/src/CudaKernels.cpp
@@ -339,6 +339,10 @@ void CudaUpdateStateDataKernel::getForces(ContextImpl& context, vector<Vec3>& fo
         forces[order[i]] = Vec3(scale*force[i], scale*force[i+paddedNumParticles], scale*force[i+paddedNumParticles*2]);
 }
 
+void CudaUpdateStateDataKernel::getEnergyParameterDerivatives(ContextImpl& context, map<string, double>& derivs) {
+    
+}
+
 void CudaUpdateStateDataKernel::getPeriodicBoxVectors(ContextImpl& context, Vec3& a, Vec3& b, Vec3& c) const {
     cu.getPeriodicBoxVectors(a, b, c);
 }

--- a/platforms/cuda/src/kernels/customCentroidBond.cu
+++ b/platforms/cuda/src/kernels/customCentroidBond.cu
@@ -111,10 +111,12 @@ extern "C" __global__ void computeGroupForces(unsigned long long* __restrict__ g
         const int* __restrict__ bondGroups, real4 periodicBoxSize, real4 invPeriodicBoxSize, real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ
         EXTRA_ARGS) {
     mixed energy = 0;
+    INIT_PARAM_DERIVS
     for (int index = blockIdx.x*blockDim.x+threadIdx.x; index < NUM_BONDS; index += blockDim.x*gridDim.x) {
         COMPUTE_FORCE
     }
     energyBuffer[blockIdx.x*blockDim.x+threadIdx.x] += energy;
+    SAVE_PARAM_DERIVS
 }
 
 /**

--- a/platforms/cuda/src/kernels/customGBEnergyN2.cu
+++ b/platforms/cuda/src/kernels/customGBEnergyN2.cu
@@ -28,6 +28,7 @@ extern "C" __global__ void computeN2Energy(unsigned long long* __restrict__ forc
     const unsigned int tgx = threadIdx.x & (TILE_SIZE-1);
     const unsigned int tbx = threadIdx.x - tgx;
     mixed energy = 0;
+    INIT_PARAM_DERIVS
     __shared__ AtomData localData[THREAD_BLOCK_SIZE];
 
     // First loop: process tiles that contain exclusions.
@@ -69,6 +70,7 @@ extern "C" __global__ void computeN2Energy(unsigned long long* __restrict__ forc
                     atom2 = y*TILE_SIZE+j;
                     real dEdR = 0;
                     real tempEnergy = 0;
+                    const real interactionScale = 0.5f;
 #ifdef USE_EXCLUSIONS
                     bool isExcluded = !(excl & 0x1);
 #endif
@@ -120,6 +122,7 @@ extern "C" __global__ void computeN2Energy(unsigned long long* __restrict__ forc
                     atom2 = y*TILE_SIZE+tj;
                     real dEdR = 0;
                     real tempEnergy = 0;
+                    const real interactionScale = 1;
 #ifdef USE_EXCLUSIONS
                     bool isExcluded = !(excl & 0x1);
 #endif
@@ -266,6 +269,7 @@ extern "C" __global__ void computeN2Energy(unsigned long long* __restrict__ forc
                         atom2 = atomIndices[tbx+tj];
                         real dEdR = 0;
                         real tempEnergy = 0;
+                        const real interactionScale = 1;
                         if (atom1 < NUM_ATOMS && atom2 < NUM_ATOMS) {
                             COMPUTE_INTERACTION
                             dEdR /= -r;
@@ -309,6 +313,7 @@ extern "C" __global__ void computeN2Energy(unsigned long long* __restrict__ forc
                         atom2 = atomIndices[tbx+tj];
                         real dEdR = 0;
                         real tempEnergy = 0;
+                        const real interactionScale = 1;
                         if (atom1 < NUM_ATOMS && atom2 < NUM_ATOMS) {
                             COMPUTE_INTERACTION
                             dEdR /= -r;
@@ -353,4 +358,5 @@ extern "C" __global__ void computeN2Energy(unsigned long long* __restrict__ forc
         pos++;
     }
     energyBuffer[blockIdx.x*blockDim.x+threadIdx.x] += energy;
+    SAVE_PARAM_DERIVS
 }

--- a/platforms/cuda/src/kernels/customGBEnergyPerParticle.cu
+++ b/platforms/cuda/src/kernels/customGBEnergyPerParticle.cu
@@ -5,6 +5,7 @@
 extern "C" __global__ void computePerParticleEnergy(long long* __restrict__ forceBuffers, mixed* __restrict__ energyBuffer, const real4* __restrict__ posq
         PARAMETER_ARGUMENTS) {
     mixed energy = 0;
+    INIT_PARAM_DERIVS
     for (unsigned int index = blockIdx.x*blockDim.x+threadIdx.x; index < NUM_ATOMS; index += blockDim.x*gridDim.x) {
         // Load the derivatives
 
@@ -17,4 +18,5 @@ extern "C" __global__ void computePerParticleEnergy(long long* __restrict__ forc
         COMPUTE_ENERGY
     }
     energyBuffer[blockIdx.x*blockDim.x+threadIdx.x] += energy;
+    SAVE_PARAM_DERIVS
 }

--- a/platforms/cuda/src/kernels/customGBGradientChainRule.cu
+++ b/platforms/cuda/src/kernels/customGBGradientChainRule.cu
@@ -4,6 +4,7 @@
 
 extern "C" __global__ void computeGradientChainRuleTerms(long long* __restrict__ forceBuffers, const real4* __restrict__ posq
         PARAMETER_ARGUMENTS) {
+    INIT_PARAM_DERIVS
     const real scale = RECIP((real) 0x100000000);
     for (unsigned int index = blockIdx.x*blockDim.x+threadIdx.x; index < NUM_ATOMS; index += blockDim.x*gridDim.x) {
         real4 pos = posq[index];
@@ -13,4 +14,5 @@ extern "C" __global__ void computeGradientChainRuleTerms(long long* __restrict__
         forceBuffers[index+PADDED_NUM_ATOMS] = (long long) (force.y*0x100000000);
         forceBuffers[index+PADDED_NUM_ATOMS*2] = (long long) (force.z*0x100000000);
     }
+    SAVE_PARAM_DERIVS
 }

--- a/platforms/cuda/src/kernels/customGBValuePerParticle.cu
+++ b/platforms/cuda/src/kernels/customGBValuePerParticle.cu
@@ -8,6 +8,7 @@ extern "C" __global__ void computePerParticleValues(real4* posq, long long* valu
         // Load the pairwise value
 
         real sum = valueBuffers[index]/(real) 0x100000000;
+        REDUCE_PARAM0_DERIV
         
         // Now calculate other values
 

--- a/platforms/cuda/src/kernels/customIntegratorPerDof.cu
+++ b/platforms/cuda/src/kernels/customIntegratorPerDof.cu
@@ -33,7 +33,8 @@ inline __device__ mixed4 convertFromDouble4(double4 a) {
 
 extern "C" __global__ void computePerDof(real4* __restrict__ posq, real4* __restrict__ posqCorrection, mixed4* __restrict__ posDelta,
         mixed4* __restrict__ velm, const long long* __restrict__ force, const mixed2* __restrict__ dt, const mixed* __restrict__ globals,
-        mixed* __restrict__ sum, const float4* __restrict__ gaussianValues, unsigned int gaussianBaseIndex, const float4* __restrict__ uniformValues, const real energy
+        mixed* __restrict__ sum, const float4* __restrict__ gaussianValues, unsigned int gaussianBaseIndex, const float4* __restrict__ uniformValues,
+        const real energy, mixed* __restrict__ energyParamDerivs
         PARAMETER_ARGUMENTS) {
     mixed stepSize = dt[0].y;
     int index = blockIdx.x*blockDim.x+threadIdx.x;

--- a/platforms/cuda/src/kernels/customNonbonded.cu
+++ b/platforms/cuda/src/kernels/customNonbonded.cu
@@ -4,15 +4,18 @@ if (!isExcluded && r2 < CUTOFF_SQUARED) {
 if (!isExcluded) {
 #endif
     real tempForce = 0;
-    COMPUTE_FORCE
+    real switchValue = 1, switchDeriv = 0;
 #if USE_SWITCH
     if (r > SWITCH_CUTOFF) {
         real x = r-SWITCH_CUTOFF;
-        real switchValue = 1+x*x*x*(SWITCH_C3+x*(SWITCH_C4+x*SWITCH_C5));
-        real switchDeriv = x*x*(3*SWITCH_C3+x*(4*SWITCH_C4+x*5*SWITCH_C5));
-        tempForce = tempForce*switchValue - tempEnergy*switchDeriv;
-        tempEnergy *= switchValue;
+        switchValue = 1+x*x*x*(SWITCH_C3+x*(SWITCH_C4+x*SWITCH_C5));
+        switchDeriv = x*x*(3*SWITCH_C3+x*(4*SWITCH_C4+x*5*SWITCH_C5));
     }
+#endif
+    COMPUTE_FORCE
+#if USE_SWITCH
+    tempForce = tempForce*switchValue - tempEnergy*switchDeriv;
+    tempEnergy *= switchValue;
 #endif
     dEdR += tempForce*invR;
 }

--- a/platforms/cuda/src/kernels/nonbonded.cu
+++ b/platforms/cuda/src/kernels/nonbonded.cu
@@ -113,6 +113,7 @@ extern "C" __global__ void computeNonbonded(
     const unsigned int tgx = threadIdx.x & (TILE_SIZE-1); // index within the warp
     const unsigned int tbx = threadIdx.x - tgx;           // block warpIndex
     mixed energy = 0;
+    INIT_DERIVATIVES
     // used shared memory if the device cannot shuffle
 #ifndef ENABLE_SHUFFLE
     __shared__ AtomData localData[THREAD_BLOCK_SIZE];
@@ -175,6 +176,7 @@ extern "C" __global__ void computeNonbonded(
                 bool isExcluded = (atom1 >= NUM_ATOMS || atom2 >= NUM_ATOMS || !(excl & 0x1));
 #endif
                 real tempEnergy = 0.0f;
+                const real interactionScale = 0.5f;
                 COMPUTE_INTERACTION
                 energy += 0.5f*tempEnergy;
 #ifdef INCLUDE_FORCES
@@ -243,6 +245,7 @@ extern "C" __global__ void computeNonbonded(
                 bool isExcluded = (atom1 >= NUM_ATOMS || atom2 >= NUM_ATOMS || !(excl & 0x1));
 #endif
                 real tempEnergy = 0.0f;
+                const real interactionScale = 1.0f;
                 COMPUTE_INTERACTION
                 energy += tempEnergy;
 #ifdef INCLUDE_FORCES
@@ -448,6 +451,7 @@ extern "C" __global__ void computeNonbonded(
                     bool isExcluded = (atom1 >= NUM_ATOMS || atom2 >= NUM_ATOMS);
 #endif
                     real tempEnergy = 0.0f;
+                    const real interactionScale = 1.0f;
                     COMPUTE_INTERACTION
                     energy += tempEnergy;
 #ifdef INCLUDE_FORCES
@@ -518,6 +522,7 @@ extern "C" __global__ void computeNonbonded(
                     bool isExcluded = (atom1 >= NUM_ATOMS || atom2 >= NUM_ATOMS);
 #endif
                     real tempEnergy = 0.0f;
+                    const real interactionScale = 1.0f;
                     COMPUTE_INTERACTION
                     energy += tempEnergy;
 #ifdef INCLUDE_FORCES
@@ -586,4 +591,5 @@ extern "C" __global__ void computeNonbonded(
 #ifdef INCLUDE_ENERGY
     energyBuffer[blockIdx.x*blockDim.x+threadIdx.x] += energy;
 #endif
+    SAVE_DERIVATIVES
 }

--- a/platforms/opencl/include/OpenCLBondedUtilities.h
+++ b/platforms/opencl/include/OpenCLBondedUtilities.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2011-2015 Stanford University and the Authors.      *
+ * Portions copyright (c) 2011-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -101,6 +101,15 @@ public:
      */
     std::string addArgument(cl::Memory& data, const std::string& type);
     /**
+     * Register that the interaction kernel will be computing the derivative of the potential energy
+     * with respect to a parameter.
+     * 
+     * @param param   the name of the parameter
+     * @return the variable that will be used to accumulate the derivative.  Any code you pass to addInteraction() should
+     * add its contributions to this variable.
+     */
+    std::string addEnergyParameterDerivative(const std::string& param);
+    /**
      * Add some OpenCL code that should be included in the program, before the start of the kernel.
      * This can be used, for example, to define functions that will be called by the kernel.
      * 
@@ -137,6 +146,7 @@ private:
     std::vector<OpenCLArray*> atomIndices;
     std::vector<OpenCLArray*> bufferIndices;
     std::vector<std::string> prefixCode;
+    std::vector<std::string> energyParameterDerivatives;
     int numForceBuffers, maxBonds, allGroups;
     bool hasInitializedKernels;
 };

--- a/platforms/opencl/include/OpenCLContext.h
+++ b/platforms/opencl/include/OpenCLContext.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2009-2015 Stanford University and the Authors.      *
+ * Portions copyright (c) 2009-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -263,6 +263,12 @@ public:
      */
     OpenCLArray& getEnergyBuffer() {
         return *energyBuffer;
+    }
+    /**
+     * Get the array which contains the buffer in which derivatives of the energy with respect to parameters are computed.
+     */
+    OpenCLArray& getEnergyParamDerivBuffer() {
+        return *energyParamDerivBuffer;
     }
     /**
      * Get a pointer to a block of pinned memory that can be used for efficient transfers between host and device.
@@ -660,6 +666,27 @@ public:
         return postComputations;
     }
     /**
+     * Get the names of all parameters with respect to which energy derivatives are computed.
+     */
+    const std::vector<std::string>& getEnergyParamDerivNames() const {
+        return energyParamDerivNames;
+    }
+    /**
+     * Get a workspace data structure used for accumulating the values of derivatives of the energy
+     * with respect to parameters.
+     */
+    std::map<std::string, double>& getEnergyParamDerivWorkspace() {
+        return energyParamDerivWorkspace;
+    }
+    /**
+     * Register that the derivative of potential energy with respect to a context parameter
+     * will need to be calculated.  If this is called multiple times for a single parameter,
+     * it is only added to the list once.
+     * 
+     * @param param    the name of the parameter to add
+     */
+    void addEnergyParameterDerivative(const std::string& param);
+    /**
      * Mark that the current molecule definitions (and hence the atom order) may be invalid.
      * This should be called whenever force field parameters change.  It will cause the definitions
      * and order to be revalidated.
@@ -725,7 +752,10 @@ private:
     OpenCLArray* forceBuffers;
     OpenCLArray* longForceBuffer;
     OpenCLArray* energyBuffer;
+    OpenCLArray* energyParamDerivBuffer;
     OpenCLArray* atomIndexDevice;
+    std::vector<std::string> energyParamDerivNames;
+    std::map<std::string, double> energyParamDerivWorkspace;
     std::vector<int> atomIndex;
     std::vector<cl::Memory*> autoclearBuffers;
     std::vector<int> autoclearBufferSizes;

--- a/platforms/opencl/include/OpenCLKernels.h
+++ b/platforms/opencl/include/OpenCLKernels.h
@@ -715,6 +715,7 @@ private:
     std::vector<cl_float> globalParamValues;
     std::vector<OpenCLArray*> tabulatedFunctions;
     double longRangeCoefficient;
+    std::vector<double> longRangeCoefficientDerivs;
     bool hasInitializedLongRangeCorrection, hasInitializedKernel;
     int numGroupThreadBlocks;
     CustomNonbondedForce* forceCopy;

--- a/platforms/opencl/include/OpenCLKernels.h
+++ b/platforms/opencl/include/OpenCLKernels.h
@@ -962,6 +962,7 @@ public:
 
 private:
     int numGroups, numBonds;
+    bool needEnergyParamDerivs;
     OpenCLContext& cl;
     OpenCLParameterSet* params;
     OpenCLArray* globals;

--- a/platforms/opencl/include/OpenCLKernels.h
+++ b/platforms/opencl/include/OpenCLKernels.h
@@ -1282,7 +1282,7 @@ public:
     enum GlobalTargetType {DT, VARIABLE, PARAMETER};
     OpenCLIntegrateCustomStepKernel(std::string name, const Platform& platform, OpenCLContext& cl) : IntegrateCustomStepKernel(name, platform), cl(cl),
             hasInitializedKernels(false), localValuesAreCurrent(false), globalValues(NULL), sumBuffer(NULL), summedValue(NULL), uniformRandoms(NULL),
-            randomSeed(NULL), perDofValues(NULL) {
+            randomSeed(NULL), perDofEnergyParamDerivs(NULL), perDofValues(NULL), needsEnergyParamDerivs(false) {
     }
     ~OpenCLIntegrateCustomStepKernel();
     /**
@@ -1347,8 +1347,11 @@ public:
 private:
     class ReorderListener;
     class GlobalTarget;
+    class DerivFunction;
     std::string createPerDofComputation(const std::string& variable, const Lepton::ParsedExpression& expr, int component, CustomIntegrator& integrator, const std::string& forceName, const std::string& energyName);
     void prepareForComputation(ContextImpl& context, CustomIntegrator& integrator, bool& forcesAreValid);
+    Lepton::ExpressionTreeNode replaceDerivFunctions(const Lepton::ExpressionTreeNode& node, OpenMM::ContextImpl& context);
+    void findExpressionsForDerivs(const Lepton::ExpressionTreeNode& node, std::vector<std::pair<Lepton::ExpressionTreeNode, std::string> >& variableNodes);
     void recordGlobalValue(double value, GlobalTarget target);
     void recordChangedParameters(ContextImpl& context);
     bool evaluateCondition(int step);
@@ -1356,18 +1359,23 @@ private:
     double energy;
     float energyFloat;
     int numGlobalVariables;
-    bool hasInitializedKernels, deviceValuesAreCurrent, deviceGlobalsAreCurrent, modifiesParameters, keNeedsForce, hasAnyConstraints;
+    bool hasInitializedKernels, deviceValuesAreCurrent, deviceGlobalsAreCurrent, modifiesParameters, keNeedsForce, hasAnyConstraints, needsEnergyParamDerivs;
     mutable bool localValuesAreCurrent;
     OpenCLArray* globalValues;
     OpenCLArray* sumBuffer;
     OpenCLArray* summedValue;
     OpenCLArray* uniformRandoms;
     OpenCLArray* randomSeed;
+    OpenCLArray* perDofEnergyParamDerivs;
     std::map<int, OpenCLArray*> savedForces;
     std::set<int> validSavedForces;
     OpenCLParameterSet* perDofValues;
     mutable std::vector<std::vector<cl_float> > localPerDofValuesFloat;
     mutable std::vector<std::vector<cl_double> > localPerDofValuesDouble;
+    std::map<std::string, double> energyParamDerivs;
+    std::vector<std::string> perDofEnergyParamDerivNames;
+    std::vector<cl_float> localPerDofEnergyParamDerivsFloat;
+    std::vector<cl_double> localPerDofEnergyParamDerivsDouble;
     std::vector<float> globalValuesFloat;
     std::vector<double> globalValuesDouble;
     std::vector<double> initialGlobalVariables;

--- a/platforms/opencl/include/OpenCLKernels.h
+++ b/platforms/opencl/include/OpenCLKernels.h
@@ -808,13 +808,15 @@ public:
     void copyParametersToContext(ContextImpl& context, const CustomGBForce& force);
 private:
     double cutoff;
-    bool hasInitializedKernels, needParameterGradient;
+    bool hasInitializedKernels, needParameterGradient, needEnergyParamDerivs;
     int maxTiles, numComputedValues;
     OpenCLContext& cl;
     OpenCLParameterSet* params;
     OpenCLParameterSet* computedValues;
     OpenCLParameterSet* energyDerivs;
     OpenCLParameterSet* energyDerivChain;
+    std::vector<OpenCLParameterSet*> dValuedParam;
+    std::vector<OpenCLArray*> dValue0dParam;
     OpenCLArray* longEnergyDerivs;
     OpenCLArray* globals;
     OpenCLArray* valueBuffers;

--- a/platforms/opencl/include/OpenCLKernels.h
+++ b/platforms/opencl/include/OpenCLKernels.h
@@ -142,6 +142,12 @@ public:
      */
     void getForces(ContextImpl& context, std::vector<Vec3>& forces);
     /**
+     * Get the current derivatives of the energy with respect to context parameters.
+     *
+     * @param derivs  on exit, this contains the derivatives
+     */
+    void getEnergyParameterDerivatives(ContextImpl& context, std::map<std::string, double>& derivs);
+    /**
      * Get the current periodic box vectors.
      *
      * @param a      on exit, this contains the vector defining the first edge of the periodic box

--- a/platforms/opencl/include/OpenCLNonbondedUtilities.h
+++ b/platforms/opencl/include/OpenCLNonbondedUtilities.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2009-2013 Stanford University and the Authors.      *
+ * Portions copyright (c) 2009-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -88,6 +88,15 @@ public:
      * Add an array (other than a per-atom parameter) that should be passed as an argument to the default interaction kernel.
      */
     void addArgument(const ParameterInfo& parameter);
+    /**
+     * Register that the interaction kernel will be computing the derivative of the potential energy
+     * with respect to a parameter.
+     * 
+     * @param param   the name of the parameter
+     * @return the variable that will be used to accumulate the derivative.  Any code you pass to addInteraction() should
+     * add its contributions to this variable.
+     */
+    std::string addEnergyParameterDerivative(const std::string& param);
     /**
      * Specify the list of exclusions that an interaction outside the default kernel will depend on.
      * 
@@ -287,6 +296,7 @@ private:
     std::vector<std::vector<int> > atomExclusions;
     std::vector<ParameterInfo> parameters;
     std::vector<ParameterInfo> arguments;
+    std::vector<std::string> energyParameterDerivatives;
     std::map<int, double> groupCutoff;
     std::map<int, std::string> groupKernelSource;
     double lastCutoff;

--- a/platforms/opencl/src/OpenCLBondedUtilities.cpp
+++ b/platforms/opencl/src/OpenCLBondedUtilities.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2011-2015 Stanford University and the Authors.      *
+ * Portions copyright (c) 2011-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -56,10 +56,23 @@ void OpenCLBondedUtilities::addInteraction(const vector<vector<int> >& atoms, co
     }
 }
 
-std::string OpenCLBondedUtilities::addArgument(cl::Memory& data, const string& type) {
+string OpenCLBondedUtilities::addArgument(cl::Memory& data, const string& type) {
     arguments.push_back(&data);
     argTypes.push_back(type);
     return "customArg"+context.intToString(arguments.size());
+}
+
+string OpenCLBondedUtilities::addEnergyParameterDerivative(const string& param) {
+    // See if the parameter has already been added.
+    
+    int index;
+    for (index = 0; index < energyParameterDerivatives.size(); index++)
+        if (param == energyParameterDerivatives[index])
+            break;
+    if (index == energyParameterDerivatives.size())
+        energyParameterDerivatives.push_back(param);
+    context.addEnergyParameterDerivative(param);
+    return string("energyParamDeriv")+context.intToString(index);
 }
 
 void OpenCLBondedUtilities::addPrefixCode(const string& source) {
@@ -190,13 +203,23 @@ void OpenCLBondedUtilities::initialize(const System& system) {
         }
         for (int i = 0; i < (int) arguments.size(); i++)
             s<<", __global "<<argTypes[i]<<"* customArg"<<(i+1);
+        if (energyParameterDerivatives.size() > 0)
+            s<<", __global mixed* energyParamDerivs";
         s<<") {\n";
         s<<"mixed energy = 0;\n";
+        for (int i = 0; i < energyParameterDerivatives.size(); i++)
+            s<<"mixed energyParamDeriv"<<i<<" = 0;\n";
         for (int i = 0; i < setSize; i++) {
             int force = set[i];
             s<<createForceSource(i, forceAtoms[force].size(), forceAtoms[force][0].size(), forceGroup[force], forceSource[force]);
         }
         s<<"energyBuffer[get_global_id(0)] += energy;\n";
+        const vector<string>& allParamDerivNames = context.getEnergyParamDerivNames();
+        int numDerivs = allParamDerivNames.size();
+        for (int i = 0; i < energyParameterDerivatives.size(); i++)
+            for (int index = 0; index < numDerivs; index++)
+                if (allParamDerivNames[index] == energyParameterDerivatives[i])
+                    s<<"energyParamDerivs[get_global_id(0)*"<<numDerivs<<"+"<<i<<"] += energyParamDeriv"<<i<<";\n";
         s<<"}\n";
         map<string, string> defines;
         defines["PADDED_NUM_ATOMS"] = context.intToString(context.getPaddedNumAtoms());
@@ -274,6 +297,8 @@ void OpenCLBondedUtilities::computeInteractions(int groups) {
             }
             for (int j = 0; j < (int) arguments.size(); j++)
                 kernel.setArg<cl::Memory>(index++, *arguments[j]);
+            if (energyParameterDerivatives.size() > 0)
+                kernel.setArg<cl::Memory>(index++, context.getEnergyParamDerivBuffer().getDeviceBuffer());
         }
     }
     for (int i = 0; i < (int) kernels.size(); i++) {

--- a/platforms/opencl/src/OpenCLBondedUtilities.cpp
+++ b/platforms/opencl/src/OpenCLBondedUtilities.cpp
@@ -204,7 +204,7 @@ void OpenCLBondedUtilities::initialize(const System& system) {
         for (int i = 0; i < (int) arguments.size(); i++)
             s<<", __global "<<argTypes[i]<<"* customArg"<<(i+1);
         if (energyParameterDerivatives.size() > 0)
-            s<<", __global mixed* energyParamDerivs";
+            s<<", __global mixed* restrict energyParamDerivs";
         s<<") {\n";
         s<<"mixed energy = 0;\n";
         for (int i = 0; i < energyParameterDerivatives.size(); i++)
@@ -219,7 +219,7 @@ void OpenCLBondedUtilities::initialize(const System& system) {
         for (int i = 0; i < energyParameterDerivatives.size(); i++)
             for (int index = 0; index < numDerivs; index++)
                 if (allParamDerivNames[index] == energyParameterDerivatives[i])
-                    s<<"energyParamDerivs[get_global_id(0)*"<<numDerivs<<"+"<<i<<"] += energyParamDeriv"<<i<<";\n";
+                    s<<"energyParamDerivs[get_global_id(0)*"<<numDerivs<<"+"<<index<<"] += energyParamDeriv"<<i<<";\n";
         s<<"}\n";
         map<string, string> defines;
         defines["PADDED_NUM_ATOMS"] = context.intToString(context.getPaddedNumAtoms());

--- a/platforms/opencl/src/OpenCLKernels.cpp
+++ b/platforms/opencl/src/OpenCLKernels.cpp
@@ -3301,7 +3301,7 @@ void OpenCLCalcCustomGBForceKernel::initialize(const System& system, const Custo
             string variableName = "dValuedParam_0_"+cl.intToString(i);
             if (useLong) {
                 extraArgs << ", __global const long* restrict dValue0dParam" << i;
-                deriv0 << "real " << variableName << " = (1.0f/0x100000000)*dValue0dParam[index];\n";
+                deriv0 << "real " << variableName << " = (1.0f/0x100000000)*dValue0dParam" << i << "[index];\n";
             }
             else {
                 extraArgs << ", __global const real* restrict dValue0dParam" << i;

--- a/platforms/opencl/src/OpenCLKernels.cpp
+++ b/platforms/opencl/src/OpenCLKernels.cpp
@@ -368,6 +368,10 @@ void OpenCLUpdateStateDataKernel::getForces(ContextImpl& context, vector<Vec3>& 
     }
 }
 
+void OpenCLUpdateStateDataKernel::getEnergyParameterDerivatives(ContextImpl& context, map<string, double>& derivs) {
+    
+}
+
 void OpenCLUpdateStateDataKernel::getPeriodicBoxVectors(ContextImpl& context, Vec3& a, Vec3& b, Vec3& c) const {
     cl.getPeriodicBoxVectors(a, b, c);
 }

--- a/platforms/opencl/src/OpenCLKernels.cpp
+++ b/platforms/opencl/src/OpenCLKernels.cpp
@@ -3010,6 +3010,10 @@ OpenCLCalcCustomGBForceKernel::~OpenCLCalcCustomGBForceKernel() {
         delete longValueBuffers;
     for (int i = 0; i < (int) tabulatedFunctions.size(); i++)
         delete tabulatedFunctions[i];
+    for (int i = 0; i < dValue0dParam.size(); i++)
+        delete dValue0dParam[i];
+    for (int i = 0; i < dValuedParam.size(); i++)
+        delete dValuedParam[i];
 }
 
 void OpenCLCalcCustomGBForceKernel::initialize(const System& system, const CustomGBForce& force) {
@@ -3101,18 +3105,24 @@ void OpenCLCalcCustomGBForceKernel::initialize(const System& system, const Custo
 
     vector<vector<Lepton::ParsedExpression> > valueGradientExpressions(force.getNumComputedValues());
     vector<vector<Lepton::ParsedExpression> > valueDerivExpressions(force.getNumComputedValues());
+    vector<vector<Lepton::ParsedExpression> > valueParamDerivExpressions(force.getNumComputedValues());
     needParameterGradient = false;
-    for (int i = 1; i < force.getNumComputedValues(); i++) {
+    for (int i = 0; i < force.getNumComputedValues(); i++) {
         Lepton::ParsedExpression ex = Lepton::Parser::parse(computedValueExpressions[i], functions).optimize();
-        valueGradientExpressions[i].push_back(ex.differentiate("x").optimize());
-        valueGradientExpressions[i].push_back(ex.differentiate("y").optimize());
-        valueGradientExpressions[i].push_back(ex.differentiate("z").optimize());
-        if (!isZeroExpression(valueGradientExpressions[i][0]) || !isZeroExpression(valueGradientExpressions[i][1]) || !isZeroExpression(valueGradientExpressions[i][2]))
-            needParameterGradient = true;
-         for (int j = 0; j < i; j++)
-            valueDerivExpressions[i].push_back(ex.differentiate(computedValueNames[j]).optimize());
+        if (i > 0) {
+            valueGradientExpressions[i].push_back(ex.differentiate("x").optimize());
+            valueGradientExpressions[i].push_back(ex.differentiate("y").optimize());
+            valueGradientExpressions[i].push_back(ex.differentiate("z").optimize());
+            if (!isZeroExpression(valueGradientExpressions[i][0]) || !isZeroExpression(valueGradientExpressions[i][1]) || !isZeroExpression(valueGradientExpressions[i][2]))
+                needParameterGradient = true;
+             for (int j = 0; j < i; j++)
+                valueDerivExpressions[i].push_back(ex.differentiate(computedValueNames[j]).optimize());
+        }
+        for (int j = 0; j < force.getNumEnergyParameterDerivatives(); j++)
+            valueParamDerivExpressions[i].push_back(ex.differentiate(force.getEnergyParameterDerivativeName(j)).optimize());
     }
     vector<vector<Lepton::ParsedExpression> > energyDerivExpressions(force.getNumEnergyTerms());
+    vector<vector<Lepton::ParsedExpression> > energyParamDerivExpressions(force.getNumEnergyTerms());
     vector<bool> needChainForValue(force.getNumComputedValues(), false);
     for (int i = 0; i < force.getNumEnergyTerms(); i++) {
         string expression;
@@ -3134,6 +3144,8 @@ void OpenCLCalcCustomGBForceKernel::initialize(const System& system, const Custo
                     needChainForValue[j] = true;
             }
         }
+        for (int j = 0; j < force.getNumEnergyParameterDerivatives(); j++)
+            energyParamDerivExpressions[i].push_back(ex.differentiate(force.getEnergyParameterDerivativeName(j)).optimize());
     }
     bool deviceIsCpu = (cl.getDevice().getInfo<CL_DEVICE_TYPE>() == CL_DEVICE_TYPE_CPU);
     bool useLong = cl.getSupports64BitGlobalAtomics();
@@ -3144,6 +3156,18 @@ void OpenCLCalcCustomGBForceKernel::initialize(const System& system, const Custo
     else
         energyDerivs = new OpenCLParameterSet(cl, force.getNumComputedValues(), cl.getPaddedNumAtoms()*cl.getNonbondedUtilities().getNumForceBuffers(), "customGBEnergyDerivatives", true);
     energyDerivChain = new OpenCLParameterSet(cl, force.getNumComputedValues(), cl.getPaddedNumAtoms(), "customGBEnergyDerivativeChain", true);
+    int elementSize = (cl.getUseDoublePrecision() ? sizeof(cl_double) : sizeof(cl_float));
+    needEnergyParamDerivs = (force.getNumEnergyParameterDerivatives() > 0);
+    for (int i = 0; i < force.getNumEnergyParameterDerivatives(); i++) {
+        dValuedParam.push_back(new OpenCLParameterSet(cl, force.getNumComputedValues(), cl.getPaddedNumAtoms(), "dValuedParam", true));
+        if (useLong)
+            dValue0dParam.push_back(OpenCLArray::create<cl_long>(cl, cl.getPaddedNumAtoms(), "dValue0dParam"));
+        else
+            dValue0dParam.push_back(new OpenCLArray(cl, cl.getPaddedNumAtoms()*cl.getNonbondedUtilities().getNumForceBuffers(), elementSize, "dValue0dParam"));
+        cl.addAutoclearBuffer(*dValue0dParam.back());
+        string name = force.getEnergyParameterDerivativeName(i);
+        cl.addEnergyParameterDerivative(name);
+    }
 
     // Create the kernels.
 
@@ -3175,11 +3199,18 @@ void OpenCLCalcCustomGBForceKernel::initialize(const System& system, const Custo
         Lepton::ParsedExpression ex = Lepton::Parser::parse(computedValueExpressions[0], functions).optimize();
         n2ValueExpressions["tempValue1 = "] = ex;
         n2ValueExpressions["tempValue2 = "] = ex.renameVariables(rename);
+        for (int i = 0; i < valueParamDerivExpressions[0].size(); i++) {
+            string variableBase = "temp_dValue0dParam"+cl.intToString(i+1);
+            if (!isZeroExpression(valueParamDerivExpressions[0][i])) {
+                n2ValueExpressions[variableBase+"_1 = "] = valueParamDerivExpressions[0][i];
+                n2ValueExpressions[variableBase+"_2 = "] = valueParamDerivExpressions[0][i].renameVariables(rename);
+            }
+        }
         n2ValueSource << cl.getExpressionUtilities().createExpressions(n2ValueExpressions, variables, functionList, functionDefinitions, "temp");
         map<string, string> replacements;
         string n2ValueStr = n2ValueSource.str();
         replacements["COMPUTE_VALUE"] = n2ValueStr;
-        stringstream extraArgs, loadLocal1, loadLocal2, load1, load2;
+        stringstream extraArgs, loadLocal1, loadLocal2, load1, load2, tempDerivs1, tempDerivs2, storeDeriv1, storeDeriv2;
         if (force.getNumGlobalParameters() > 0)
             extraArgs << ", __global const float* globals";
         pairValueUsesParam.resize(params->getBuffers().size(), false);
@@ -3195,11 +3226,39 @@ void OpenCLCalcCustomGBForceKernel::initialize(const System& system, const Custo
                 pairValueUsesParam[i] = true;
             }
         }
+        for (int i = 0; i < force.getNumEnergyParameterDerivatives(); i++) {
+            string derivName = "dValue0dParam"+cl.intToString(i+1);
+            if (useLong)
+                extraArgs << ", __global long* restrict global_" << derivName;
+            else
+                extraArgs << ", __global real* restrict global_" << derivName;
+            extraArgs << ", __local real* restrict local_" << derivName;
+            loadLocal2 << "local_" << derivName << "[localAtomIndex] = 0;\n";
+            load1 << "real " << derivName << " = 0;\n";
+            if (!isZeroExpression(valueParamDerivExpressions[0][i])) {
+                load2 << "real temp_" << derivName << "_1 = 0;\n";
+                load2 << "real temp_" << derivName << "_2 = 0;\n";
+                tempDerivs1 << derivName << " += temp_" << derivName << "_1;\n";
+                tempDerivs2 << "local_" << derivName << "[tbx+tj] += temp_" << derivName << "_2;\n";
+                if (useLong) {
+                    storeDeriv1 << "atom_add(&global_" << derivName << "[offset1], (long) (" << derivName << "*0x100000000));\n";
+                    storeDeriv2 << "atom_add(&global_" << derivName << "[offset2], (long) (local_" << derivName << "[get_local_id(0)]*0x100000000));\n";
+                }
+                else {
+                    storeDeriv1 << "global_" << derivName << "[offset1] += " << derivName << ";\n";
+                    storeDeriv2 << "global_" << derivName << "[offset2] += local_" << derivName << "[get_local_id(0)];\n";
+                }
+            }
+        }
         replacements["PARAMETER_ARGUMENTS"] = extraArgs.str()+tableArgs.str();
         replacements["LOAD_LOCAL_PARAMETERS_FROM_1"] = loadLocal1.str();
         replacements["LOAD_LOCAL_PARAMETERS_FROM_GLOBAL"] = loadLocal2.str();
         replacements["LOAD_ATOM1_PARAMETERS"] = load1.str();
         replacements["LOAD_ATOM2_PARAMETERS"] = load2.str();
+        replacements["ADD_TEMP_DERIVS1"] = tempDerivs1.str();
+        replacements["ADD_TEMP_DERIVS2"] = tempDerivs2.str();
+        replacements["STORE_PARAM_DERIVS1"] = storeDeriv1.str();
+        replacements["STORE_PARAM_DERIVS2"] = storeDeriv2.str();
         if (useCutoff)
             pairValueDefines["USE_CUTOFF"] = "1";
         if (usePeriodic)
@@ -3224,7 +3283,7 @@ void OpenCLCalcCustomGBForceKernel::initialize(const System& system, const Custo
     {
         // Create the kernel to reduce the N2 value and calculate other values.
 
-        stringstream reductionSource, extraArgs;
+        stringstream reductionSource, extraArgs, deriv0;
         if (force.getNumGlobalParameters() > 0)
             extraArgs << ", __global const float* globals";
         for (int i = 0; i < (int) params->getBuffers().size(); i++) {
@@ -3237,6 +3296,22 @@ void OpenCLCalcCustomGBForceKernel::initialize(const System& system, const Custo
             string valueName = "values"+cl.intToString(i+1);
             extraArgs << ", __global " << buffer.getType() << "* restrict global_" << valueName;
             reductionSource << buffer.getType() << " local_" << valueName << ";\n";
+        }
+        for (int i = 0; i < force.getNumEnergyParameterDerivatives(); i++) {
+            string variableName = "dValuedParam_0_"+cl.intToString(i);
+            if (useLong) {
+                extraArgs << ", __global const long* restrict dValue0dParam" << i;
+                deriv0 << "real " << variableName << " = (1.0f/0x100000000)*dValue0dParam[index];\n";
+            }
+            else {
+                extraArgs << ", __global const real* restrict dValue0dParam" << i;
+                deriv0 << "real " << variableName << " = dValue0dParam" << i << "[index];\n";
+                deriv0 << "for (int i = index+bufferSize; i < totalSize; i += bufferSize)\n";
+                deriv0 << "    " << variableName << " += dValue0dParam" << i << "[i];\n";
+            }
+            for (int j = 0; j < dValuedParam[i]->getBuffers().size(); j++)
+                extraArgs << ", __global real* restrict global_dValuedParam_" << j << "_" << i;
+            deriv0 << "global_dValuedParam_0_" << i << "[index] = dValuedParam_0_" << i << ";\n";
         }
         reductionSource << "local_values" << computedValues->getParameterSuffix(0) << " = sum;\n";
         map<string, string> variables;
@@ -3257,8 +3332,26 @@ void OpenCLCalcCustomGBForceKernel::initialize(const System& system, const Custo
             string valueName = "values"+cl.intToString(i+1);
             reductionSource << "global_" << valueName << "[index] = local_" << valueName << ";\n";
         }
+        if (needEnergyParamDerivs) {
+            map<string, Lepton::ParsedExpression> derivExpressions;
+            for (int i = 1; i < force.getNumComputedValues(); i++) {
+                for (int j = 0; j < valueParamDerivExpressions[i].size(); j++)
+                    derivExpressions["real dValuedParam_"+cl.intToString(i)+"_"+cl.intToString(j)+" = "] = valueParamDerivExpressions[i][j];
+                for (int j = 0; j < i; j++)
+                    derivExpressions["real dVdV_"+cl.intToString(i)+"_"+cl.intToString(j)+" = "] = valueDerivExpressions[i][j];
+            }
+            reductionSource << cl.getExpressionUtilities().createExpressions(derivExpressions, variables, functionList, functionDefinitions, "derivChain_temp");
+            for (int i = 1; i < force.getNumComputedValues(); i++) {
+                for (int j = 0; j < i; j++)
+                    for (int k = 0; k < valueParamDerivExpressions[i].size(); k++)
+                        reductionSource << "dValuedParam_" << i << "_" << k << " += dVdV_" << i << "_" << j << "*dValuedParam_" << j <<"_" << k << ";\n";
+                for (int j = 0; j < valueParamDerivExpressions[i].size(); j++)
+                    reductionSource << "global_dValuedParam_" << i << "_" << j << "[index] = dValuedParam_" << i << "_" << j << ";\n";
+            }
+        }
         map<string, string> replacements;
         replacements["PARAMETER_ARGUMENTS"] = extraArgs.str()+tableArgs.str();
+        replacements["REDUCE_PARAM0_DERIV"] = deriv0.str();
         replacements["COMPUTE_VALUES"] = reductionSource.str();
         map<string, string> defines;
         defines["NUM_ATOMS"] = cl.intToString(cl.getNumAtoms());
@@ -3313,6 +3406,8 @@ void OpenCLCalcCustomGBForceKernel::initialize(const System& system, const Custo
                     }
                 }
             }
+            for (int j = 0; j < force.getNumEnergyParameterDerivatives(); j++)
+                n2EnergyExpressions["energyParamDeriv"+cl.intToString(j)+" += interactionScale*"] = energyParamDerivExpressions[i][j];
             if (exclude)
                 n2EnergySource << "if (!isExcluded) {\n";
             n2EnergySource << cl.getExpressionUtilities().createExpressions(n2EnergyExpressions, variables, functionList, functionDefinitions, "temp");
@@ -3322,7 +3417,7 @@ void OpenCLCalcCustomGBForceKernel::initialize(const System& system, const Custo
         map<string, string> replacements;
         string n2EnergyStr = n2EnergySource.str();
         replacements["COMPUTE_INTERACTION"] = n2EnergyStr;
-        stringstream extraArgs, loadLocal1, loadLocal2, clearLocal, load1, load2, declare1, recordDeriv, storeDerivs1, storeDerivs2, declareTemps, setTemps;
+        stringstream extraArgs, loadLocal1, loadLocal2, clearLocal, load1, load2, declare1, recordDeriv, storeDerivs1, storeDerivs2, declareTemps, setTemps, initParamDerivs, saveParamDerivs;
         if (force.getNumGlobalParameters() > 0)
             extraArgs << ", __global const float* globals";
         pairEnergyUsesParam.resize(params->getBuffers().size(), false);
@@ -3381,6 +3476,17 @@ void OpenCLCalcCustomGBForceKernel::initialize(const System& system, const Custo
                 setTemps << "tempDerivBuffer" << index << "[get_local_id(0)] = deriv" << index << "_1;\n";
             }
         }
+        if (needEnergyParamDerivs) {
+            extraArgs << ", __global mixed* restrict energyParamDerivs";
+            const vector<string>& allParamDerivNames = cl.getEnergyParamDerivNames();
+            int numDerivs = allParamDerivNames.size();
+            for (int i = 0; i < force.getNumEnergyParameterDerivatives(); i++) {
+                initParamDerivs << "mixed energyParamDeriv" << i << " = 0;\n";
+                for (int index = 0; index < numDerivs; index++)
+                    if (allParamDerivNames[index] == force.getEnergyParameterDerivativeName(i))
+                        saveParamDerivs << "energyParamDerivs[get_global_id(0)*" << numDerivs << "+" << index << "] += energyParamDeriv" << i << ";\n";
+            }
+        }
         replacements["PARAMETER_ARGUMENTS"] = extraArgs.str()+tableArgs.str();
         replacements["LOAD_LOCAL_PARAMETERS_FROM_1"] = loadLocal1.str();
         replacements["LOAD_LOCAL_PARAMETERS_FROM_GLOBAL"] = loadLocal2.str();
@@ -3393,6 +3499,8 @@ void OpenCLCalcCustomGBForceKernel::initialize(const System& system, const Custo
         replacements["STORE_DERIVATIVES_2"] = storeDerivs2.str();
         replacements["DECLARE_TEMP_BUFFERS"] = declareTemps.str();
         replacements["SET_TEMP_BUFFERS"] = setTemps.str();
+        replacements["INIT_PARAM_DERIVS"] = initParamDerivs.str();
+        replacements["SAVE_PARAM_DERIVS"] = saveParamDerivs.str();
         if (useCutoff)
             pairEnergyDefines["USE_CUTOFF"] = "1";
         if (usePeriodic)
@@ -3415,7 +3523,7 @@ void OpenCLCalcCustomGBForceKernel::initialize(const System& system, const Custo
     {
         // Create the kernel to reduce the derivatives and calculate per-particle energy terms.
 
-        stringstream compute, extraArgs, reduce;
+        stringstream compute, extraArgs, reduce, initParamDerivs, saveParamDerivs;
         if (force.getNumGlobalParameters() > 0)
             extraArgs << ", __global const float* globals";
         for (int i = 0; i < (int) params->getBuffers().size(); i++) {
@@ -3448,6 +3556,17 @@ void OpenCLCalcCustomGBForceKernel::initialize(const System& system, const Custo
         else {
             for (int i = 0; i < (int) energyDerivs->getBuffers().size(); i++)
                 reduce << "REDUCE_VALUE(derivBuffers" << cl.intToString(i+1) << ", " << energyDerivs->getBuffers()[i].getType() << ")\n";
+        }
+        if (needEnergyParamDerivs) {
+            extraArgs << ", __global mixed* restrict energyParamDerivs";
+            const vector<string>& allParamDerivNames = cl.getEnergyParamDerivNames();
+            int numDerivs = allParamDerivNames.size();
+            for (int i = 0; i < force.getNumEnergyParameterDerivatives(); i++) {
+                initParamDerivs << "mixed energyParamDeriv" << i << " = 0;\n";
+                for (int index = 0; index < numDerivs; index++)
+                    if (allParamDerivNames[index] == force.getEnergyParameterDerivativeName(i))
+                        saveParamDerivs << "energyParamDerivs[get_global_id(0)*" << numDerivs << "+" << index << "] += energyParamDeriv" << i << ";\n";
+            }
         }
         
         // Compute the various expressions.
@@ -3482,6 +3601,8 @@ void OpenCLCalcCustomGBForceKernel::initialize(const System& system, const Custo
                 expressions["/*"+cl.intToString(i+1)+"*/ force.y -= "] = grady;
             if (!isZeroExpression(gradz))
                 expressions["/*"+cl.intToString(i+1)+"*/ force.z -= "] = gradz;
+            for (int j = 0; j < force.getNumEnergyParameterDerivatives(); j++)
+                expressions["/*"+cl.intToString(i+1)+"*/ energyParamDeriv"+cl.intToString(j)+" += "] = energyParamDerivExpressions[i][j];
         }
         for (int i = 1; i < force.getNumComputedValues(); i++)
             for (int j = 0; j < i; j++)
@@ -3510,16 +3631,19 @@ void OpenCLCalcCustomGBForceKernel::initialize(const System& system, const Custo
         replacements["PARAMETER_ARGUMENTS"] = extraArgs.str()+tableArgs.str();
         replacements["REDUCE_DERIVATIVES"] = reduce.str();
         replacements["COMPUTE_ENERGY"] = compute.str();
+        replacements["INIT_PARAM_DERIVS"] = initParamDerivs.str();
+        replacements["SAVE_PARAM_DERIVS"] = saveParamDerivs.str();
         map<string, string> defines;
         defines["NUM_ATOMS"] = cl.intToString(cl.getNumAtoms());
         defines["PADDED_NUM_ATOMS"] = cl.intToString(cl.getPaddedNumAtoms());
         cl::Program program = cl.createProgram(cl.replaceStrings(OpenCLKernelSources::customGBEnergyPerParticle, replacements), defines);
         perParticleEnergyKernel = cl::Kernel(program, "computePerParticleEnergy");
     }
-    if (needParameterGradient) {
-        // Create the kernel to compute chain rule terms for computed values that depend explicitly on particle coordinates.
+    if (needParameterGradient || needEnergyParamDerivs) {
+        // Create the kernel to compute chain rule terms for computed values that depend explicitly on particle coordinates, and for
+        // derivatives with respect to global parameters.
 
-        stringstream compute, extraArgs;
+        stringstream compute, extraArgs, initParamDerivs, saveParamDerivs;
         if (force.getNumGlobalParameters() > 0)
             extraArgs << ", __global const float* globals";
         for (int i = 0; i < (int) params->getBuffers().size(); i++) {
@@ -3538,6 +3662,19 @@ void OpenCLCalcCustomGBForceKernel::initialize(const System& system, const Custo
             extraArgs << ", __global " << buffer.getType() << "* restrict derivBuffers" << index;
             compute << buffer.getType() << " deriv" << index << " = derivBuffers" << index << "[index];\n";
         }
+        if (needEnergyParamDerivs) {
+            extraArgs << ", __global mixed* restrict energyParamDerivs";
+            const vector<string>& allParamDerivNames = cl.getEnergyParamDerivNames();
+            int numDerivs = allParamDerivNames.size();
+            for (int i = 0; i < force.getNumEnergyParameterDerivatives(); i++) {
+                for (int j = 0; j < dValuedParam[i]->getBuffers().size(); j++)
+                    extraArgs << ", __global real* restrict dValuedParam_" << j << "_" << i;
+                initParamDerivs << "mixed energyParamDeriv" << i << " = 0;\n";
+                for (int index = 0; index < numDerivs; index++)
+                    if (allParamDerivNames[index] == force.getEnergyParameterDerivativeName(i))
+                        saveParamDerivs << "energyParamDerivs[get_global_id(0)*" << numDerivs << "+" << index << "] += energyParamDeriv" << i << ";\n";
+            }
+        }
         map<string, string> variables;
         variables["x"] = "pos.x";
         variables["y"] = "pos.y";
@@ -3548,34 +3685,40 @@ void OpenCLCalcCustomGBForceKernel::initialize(const System& system, const Custo
             variables[force.getGlobalParameterName(i)] = "globals["+cl.intToString(i)+"]";
         for (int i = 0; i < force.getNumComputedValues(); i++)
             variables[computedValueNames[i]] = "values"+computedValues->getParameterSuffix(i, "[index]");
-        for (int i = 1; i < force.getNumComputedValues(); i++) {
-            string is = cl.intToString(i);
-            compute << "real4 dV"<<is<<"dR = (real4) 0;\n";
-            for (int j = 1; j < i; j++) {
-                if (!isZeroExpression(valueDerivExpressions[i][j])) {
-                    map<string, Lepton::ParsedExpression> derivExpressions;
-                    string js = cl.intToString(j);
-                    derivExpressions["real dV"+is+"dV"+js+" = "] = valueDerivExpressions[i][j];
-                    compute << cl.getExpressionUtilities().createExpressions(derivExpressions, variables, functionList, functionDefinitions, "temp_"+is+"_"+js);
-                    compute << "dV"<<is<<"dR += dV"<<is<<"dV"<<js<<"*dV"<<js<<"dR;\n";
+        if (needParameterGradient) {
+            for (int i = 1; i < force.getNumComputedValues(); i++) {
+                string is = cl.intToString(i);
+                compute << "real4 dV"<<is<<"dR = (real4) 0;\n";
+                for (int j = 1; j < i; j++) {
+                    if (!isZeroExpression(valueDerivExpressions[i][j])) {
+                        map<string, Lepton::ParsedExpression> derivExpressions;
+                        string js = cl.intToString(j);
+                        derivExpressions["real dV"+is+"dV"+js+" = "] = valueDerivExpressions[i][j];
+                        compute << cl.getExpressionUtilities().createExpressions(derivExpressions, variables, functionList, functionDefinitions, "temp_"+is+"_"+js);
+                        compute << "dV"<<is<<"dR += dV"<<is<<"dV"<<js<<"*dV"<<js<<"dR;\n";
+                    }
                 }
+                map<string, Lepton::ParsedExpression> gradientExpressions;
+                if (!isZeroExpression(valueGradientExpressions[i][0]))
+                    gradientExpressions["dV"+is+"dR.x += "] = valueGradientExpressions[i][0];
+                if (!isZeroExpression(valueGradientExpressions[i][1]))
+                    gradientExpressions["dV"+is+"dR.y += "] = valueGradientExpressions[i][1];
+                if (!isZeroExpression(valueGradientExpressions[i][2]))
+                    gradientExpressions["dV"+is+"dR.z += "] = valueGradientExpressions[i][2];
+                compute << cl.getExpressionUtilities().createExpressions(gradientExpressions, variables, functionList, functionDefinitions, "temp");
             }
-            map<string, Lepton::ParsedExpression> gradientExpressions;
-            if (!isZeroExpression(valueGradientExpressions[i][0]))
-                gradientExpressions["dV"+is+"dR.x += "] = valueGradientExpressions[i][0];
-            if (!isZeroExpression(valueGradientExpressions[i][1]))
-                gradientExpressions["dV"+is+"dR.y += "] = valueGradientExpressions[i][1];
-            if (!isZeroExpression(valueGradientExpressions[i][2]))
-                gradientExpressions["dV"+is+"dR.z += "] = valueGradientExpressions[i][2];
-            compute << cl.getExpressionUtilities().createExpressions(gradientExpressions, variables, functionList, functionDefinitions, "temp");
+            for (int i = 1; i < force.getNumComputedValues(); i++)
+                compute << "force -= deriv"<<energyDerivs->getParameterSuffix(i)<<"*dV"<<i<<"dR;\n";
         }
-        for (int i = 1; i < force.getNumComputedValues(); i++) {
-            string is = cl.intToString(i);
-            compute << "force -= deriv"<<energyDerivs->getParameterSuffix(i)<<"*dV"<<is<<"dR;\n";
-        }
+        if (needEnergyParamDerivs)
+            for (int i = 0; i < force.getNumComputedValues(); i++)
+                for (int j = 0; j < dValuedParam.size(); j++)
+                    compute << "energyParamDeriv"<<j<<" += deriv"<<energyDerivs->getParameterSuffix(i)<<"*dValuedParam_"<<i<<"_"<<j<<"[index];\n";
         map<string, string> replacements;
         replacements["PARAMETER_ARGUMENTS"] = extraArgs.str()+tableArgs.str();
         replacements["COMPUTE_FORCES"] = compute.str();
+        replacements["INIT_PARAM_DERIVS"] = initParamDerivs.str();
+        replacements["SAVE_PARAM_DERIVS"] = saveParamDerivs.str();
         map<string, string> defines;
         defines["NUM_ATOMS"] = cl.intToString(cl.getNumAtoms());
         cl::Program program = cl.createProgram(cl.replaceStrings(OpenCLKernelSources::customGBGradientChainRule, replacements), defines);
@@ -3749,6 +3892,10 @@ double OpenCLCalcCustomGBForceKernel::execute(ContextImpl& context, bool include
                 pairValueKernel.setArg(index++, (deviceIsCpu ? OpenCLContext::TileSize : nb.getForceThreadBlockSize())*buffer.getSize(), NULL);
             }
         }
+        for (int i = 0; i < dValue0dParam.size(); i++) {
+            pairValueKernel.setArg<cl::Buffer>(index++, dValue0dParam[i]->getDeviceBuffer());
+            pairValueKernel.setArg(index++, (deviceIsCpu ? OpenCLContext::TileSize : nb.getForceThreadBlockSize())*dValue0dParam[i]->getElementSize(), NULL);
+        }
         for (int i = 0; i < (int) tabulatedFunctions.size(); i++)
             pairValueKernel.setArg<cl::Buffer>(index++, tabulatedFunctions[i]->getDeviceBuffer());
         index = 0;
@@ -3762,6 +3909,11 @@ double OpenCLCalcCustomGBForceKernel::execute(ContextImpl& context, bool include
             perParticleValueKernel.setArg<cl::Memory>(index++, params->getBuffers()[i].getMemory());
         for (int i = 0; i < (int) computedValues->getBuffers().size(); i++)
             perParticleValueKernel.setArg<cl::Memory>(index++, computedValues->getBuffers()[i].getMemory());
+        for (int i = 0; i < dValuedParam.size(); i++) {
+            perParticleValueKernel.setArg<cl::Memory>(index++, dValue0dParam[i]->getDeviceBuffer());
+            for (int j = 0; j < dValuedParam[i]->getBuffers().size(); j++)
+                perParticleValueKernel.setArg<cl::Memory>(index++, dValuedParam[i]->getBuffers()[j].getMemory());
+        }
         for (int i = 0; i < (int) tabulatedFunctions.size(); i++)
             perParticleValueKernel.setArg<cl::Buffer>(index++, tabulatedFunctions[i]->getDeviceBuffer());
         index = 0;
@@ -3811,6 +3963,8 @@ double OpenCLCalcCustomGBForceKernel::execute(ContextImpl& context, bool include
                 pairEnergyKernel.setArg(index++, (deviceIsCpu ? OpenCLContext::TileSize : nb.getForceThreadBlockSize())*buffer.getSize(), NULL);
             }
         }
+        if (needEnergyParamDerivs)
+            pairEnergyKernel.setArg<cl::Memory>(index++, cl.getEnergyParamDerivBuffer().getDeviceBuffer());
         for (int i = 0; i < (int) tabulatedFunctions.size(); i++)
             pairEnergyKernel.setArg<cl::Buffer>(index++, tabulatedFunctions[i]->getDeviceBuffer());
         index = 0;
@@ -3831,9 +3985,11 @@ double OpenCLCalcCustomGBForceKernel::execute(ContextImpl& context, bool include
             perParticleEnergyKernel.setArg<cl::Memory>(index++, energyDerivChain->getBuffers()[i].getMemory());
         if (useLong)
             perParticleEnergyKernel.setArg<cl::Memory>(index++, longEnergyDerivs->getDeviceBuffer());
+        if (needEnergyParamDerivs)
+            perParticleEnergyKernel.setArg<cl::Memory>(index++, cl.getEnergyParamDerivBuffer().getDeviceBuffer());
         for (int i = 0; i < (int) tabulatedFunctions.size(); i++)
             perParticleEnergyKernel.setArg<cl::Buffer>(index++, tabulatedFunctions[i]->getDeviceBuffer());
-        if (needParameterGradient) {
+        if (needParameterGradient || needEnergyParamDerivs) {
             index = 0;
             gradientChainRuleKernel.setArg<cl::Buffer>(index++, cl.getForceBuffers().getDeviceBuffer());
             gradientChainRuleKernel.setArg<cl::Buffer>(index++, cl.getPosq().getDeviceBuffer());
@@ -3845,6 +4001,12 @@ double OpenCLCalcCustomGBForceKernel::execute(ContextImpl& context, bool include
                 gradientChainRuleKernel.setArg<cl::Memory>(index++, computedValues->getBuffers()[i].getMemory());
             for (int i = 0; i < (int) energyDerivs->getBuffers().size(); i++)
                 gradientChainRuleKernel.setArg<cl::Memory>(index++, energyDerivs->getBuffers()[i].getMemory());
+            if (needEnergyParamDerivs) {
+                gradientChainRuleKernel.setArg<cl::Buffer>(index++, cl.getEnergyParamDerivBuffer().getDeviceBuffer());
+                for (int i = 0; i < dValuedParam.size(); i++)
+                    for (int j = 0; j < dValuedParam[i]->getBuffers().size(); j++)
+                        gradientChainRuleKernel.setArg<cl::Memory>(index++, dValuedParam[i]->getBuffers()[j].getMemory());
+            }
         }
     }
     if (globals != NULL) {
@@ -3875,7 +4037,7 @@ double OpenCLCalcCustomGBForceKernel::execute(ContextImpl& context, bool include
     cl.executeKernel(perParticleValueKernel, cl.getPaddedNumAtoms());
     cl.executeKernel(pairEnergyKernel, nb.getNumForceThreadBlocks()*nb.getForceThreadBlockSize(), nb.getForceThreadBlockSize());
     cl.executeKernel(perParticleEnergyKernel, cl.getPaddedNumAtoms());
-    if (needParameterGradient)
+    if (needParameterGradient || needEnergyParamDerivs)
         cl.executeKernel(gradientChainRuleKernel, cl.getPaddedNumAtoms());
     return 0.0;
 }

--- a/platforms/opencl/src/OpenCLKernels.cpp
+++ b/platforms/opencl/src/OpenCLKernels.cpp
@@ -3239,14 +3239,23 @@ void OpenCLCalcCustomGBForceKernel::initialize(const System& system, const Custo
                 load2 << "real temp_" << derivName << "_1 = 0;\n";
                 load2 << "real temp_" << derivName << "_2 = 0;\n";
                 tempDerivs1 << derivName << " += temp_" << derivName << "_1;\n";
-                tempDerivs2 << "local_" << derivName << "[tbx+tj] += temp_" << derivName << "_2;\n";
+                if (deviceIsCpu)
+                    tempDerivs2 << "local_" << derivName << "[j] += temp_" << derivName << "_2;\n";
+                else
+                    tempDerivs2 << "local_" << derivName << "[tbx+tj] += temp_" << derivName << "_2;\n";
                 if (useLong) {
                     storeDeriv1 << "atom_add(&global_" << derivName << "[offset1], (long) (" << derivName << "*0x100000000));\n";
-                    storeDeriv2 << "atom_add(&global_" << derivName << "[offset2], (long) (local_" << derivName << "[get_local_id(0)]*0x100000000));\n";
+                    if (deviceIsCpu)
+                        storeDeriv2 << "atom_add(&global_" << derivName << "[offset2], (long) (local_" << derivName << "[tgx]*0x100000000));\n";
+                    else
+                        storeDeriv2 << "atom_add(&global_" << derivName << "[offset2], (long) (local_" << derivName << "[get_local_id(0)]*0x100000000));\n";
                 }
                 else {
                     storeDeriv1 << "global_" << derivName << "[offset1] += " << derivName << ";\n";
-                    storeDeriv2 << "global_" << derivName << "[offset2] += local_" << derivName << "[get_local_id(0)];\n";
+                    if (deviceIsCpu)
+                        storeDeriv2 << "global_" << derivName << "[offset2] += local_" << derivName << "[tgx];\n";
+                    else
+                        storeDeriv2 << "global_" << derivName << "[offset2] += local_" << derivName << "[get_local_id(0)];\n";
                 }
             }
         }

--- a/platforms/opencl/src/OpenCLKernels.cpp
+++ b/platforms/opencl/src/OpenCLKernels.cpp
@@ -5220,6 +5220,12 @@ void OpenCLCalcCustomCompoundBondForceKernel::initialize(const System& system, c
         compute<<buffer.getType()<<" bondParams"<<(i+1)<<" = "<<argName<<"[index];\n";
     }
     forceExpressions["energy += "] = energyExpression;
+    for (int i = 0; i < force.getNumEnergyParameterDerivatives(); i++) {
+        string paramName = force.getEnergyParameterDerivativeName(i);
+        string derivVariable = cl.getBondedUtilities().addEnergyParameterDerivative(paramName);
+        Lepton::ParsedExpression derivExpression = energyExpression.differentiate(paramName).optimize();
+        forceExpressions[derivVariable+" += "] = derivExpression;
+    }
     compute << cl.getExpressionUtilities().createExpressions(forceExpressions, variables, functionList, functionDefinitions, "temp");
 
     // Finally, apply forces to atoms.

--- a/platforms/opencl/src/OpenCLKernels.cpp
+++ b/platforms/opencl/src/OpenCLKernels.cpp
@@ -2608,13 +2608,13 @@ double OpenCLCalcCustomNonbondedForceKernel::execute(ContextImpl& context, bool 
         if (changed) {
             globals->upload(globalParamValues);
             if (forceCopy != NULL) {
-                longRangeCoefficient = CustomNonbondedForceImpl::calcLongRangeCorrection(*forceCopy, context.getOwner());
+                CustomNonbondedForceImpl::calcLongRangeCorrection(*forceCopy, context.getOwner(), longRangeCoefficient, longRangeCoefficientDerivs);
                 hasInitializedLongRangeCorrection = true;
             }
         }
     }
     if (!hasInitializedLongRangeCorrection) {
-        longRangeCoefficient = CustomNonbondedForceImpl::calcLongRangeCorrection(*forceCopy, context.getOwner());
+        CustomNonbondedForceImpl::calcLongRangeCorrection(*forceCopy, context.getOwner(), longRangeCoefficient, longRangeCoefficientDerivs);
         hasInitializedLongRangeCorrection = true;
     }
     if (interactionGroupData != NULL) {
@@ -2662,7 +2662,7 @@ void OpenCLCalcCustomNonbondedForceKernel::copyParametersToContext(ContextImpl& 
     // If necessary, recompute the long range correction.
     
     if (forceCopy != NULL) {
-        longRangeCoefficient = CustomNonbondedForceImpl::calcLongRangeCorrection(force, context.getOwner());
+        CustomNonbondedForceImpl::calcLongRangeCorrection(force, context.getOwner(), longRangeCoefficient, longRangeCoefficientDerivs);
         hasInitializedLongRangeCorrection = true;
         *forceCopy = force;
     }

--- a/platforms/opencl/src/OpenCLNonbondedUtilities.cpp
+++ b/platforms/opencl/src/OpenCLNonbondedUtilities.cpp
@@ -605,7 +605,7 @@ cl::Kernel OpenCLNonbondedUtilities::createInteractionKernel(const string& sourc
         }
     }
     if (energyParameterDerivatives.size() > 0)
-        args << ", __global mixed* energyParamDerivs";
+        args << ", __global mixed* restrict energyParamDerivs";
     replacements["PARAMETER_ARGUMENTS"] = args.str();
     stringstream loadLocal1;
     for (int i = 0; i < (int) params.size(); i++) {
@@ -666,7 +666,7 @@ cl::Kernel OpenCLNonbondedUtilities::createInteractionKernel(const string& sourc
     for (int i = 0; i < energyParameterDerivatives.size(); i++)
         for (int index = 0; index < numDerivs; index++)
             if (allParamDerivNames[index] == energyParameterDerivatives[i])
-                saveDerivs<<"energyParamDerivs[get_global_id(0)*"<<numDerivs<<"+"<<i<<"] += energyParamDeriv"<<i<<";\n";
+                saveDerivs<<"energyParamDerivs[get_global_id(0)*"<<numDerivs<<"+"<<index<<"] += energyParamDeriv"<<i<<";\n";
     replacements["SAVE_DERIVATIVES"] = saveDerivs.str();
     map<string, string> defines;
     if (useCutoff)

--- a/platforms/opencl/src/kernels/customCentroidBond.cl
+++ b/platforms/opencl/src/kernels/customCentroidBond.cl
@@ -116,10 +116,12 @@ __kernel void computeGroupForces(__global long* restrict groupForce, __global mi
         __global const int* restrict bondGroups, real4 periodicBoxSize, real4 invPeriodicBoxSize, real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ
         EXTRA_ARGS) {
     mixed energy = 0;
+    INIT_PARAM_DERIVS
     for (int index = get_global_id(0); index < NUM_BONDS; index += get_global_size(0)) {
         COMPUTE_FORCE
     }
     energyBuffer[get_global_id(0)] += energy;
+    SAVE_PARAM_DERIVS
 }
 
 /**

--- a/platforms/opencl/src/kernels/customGBEnergyN2.cl
+++ b/platforms/opencl/src/kernels/customGBEnergyN2.cl
@@ -32,6 +32,7 @@ __kernel void computeN2Energy(
     const unsigned int tgx = get_local_id(0) & (TILE_SIZE-1);
     const unsigned int tbx = get_local_id(0) - tgx;
     mixed energy = 0;
+    INIT_PARAM_DERIVS
 
     // First loop: process tiles that contain exclusions.
     
@@ -73,6 +74,7 @@ __kernel void computeN2Energy(
                     atom2 = y*TILE_SIZE+j;
                     real dEdR = 0;
                     real tempEnergy = 0;
+                    const real interactionScale = 0.5f;
 #ifdef USE_EXCLUSIONS
                     bool isExcluded = !(excl & 0x1);
 #endif
@@ -123,6 +125,7 @@ __kernel void computeN2Energy(
                     atom2 = y*TILE_SIZE+tj;
                     real dEdR = 0;
                     real tempEnergy = 0;
+                    const real interactionScale = 1.0f;
 #ifdef USE_EXCLUSIONS
                     bool isExcluded = !(excl & 0x1);
 #endif
@@ -281,6 +284,7 @@ __kernel void computeN2Energy(
                         atom2 = atomIndices[tbx+tj];
                         real dEdR = 0;
                         real tempEnergy = 0;
+                        const real interactionScale = 1.0f;
                         if (atom1 < NUM_ATOMS && atom2 < NUM_ATOMS) {
                             COMPUTE_INTERACTION
                             dEdR /= -r;
@@ -319,6 +323,7 @@ __kernel void computeN2Energy(
                         atom2 = atomIndices[tbx+tj];
                         real dEdR = 0;
                         real tempEnergy = 0;
+                        const real interactionScale = 1.0f;
                         if (atom1 < NUM_ATOMS && atom2 < NUM_ATOMS) {
                             COMPUTE_INTERACTION
                             dEdR /= -r;
@@ -373,4 +378,5 @@ __kernel void computeN2Energy(
         pos++;
     }
     energyBuffer[get_global_id(0)] += energy;
+    SAVE_PARAM_DERIVS
 }

--- a/platforms/opencl/src/kernels/customGBEnergyN2_cpu.cl
+++ b/platforms/opencl/src/kernels/customGBEnergyN2_cpu.cl
@@ -28,6 +28,7 @@ __kernel void computeN2Energy(
 #endif
         PARAMETER_ARGUMENTS) {
     mixed energy = 0;
+    INIT_PARAM_DERIVS
 
     // First loop: process tiles that contain exclusions.
     
@@ -74,6 +75,7 @@ __kernel void computeN2Energy(
                         atom2 = y*TILE_SIZE+j;
                         real dEdR = 0;
                         real tempEnergy = 0;
+                        const real interactionScale = 0.5f;
 #ifdef USE_EXCLUSIONS
                         bool isExcluded = !(excl & 0x1);
 #endif
@@ -140,6 +142,7 @@ __kernel void computeN2Energy(
                         atom2 = y*TILE_SIZE+j;
                         real dEdR = 0;
                         real tempEnergy = 0;
+                        const real interactionScale = 1.0f;
 #ifdef USE_EXCLUSIONS
                         bool isExcluded = (atom1 >= NUM_ATOMS || atom2 >= NUM_ATOMS || !(excl & 0x1));
                         if (!isExcluded) {
@@ -291,6 +294,7 @@ __kernel void computeN2Energy(
                             atom2 = atomIndices[j];
                             real dEdR = 0;
                             real tempEnergy = 0;
+                            const real interactionScale = 1.0f;
                             COMPUTE_INTERACTION
                             dEdR /= -r;
                             energy += tempEnergy;
@@ -347,6 +351,7 @@ __kernel void computeN2Energy(
                             atom2 = atomIndices[j];
                             real dEdR = 0;
                             real tempEnergy = 0;
+                            const real interactionScale = 1.0f;
                             COMPUTE_INTERACTION
                             dEdR /= -r;
                             energy += tempEnergy;
@@ -400,4 +405,5 @@ __kernel void computeN2Energy(
         pos++;
     }
     energyBuffer[get_global_id(0)] += energy;
+    SAVE_PARAM_DERIVS
 }

--- a/platforms/opencl/src/kernels/customGBEnergyPerParticle.cl
+++ b/platforms/opencl/src/kernels/customGBEnergyPerParticle.cl
@@ -12,6 +12,7 @@
 __kernel void computePerParticleEnergy(int bufferSize, int numBuffers, __global real4* restrict forceBuffers, __global mixed* restrict energyBuffer, __global const real4* restrict posq
         PARAMETER_ARGUMENTS) {
     mixed energy = 0;
+    INIT_PARAM_DERIVS
     unsigned int index = get_global_id(0);
     while (index < NUM_ATOMS) {
         // Reduce the derivatives
@@ -27,4 +28,5 @@ __kernel void computePerParticleEnergy(int bufferSize, int numBuffers, __global 
         index += get_global_size(0);
     }
     energyBuffer[get_global_id(0)] += energy;
+    SAVE_PARAM_DERIVS
 }

--- a/platforms/opencl/src/kernels/customGBGradientChainRule.cl
+++ b/platforms/opencl/src/kernels/customGBGradientChainRule.cl
@@ -4,6 +4,7 @@
 
 __kernel void computeGradientChainRuleTerms(__global real4* restrict forceBuffers, __global const real4* restrict posq
         PARAMETER_ARGUMENTS) {
+    INIT_PARAM_DERIVS
     unsigned int index = get_global_id(0);
     while (index < NUM_ATOMS) {
         real4 pos = posq[index];
@@ -12,4 +13,5 @@ __kernel void computeGradientChainRuleTerms(__global real4* restrict forceBuffer
         forceBuffers[index] = force;
         index += get_global_size(0);
     }
+    SAVE_PARAM_DERIVS
 }

--- a/platforms/opencl/src/kernels/customGBValueN2.cl
+++ b/platforms/opencl/src/kernels/customGBValueN2.cl
@@ -320,7 +320,7 @@ __kernel void computeN2Value(__global const real4* restrict posq, __local real4*
             unsigned int atom2 = y*TILE_SIZE + tgx;
 #endif
 #ifdef SUPPORTS_64_BIT_ATOMICS
-            unsigned in offset1 = atom1;
+            unsigned int offset1 = atom1;
             atom_add(&global_value[offset1], (long) (value*0x100000000));
             STORE_PARAM_DERIVS1
             if (atom2 < PADDED_NUM_ATOMS) {

--- a/platforms/opencl/src/kernels/customGBValueN2.cl
+++ b/platforms/opencl/src/kernels/customGBValueN2.cl
@@ -267,6 +267,8 @@ __kernel void computeN2Value(__global const real4* restrict posq, __local real4*
                         }
                         value += tempValue1;
                         local_value[tbx+tj] += tempValue2;
+                        ADD_TEMP_DERIVS1
+                        ADD_TEMP_DERIVS2
                     }
                     tj = (tj + 1) & (TILE_SIZE - 1);
                     SYNC_WARPS;

--- a/platforms/opencl/src/kernels/customGBValueN2_cpu.cl
+++ b/platforms/opencl/src/kernels/customGBValueN2_cpu.cl
@@ -87,11 +87,13 @@ __kernel void computeN2Value(__global const real4* restrict posq, __local real4*
                 // Write results.
 
 #ifdef SUPPORTS_64_BIT_ATOMICS
-                atom_add(&global_value[atom1], (long) (value*0x100000000));
+                unsigned int offset1 = atom1;
+                atom_add(&global_value[offset1], (long) (value*0x100000000));
 #else
-                unsigned int offset = atom1 + get_group_id(0)*PADDED_NUM_ATOMS;
-                global_value[offset] += value;
+                unsigned int offset1 = atom1 + get_group_id(0)*PADDED_NUM_ATOMS;
+                global_value[offset1] += value;
 #endif
+                STORE_PARAM_DERIVS1
             }
         }
         else {
@@ -274,11 +276,13 @@ __kernel void computeN2Value(__global const real4* restrict posq, __local real4*
                     // Write results for atom1.
 
 #ifdef SUPPORTS_64_BIT_ATOMICS
-                    atom_add(&global_value[atom1], (long) (value*0x100000000));
+                    unsigned int offset1 = atom1;
+                    atom_add(&global_value[offset1], (long) (value*0x100000000));
 #else
-                    unsigned int offset = atom1 + get_group_id(0)*PADDED_NUM_ATOMS;
-                    global_value[offset] += value;
+                    unsigned int offset1 = atom1 + get_group_id(0)*PADDED_NUM_ATOMS;
+                    global_value[offset1] += value;
 #endif
+                    STORE_PARAM_DERIVS1
                 }
             }
             else

--- a/platforms/opencl/src/kernels/customGBValuePerParticle.cl
+++ b/platforms/opencl/src/kernels/customGBValuePerParticle.cl
@@ -21,6 +21,7 @@ __kernel void computePerParticleValues(int bufferSize, int numBuffers, __global 
         for (int i = index+bufferSize; i < totalSize; i += bufferSize)
             sum += valueBuffers[i];
 #endif
+        REDUCE_PARAM0_DERIV
         
         // Now calculate other values
 

--- a/platforms/opencl/src/kernels/customIntegratorPerDof.cl
+++ b/platforms/opencl/src/kernels/customIntegratorPerDof.cl
@@ -25,7 +25,8 @@ void storePos(__global real4* restrict posq, __global real4* restrict posqCorrec
 
 __kernel void computePerDof(__global real4* restrict posq, __global real4* restrict posqCorrection, __global mixed4* restrict posDelta,
         __global mixed4* restrict velm, __global const real4* restrict force, __global const mixed2* restrict dt, __global const mixed* restrict globals,
-        __global mixed* restrict sum, __global const float4* restrict gaussianValues, unsigned int gaussianBaseIndex, __global const float4* restrict uniformValues, const real energy
+        __global mixed* restrict sum, __global const float4* restrict gaussianValues, unsigned int gaussianBaseIndex, __global const float4* restrict uniformValues,
+        const real energy, __global mixed* restrict energyParamDerivs
         PARAMETER_ARGUMENTS) {
     mixed stepSize = dt[0].y;
     int index = get_global_id(0);

--- a/platforms/opencl/src/kernels/customNonbonded.cl
+++ b/platforms/opencl/src/kernels/customNonbonded.cl
@@ -4,15 +4,18 @@ if (!isExcluded && r2 < CUTOFF_SQUARED) {
 if (!isExcluded) {
 #endif
     real tempForce = 0.0f;
-    COMPUTE_FORCE
+    real switchValue = 1, switchDeriv = 0;
 #if USE_SWITCH
     if (r > SWITCH_CUTOFF) {
         real x = r-SWITCH_CUTOFF;
-        real switchValue = 1+x*x*x*(SWITCH_C3+x*(SWITCH_C4+x*SWITCH_C5));
-        real switchDeriv = x*x*(3*SWITCH_C3+x*(4*SWITCH_C4+x*5*SWITCH_C5));
-        tempForce = tempForce*switchValue - tempEnergy*switchDeriv;
-        tempEnergy *= switchValue;
+        switchValue = 1+x*x*x*(SWITCH_C3+x*(SWITCH_C4+x*SWITCH_C5));
+        switchDeriv = x*x*(3*SWITCH_C3+x*(4*SWITCH_C4+x*5*SWITCH_C5));
     }
+#endif
+    COMPUTE_FORCE
+#if USE_SWITCH
+    tempForce = tempForce*switchValue - tempEnergy*switchDeriv;
+    tempEnergy *= switchValue;
 #endif
     dEdR += tempForce*invR;
 }

--- a/platforms/opencl/src/kernels/nonbonded.cl
+++ b/platforms/opencl/src/kernels/nonbonded.cl
@@ -35,6 +35,7 @@ __kernel void computeNonbonded(
     const unsigned int tgx = get_local_id(0) & (TILE_SIZE-1);
     const unsigned int tbx = get_local_id(0) - tgx;
     mixed energy = 0;
+    INIT_DERIVATIVES
     __local AtomData localData[FORCE_WORK_GROUP_SIZE];
 
     // First loop: process tiles that contain exclusions.
@@ -85,6 +86,7 @@ __kernel void computeNonbonded(
                 bool isExcluded = (atom1 >= NUM_ATOMS || atom2 >= NUM_ATOMS || !(excl & 0x1));
 #endif
                 real tempEnergy = 0;
+                const real interactionScale = 0.5f;
                 COMPUTE_INTERACTION
                 energy += 0.5f*tempEnergy;
 #ifdef INCLUDE_FORCES
@@ -144,6 +146,7 @@ __kernel void computeNonbonded(
                     bool isExcluded = (atom1 >= NUM_ATOMS || atom2 >= NUM_ATOMS || !(excl & 0x1));
 #endif
                     real tempEnergy = 0;
+                    const real interactionScale = 1.0f;
                     COMPUTE_INTERACTION
                     energy += tempEnergy;
 #ifdef INCLUDE_FORCES
@@ -320,6 +323,7 @@ __kernel void computeNonbonded(
                         bool isExcluded = (atom1 >= NUM_ATOMS || atom2 >= NUM_ATOMS);
 #endif
                         real tempEnergy = 0;
+                        const real interactionScale = 1.0f;
                         COMPUTE_INTERACTION
                         energy += tempEnergy;
 #ifdef INCLUDE_FORCES
@@ -374,6 +378,7 @@ __kernel void computeNonbonded(
                         bool isExcluded = (atom1 >= NUM_ATOMS || atom2 >= NUM_ATOMS);
 #endif
                         real tempEnergy = 0;
+                        const real interactionScale = 1.0f;
                         COMPUTE_INTERACTION
                         energy += tempEnergy;
 #ifdef INCLUDE_FORCES
@@ -429,4 +434,5 @@ __kernel void computeNonbonded(
 #ifdef INCLUDE_ENERGY
     energyBuffer[get_global_id(0)] += energy;
 #endif
+    SAVE_DERIVATIVES
 }

--- a/platforms/reference/include/ReferenceAngleBondIxn.h
+++ b/platforms/reference/include/ReferenceAngleBondIxn.h
@@ -1,5 +1,5 @@
 
-/* Portions copyright (c) 2006 Stanford University and Simbios.
+/* Portions copyright (c) 2006-2016 Stanford University and Simbios.
  * Contributors: Pande Group
  *
  * Permission is hereby granted, free of charge, to any person obtaining
@@ -94,7 +94,7 @@ class OPENMM_EXPORT ReferenceAngleBondIxn : public ReferenceBondIxn {
       
       void calculateBondIxn(int* atomIndices, std::vector<OpenMM::RealVec>& atomCoordinates,
                             RealOpenMM* parameters, std::vector<OpenMM::RealVec>& forces,
-                            RealOpenMM* totalEnergy) const;
+                            RealOpenMM* totalEnergy, double* energyParamDerivs);
       
 
 };

--- a/platforms/reference/include/ReferenceBondIxn.h
+++ b/platforms/reference/include/ReferenceBondIxn.h
@@ -1,5 +1,5 @@
 
-/* Portions copyright (c) 2006 Stanford University and Simbios.
+/* Portions copyright (c) 2006-2016 Stanford University and Simbios.
  * Contributors: Pande Group
  *
  * Permission is hereby granted, free of charge, to any person obtaining
@@ -67,7 +67,7 @@ class OPENMM_EXPORT ReferenceBondIxn {
       
       virtual void calculateBondIxn(int* atomIndices, std::vector<OpenMM::RealVec>& atomCoordinates,
                                     RealOpenMM* parameters, std::vector<OpenMM::RealVec>& forces,
-                                    RealOpenMM* totalEnergy) const;
+                                    RealOpenMM* totalEnergy, double* energyParamDerivs);
       
       /**---------------------------------------------------------------------------------------
       

--- a/platforms/reference/include/ReferenceCMAPTorsionIxn.h
+++ b/platforms/reference/include/ReferenceCMAPTorsionIxn.h
@@ -1,5 +1,5 @@
 
-/* Portions copyright (c) 2010 Stanford University and Simbios.
+/* Portions copyright (c) 2010-2016 Stanford University and Simbios.
  * Contributors: Peter Eastman
  *
  * Permission is hereby granted, free of charge, to any person obtaining
@@ -97,7 +97,7 @@ public:
 
     void calculateBondIxn(int* atomIndices, std::vector<OpenMM::RealVec>& atomCoordinates,
                          RealOpenMM* parameters, std::vector<OpenMM::RealVec>& forces,
-                         RealOpenMM* totalEnergy) const;
+                         RealOpenMM* totalEnergy, double* energyParamDerivs);
 
 // ---------------------------------------------------------------------------------------
 

--- a/platforms/reference/include/ReferenceCustomAngleIxn.h
+++ b/platforms/reference/include/ReferenceCustomAngleIxn.h
@@ -85,7 +85,7 @@ class ReferenceCustomAngleIxn : public ReferenceBondIxn {
 
       void calculateBondIxn(int* atomIndices, std::vector<OpenMM::RealVec>& atomCoordinates,
                             RealOpenMM* parameters, std::vector<OpenMM::RealVec>& forces,
-                            RealOpenMM* totalEnergy) const;
+                            RealOpenMM* totalEnergy, double* energyParamDerivs);
 
 
 };

--- a/platforms/reference/include/ReferenceCustomAngleIxn.h
+++ b/platforms/reference/include/ReferenceCustomAngleIxn.h
@@ -25,7 +25,7 @@
 #define __ReferenceCustomAngleIxn_H__
 
 #include "ReferenceBondIxn.h"
-#include "lepton/CompiledExpression.h"
+#include "openmm/internal/CompiledExpressionSet.h"
 
 namespace OpenMM {
 
@@ -34,10 +34,10 @@ class ReferenceCustomAngleIxn : public ReferenceBondIxn {
    private:
       Lepton::CompiledExpression energyExpression;
       Lepton::CompiledExpression forceExpression;
-      std::vector<double*> energyParams;
-      std::vector<double*> forceParams;
-      double* energyTheta;
-      double* forceTheta;
+      std::vector<Lepton::CompiledExpression> energyParamDerivExpressions;
+      CompiledExpressionSet expressionSet;
+      std::vector<int> angleParamIndex;
+      int thetaIndex;
       int numParameters;
       bool usePeriodic;
       RealVec boxVectors[3];
@@ -51,7 +51,8 @@ class ReferenceCustomAngleIxn : public ReferenceBondIxn {
          --------------------------------------------------------------------------------------- */
 
        ReferenceCustomAngleIxn(const Lepton::CompiledExpression& energyExpression, const Lepton::CompiledExpression& forceExpression,
-                              const std::vector<std::string>& parameterNames, std::map<std::string, double> globalParameters);
+                              const std::vector<std::string>& parameterNames, std::map<std::string, double> globalParameters,
+                              const std::vector<Lepton::CompiledExpression> energyParamDerivExpressions);
 
       /**---------------------------------------------------------------------------------------
 

--- a/platforms/reference/include/ReferenceCustomBondIxn.h
+++ b/platforms/reference/include/ReferenceCustomBondIxn.h
@@ -26,6 +26,7 @@
 #define __ReferenceCustomBondIxn_H__
 
 #include "ReferenceBondIxn.h"
+#include "openmm/internal/CompiledExpressionSet.h"
 #include "lepton/CompiledExpression.h"
 
 namespace OpenMM {
@@ -35,10 +36,10 @@ class ReferenceCustomBondIxn : public ReferenceBondIxn {
    private:
       Lepton::CompiledExpression energyExpression;
       Lepton::CompiledExpression forceExpression;
-      std::vector<double*> energyParams;
-      std::vector<double*> forceParams;
-      double* energyR;
-      double* forceR;
+      std::vector<Lepton::CompiledExpression> energyParamDerivExpressions;
+      CompiledExpressionSet expressionSet;
+      std::vector<int> bondParamIndex;
+      int rIndex;
       int numParameters;
       bool usePeriodic;
       RealVec boxVectors[3];
@@ -52,7 +53,8 @@ class ReferenceCustomBondIxn : public ReferenceBondIxn {
          --------------------------------------------------------------------------------------- */
 
        ReferenceCustomBondIxn(const Lepton::CompiledExpression& energyExpression, const Lepton::CompiledExpression& forceExpression,
-                              const std::vector<std::string>& parameterNames, std::map<std::string, double> globalParameters);
+                              const std::vector<std::string>& parameterNames, std::map<std::string, double> globalParameters,
+                              const std::vector<Lepton::CompiledExpression> energyParamDerivExpressions);
 
       /**---------------------------------------------------------------------------------------
 
@@ -86,7 +88,7 @@ class ReferenceCustomBondIxn : public ReferenceBondIxn {
 
       void calculateBondIxn(int* atomIndices, std::vector<OpenMM::RealVec>& atomCoordinates,
                             RealOpenMM* parameters, std::vector<OpenMM::RealVec>& forces,
-                            RealOpenMM* totalEnergy) const;
+                            RealOpenMM* totalEnergy, double* energyParamDerivs);
 
 
 };

--- a/platforms/reference/include/ReferenceCustomBondIxn.h
+++ b/platforms/reference/include/ReferenceCustomBondIxn.h
@@ -27,7 +27,6 @@
 
 #include "ReferenceBondIxn.h"
 #include "openmm/internal/CompiledExpressionSet.h"
-#include "lepton/CompiledExpression.h"
 
 namespace OpenMM {
 

--- a/platforms/reference/include/ReferenceCustomCompoundBondIxn.h
+++ b/platforms/reference/include/ReferenceCustomCompoundBondIxn.h
@@ -26,7 +26,7 @@
 #define __ReferenceCustomCompoundBondIxn_H__
 
 #include "ReferenceBondIxn.h"
-#include "lepton/ExpressionProgram.h"
+#include "openmm/internal/CompiledExpressionSet.h"
 #include "lepton/ParsedExpression.h"
 #include <map>
 #include <vector>
@@ -42,12 +42,15 @@ class ReferenceCustomCompoundBondIxn : public ReferenceBondIxn {
       class AngleTermInfo;
       class DihedralTermInfo;
       std::vector<std::vector<int> > bondAtoms;
-      Lepton::ExpressionProgram energyExpression;
-      std::vector<std::string> bondParamNames;
+      CompiledExpressionSet expressionSet;
+      Lepton::CompiledExpression energyExpression;
+      std::vector<Lepton::CompiledExpression> energyParamDerivExpressions;
+      std::vector<int> bondParamIndex;
       std::vector<ParticleTermInfo> particleTerms;
       std::vector<DistanceTermInfo> distanceTerms;
       std::vector<AngleTermInfo> angleTerms;
       std::vector<DihedralTermInfo> dihedralTerms;
+      int numParameters;
       bool usePeriodic;
       RealVec boxVectors[3];
 
@@ -58,15 +61,13 @@ class ReferenceCustomCompoundBondIxn : public ReferenceBondIxn {
 
          @param bond             the index of the bond
          @param atomCoordinates  atom coordinates
-         @param variables        the values of variables that may appear in expressions
          @param forces           force array (forces added)
          @param totalEnergy      total energy
 
          --------------------------------------------------------------------------------------- */
 
       void calculateOneIxn(int bond, std::vector<OpenMM::RealVec>& atomCoordinates,
-                           std::map<std::string, double>& variables, std::vector<OpenMM::RealVec>& forces,
-                           RealOpenMM* totalEnergy) const;
+                           std::vector<OpenMM::RealVec>& forces, RealOpenMM* totalEnergy, double* energyParamDerivs);
 
       void computeDelta(int atom1, int atom2, RealOpenMM* delta, std::vector<OpenMM::RealVec>& atomCoordinates) const;
 
@@ -83,7 +84,8 @@ class ReferenceCustomCompoundBondIxn : public ReferenceBondIxn {
 
        ReferenceCustomCompoundBondIxn(int numParticlesPerBond, const std::vector<std::vector<int> >& bondAtoms, const Lepton::ParsedExpression& energyExpression,
                                const std::vector<std::string>& bondParameterNames, const std::map<std::string, std::vector<int> >& distances,
-                               const std::map<std::string, std::vector<int> >& angles, const std::map<std::string, std::vector<int> >& dihedrals);
+                               const std::map<std::string, std::vector<int> >& angles, const std::map<std::string, std::vector<int> >& dihedrals,
+                               const std::vector<Lepton::CompiledExpression> energyParamDerivExpressions);
 
       /**---------------------------------------------------------------------------------------
 
@@ -127,7 +129,7 @@ class ReferenceCustomCompoundBondIxn : public ReferenceBondIxn {
 
       void calculatePairIxn(std::vector<OpenMM::RealVec>& atomCoordinates, RealOpenMM** bondParameters,
                             const std::map<std::string, double>& globalParameters,
-                            std::vector<OpenMM::RealVec>& forces, RealOpenMM* totalEnergy) const;
+                            std::vector<OpenMM::RealVec>& forces, RealOpenMM* totalEnergy, double* energyParamDerivs);
 
 // ---------------------------------------------------------------------------------------
 
@@ -136,9 +138,9 @@ class ReferenceCustomCompoundBondIxn : public ReferenceBondIxn {
 class ReferenceCustomCompoundBondIxn::ParticleTermInfo {
 public:
     std::string name;
-    int atom, component;
-    Lepton::ExpressionProgram forceExpression;
-    ParticleTermInfo(const std::string& name, int atom, int component, const Lepton::ExpressionProgram& forceExpression) :
+    int atom, component, index;
+    Lepton::CompiledExpression forceExpression;
+    ParticleTermInfo(const std::string& name, int atom, int component, const Lepton::CompiledExpression& forceExpression) :
             name(name), atom(atom), component(component), forceExpression(forceExpression) {
     }
 };
@@ -146,10 +148,10 @@ public:
 class ReferenceCustomCompoundBondIxn::DistanceTermInfo {
 public:
     std::string name;
-    int p1, p2;
-    Lepton::ExpressionProgram forceExpression;
+    int p1, p2, index;
+    Lepton::CompiledExpression forceExpression;
     mutable RealOpenMM delta[ReferenceForce::LastDeltaRIndex];
-    DistanceTermInfo(const std::string& name, const std::vector<int>& atoms, const Lepton::ExpressionProgram& forceExpression) :
+    DistanceTermInfo(const std::string& name, const std::vector<int>& atoms, const Lepton::CompiledExpression& forceExpression) :
             name(name), p1(atoms[0]), p2(atoms[1]), forceExpression(forceExpression) {
     }
 };
@@ -157,11 +159,11 @@ public:
 class ReferenceCustomCompoundBondIxn::AngleTermInfo {
 public:
     std::string name;
-    int p1, p2, p3;
-    Lepton::ExpressionProgram forceExpression;
+    int p1, p2, p3, index;
+    Lepton::CompiledExpression forceExpression;
     mutable RealOpenMM delta1[ReferenceForce::LastDeltaRIndex];
     mutable RealOpenMM delta2[ReferenceForce::LastDeltaRIndex];
-    AngleTermInfo(const std::string& name, const std::vector<int>& atoms, const Lepton::ExpressionProgram& forceExpression) :
+    AngleTermInfo(const std::string& name, const std::vector<int>& atoms, const Lepton::CompiledExpression& forceExpression) :
             name(name), p1(atoms[0]), p2(atoms[1]), p3(atoms[2]), forceExpression(forceExpression) {
     }
 };
@@ -169,14 +171,14 @@ public:
 class ReferenceCustomCompoundBondIxn::DihedralTermInfo {
 public:
     std::string name;
-    int p1, p2, p3, p4;
-    Lepton::ExpressionProgram forceExpression;
+    int p1, p2, p3, p4, index;
+    Lepton::CompiledExpression forceExpression;
     mutable RealOpenMM delta1[ReferenceForce::LastDeltaRIndex];
     mutable RealOpenMM delta2[ReferenceForce::LastDeltaRIndex];
     mutable RealOpenMM delta3[ReferenceForce::LastDeltaRIndex];
     mutable RealOpenMM cross1[3];
     mutable RealOpenMM cross2[3];
-    DihedralTermInfo(const std::string& name, const std::vector<int>& atoms, const Lepton::ExpressionProgram& forceExpression) :
+    DihedralTermInfo(const std::string& name, const std::vector<int>& atoms, const Lepton::CompiledExpression& forceExpression) :
             name(name), p1(atoms[0]), p2(atoms[1]), p3(atoms[2]), p4(atoms[3]), forceExpression(forceExpression) {
     }
 };

--- a/platforms/reference/include/ReferenceCustomDynamics.h
+++ b/platforms/reference/include/ReferenceCustomDynamics.h
@@ -41,6 +41,7 @@ namespace OpenMM {
 class ReferenceCustomDynamics : public ReferenceDynamics {
 private:
 
+    class DerivFunction;
     const OpenMM::CustomIntegrator& integrator;
     std::vector<RealOpenMM> inverseMasses;
     std::vector<OpenMM::RealVec> sumBuffer, oldPos;
@@ -51,6 +52,7 @@ private:
     std::vector<bool> invalidatesForces, needsForces, needsEnergy, computeBothForceAndEnergy;
     std::vector<int> forceGroupFlags, blockEnd;
     RealOpenMM energy;
+    std::map<std::string, double> energyParamDerivs;
     Lepton::CompiledExpression kineticEnergyExpression;
     bool kineticEnergyNeedsForce;
     CompiledExpressionSet expressionSet;
@@ -58,6 +60,8 @@ private:
     std::vector<int> forceVariableIndex, energyVariableIndex, perDofVariableIndex, stepVariableIndex;
 
     void initialize(OpenMM::ContextImpl& context, std::vector<RealOpenMM>& masses, std::map<std::string, RealOpenMM>& globals);
+    
+    Lepton::ExpressionTreeNode replaceDerivFunctions(const Lepton::ExpressionTreeNode& node, OpenMM::ContextImpl& context);
     
     void computePerDof(int numberOfAtoms, std::vector<OpenMM::RealVec>& results, const std::vector<OpenMM::RealVec>& atomCoordinates,
                   const std::vector<OpenMM::RealVec>& velocities, const std::vector<OpenMM::RealVec>& forces, const std::vector<RealOpenMM>& masses,

--- a/platforms/reference/include/ReferenceCustomGBIxn.h
+++ b/platforms/reference/include/ReferenceCustomGBIxn.h
@@ -170,7 +170,7 @@ class ReferenceCustomGBIxn {
          --------------------------------------------------------------------------------------- */
 
       void calculateChainRuleForces(int numAtoms, std::vector<OpenMM::RealVec>& atomCoordinates, RealOpenMM** atomParameters,
-                                      const std::vector<std::set<int> >& exclusions, std::vector<OpenMM::RealVec>& forces);
+                                      const std::vector<std::set<int> >& exclusions, std::vector<OpenMM::RealVec>& forces, double* energyParamDerivs);
 
       /**---------------------------------------------------------------------------------------
 

--- a/platforms/reference/include/ReferenceCustomGBIxn.h
+++ b/platforms/reference/include/ReferenceCustomGBIxn.h
@@ -26,7 +26,7 @@
 #define __ReferenceCustomGBIxn_H__
 
 #include "ReferenceNeighborList.h"
-#include "lepton/ExpressionProgram.h"
+#include "openmm/internal/CompiledExpressionSet.h"
 #include "openmm/CustomGBForce.h"
 #include <map>
 #include <set>
@@ -43,18 +43,20 @@ class ReferenceCustomGBIxn {
       const OpenMM::NeighborList* neighborList;
       OpenMM::RealVec periodicBoxVectors[3];
       RealOpenMM cutoffDistance;
-      std::vector<Lepton::ExpressionProgram> valueExpressions;
-      std::vector<std::vector<Lepton::ExpressionProgram> > valueDerivExpressions;
-      std::vector<std::vector<Lepton::ExpressionProgram> > valueGradientExpressions;
-      std::vector<std::string> valueNames;
+      CompiledExpressionSet expressionSet;
+      std::vector<Lepton::CompiledExpression> valueExpressions;
+      std::vector<std::vector<Lepton::CompiledExpression> > valueDerivExpressions;
+      std::vector<std::vector<Lepton::CompiledExpression> > valueGradientExpressions;
       std::vector<OpenMM::CustomGBForce::ComputationType> valueTypes;
-      std::vector<Lepton::ExpressionProgram> energyExpressions;
-      std::vector<std::vector<Lepton::ExpressionProgram> > energyDerivExpressions;
-      std::vector<std::vector<Lepton::ExpressionProgram> > energyGradientExpressions;
-      std::vector<std::string> paramNames;
+      std::vector<Lepton::CompiledExpression> energyExpressions;
+      std::vector<std::vector<Lepton::CompiledExpression> > energyDerivExpressions;
+      std::vector<std::vector<Lepton::CompiledExpression> > energyGradientExpressions;
       std::vector<OpenMM::CustomGBForce::ComputationType> energyTypes;
-      std::vector<std::string> particleParamNames;
-      std::vector<std::string> particleValueNames;
+      std::vector<int> paramIndex;
+      std::vector<int> valueIndex;
+      std::vector<int> particleParamIndex;
+      std::vector<int> particleValueIndex;
+      int rIndex, xIndex, yIndex, zIndex;
 
       /**---------------------------------------------------------------------------------------
 
@@ -64,13 +66,12 @@ class ReferenceCustomGBIxn {
          @param numAtoms         number of atoms
          @param atomCoordinates  atom coordinates
          @param values           the vector to store computed values into
-         @param globalParameters the values of global parameters
          @param atomParameters   atomParameters[atomIndex][paramterIndex]
 
          --------------------------------------------------------------------------------------- */
 
       void calculateSingleParticleValue(int index, int numAtoms, std::vector<OpenMM::RealVec>& atomCoordinates, std::vector<std::vector<RealOpenMM> >& values,
-                                        const std::map<std::string, double>& globalParameters, RealOpenMM** atomParameters) const;
+                                        RealOpenMM** atomParameters);
 
       /**---------------------------------------------------------------------------------------
 
@@ -81,7 +82,6 @@ class ReferenceCustomGBIxn {
          @param atomCoordinates  atom coordinates
          @param atomParameters   atomParameters[atomIndex][paramterIndex]
          @param values           the vector to store computed values into
-         @param globalParameters the values of global parameters
          @param exclusions       exclusions[i] is the set of excluded indices for atom i
          @param useExclusions    specifies whether to use exclusions
 
@@ -89,8 +89,7 @@ class ReferenceCustomGBIxn {
 
       void calculateParticlePairValue(int index, int numAtoms, std::vector<OpenMM::RealVec>& atomCoordinates, RealOpenMM** atomParameters,
                                       std::vector<std::vector<RealOpenMM> >& values,
-                                      const std::map<std::string, double>& globalParameters,
-                                      const std::vector<std::set<int> >& exclusions, bool useExclusions) const;
+                                      const std::vector<std::set<int> >& exclusions, bool useExclusions);
 
       /**---------------------------------------------------------------------------------------
 
@@ -101,14 +100,12 @@ class ReferenceCustomGBIxn {
          @param atom2            the index of the second atom in the pair
          @param atomCoordinates  atom coordinates
          @param atomParameters   atomParameters[atomIndex][paramterIndex]
-         @param globalParameters the values of global parameters
          @param values           the vector to store computed values into
 
          --------------------------------------------------------------------------------------- */
 
       void calculateOnePairValue(int index, int atom1, int atom2, std::vector<OpenMM::RealVec>& atomCoordinates, RealOpenMM** atomParameters,
-                                 const std::map<std::string, double>& globalParameters,
-                                 std::vector<std::vector<RealOpenMM> >& values) const;
+                                 std::vector<std::vector<RealOpenMM> >& values);
 
       /**---------------------------------------------------------------------------------------
 
@@ -118,7 +115,6 @@ class ReferenceCustomGBIxn {
          @param numAtoms         number of atoms
          @param atomCoordinates  atom coordinates
          @param values           the vector containing computed values
-         @param globalParameters the values of global parameters
          @param atomParameters   atomParameters[atomIndex][paramterIndex]
          @param forces           forces on atoms are added to this
          @param totalEnergy      the energy contribution is added to this
@@ -127,8 +123,8 @@ class ReferenceCustomGBIxn {
          --------------------------------------------------------------------------------------- */
 
       void calculateSingleParticleEnergyTerm(int index, int numAtoms, std::vector<OpenMM::RealVec>& atomCoordinates, const std::vector<std::vector<RealOpenMM> >& values,
-                                        const std::map<std::string, double>& globalParameters, RealOpenMM** atomParameters, std::vector<OpenMM::RealVec>& forces,
-                                        RealOpenMM* totalEnergy, std::vector<std::vector<RealOpenMM> >& dEdV) const;
+                                        RealOpenMM** atomParameters, std::vector<OpenMM::RealVec>& forces,
+                                        RealOpenMM* totalEnergy, std::vector<std::vector<RealOpenMM> >& dEdV);
 
       /**---------------------------------------------------------------------------------------
 
@@ -139,7 +135,6 @@ class ReferenceCustomGBIxn {
          @param atomCoordinates  atom coordinates
          @param atomParameters   atomParameters[atomIndex][paramterIndex]
          @param values           the vector containing computed values
-         @param globalParameters the values of global parameters
          @param exclusions       exclusions[i] is the set of excluded indices for atom i
          @param useExclusions    specifies whether to use exclusions
          @param forces           forces on atoms are added to this
@@ -150,9 +145,8 @@ class ReferenceCustomGBIxn {
 
       void calculateParticlePairEnergyTerm(int index, int numAtoms, std::vector<OpenMM::RealVec>& atomCoordinates, RealOpenMM** atomParameters,
                                       const std::vector<std::vector<RealOpenMM> >& values,
-                                      const std::map<std::string, double>& globalParameters,
                                       const std::vector<std::set<int> >& exclusions, bool useExclusions,
-                                      std::vector<OpenMM::RealVec>& forces, RealOpenMM* totalEnergy, std::vector<std::vector<RealOpenMM> >& dEdV) const;
+                                      std::vector<OpenMM::RealVec>& forces, RealOpenMM* totalEnergy, std::vector<std::vector<RealOpenMM> >& dEdV);
 
       /**---------------------------------------------------------------------------------------
 
@@ -163,7 +157,6 @@ class ReferenceCustomGBIxn {
          @param atom2            the index of the second atom in the pair
          @param atomCoordinates  atom coordinates
          @param atomParameters   atomParameters[atomIndex][paramterIndex]
-         @param globalParameters the values of global parameters
          @param values           the vector containing computed values
          @param forces           forces on atoms are added to this
          @param totalEnergy      the energy contribution is added to this
@@ -172,9 +165,8 @@ class ReferenceCustomGBIxn {
          --------------------------------------------------------------------------------------- */
 
       void calculateOnePairEnergyTerm(int index, int atom1, int atom2, std::vector<OpenMM::RealVec>& atomCoordinates, RealOpenMM** atomParameters,
-                                 const std::map<std::string, double>& globalParameters,
                                  const std::vector<std::vector<RealOpenMM> >& values,
-                                 std::vector<OpenMM::RealVec>& forces, RealOpenMM* totalEnergy, std::vector<std::vector<RealOpenMM> >& dEdV) const;
+                                 std::vector<OpenMM::RealVec>& forces, RealOpenMM* totalEnergy, std::vector<std::vector<RealOpenMM> >& dEdV);
 
       /**---------------------------------------------------------------------------------------
 
@@ -184,7 +176,6 @@ class ReferenceCustomGBIxn {
          @param atomCoordinates  atom coordinates
          @param atomParameters   atomParameters[atomIndex][paramterIndex]
          @param values           the vector containing computed values
-         @param globalParameters the values of global parameters
          @param exclusions       exclusions[i] is the set of excluded indices for atom i
          @param forces           forces on atoms are added to this
          @param dEdV             the derivative of energy with respect to computed values is stored in this
@@ -193,9 +184,8 @@ class ReferenceCustomGBIxn {
 
       void calculateChainRuleForces(int numAtoms, std::vector<OpenMM::RealVec>& atomCoordinates, RealOpenMM** atomParameters,
                                       const std::vector<std::vector<RealOpenMM> >& values,
-                                      const std::map<std::string, double>& globalParameters,
                                       const std::vector<std::set<int> >& exclusions,
-                                      std::vector<OpenMM::RealVec>& forces, std::vector<std::vector<RealOpenMM> >& dEdV) const;
+                                      std::vector<OpenMM::RealVec>& forces, std::vector<std::vector<RealOpenMM> >& dEdV);
 
       /**---------------------------------------------------------------------------------------
 
@@ -205,7 +195,6 @@ class ReferenceCustomGBIxn {
          @param atom2            the index of the second atom in the pair
          @param atomCoordinates  atom coordinates
          @param atomParameters   atomParameters[atomIndex][paramterIndex]
-         @param globalParameters the values of global parameters
          @param values           the vector containing computed values
          @param forces           forces on atoms are added to this
          @param dEdV             the derivative of energy with respect to computed values is stored in this
@@ -214,10 +203,9 @@ class ReferenceCustomGBIxn {
          --------------------------------------------------------------------------------------- */
 
       void calculateOnePairChainRule(int atom1, int atom2, std::vector<OpenMM::RealVec>& atomCoordinates, RealOpenMM** atomParameters,
-                                 const std::map<std::string, double>& globalParameters,
                                  const std::vector<std::vector<RealOpenMM> >& values,
                                  std::vector<OpenMM::RealVec>& forces, std::vector<std::vector<RealOpenMM> >& dEdV,
-                                 bool isExcluded) const;
+                                 bool isExcluded);
 
    public:
 
@@ -227,14 +215,14 @@ class ReferenceCustomGBIxn {
 
          --------------------------------------------------------------------------------------- */
 
-       ReferenceCustomGBIxn(const std::vector<Lepton::ExpressionProgram>& valueExpressions,
-                            const std::vector<std::vector<Lepton::ExpressionProgram> > valueDerivExpressions,
-                            const std::vector<std::vector<Lepton::ExpressionProgram> > valueGradientExpressions,
+       ReferenceCustomGBIxn(const std::vector<Lepton::CompiledExpression>& valueExpressions,
+                            const std::vector<std::vector<Lepton::CompiledExpression> > valueDerivExpressions,
+                            const std::vector<std::vector<Lepton::CompiledExpression> > valueGradientExpressions,
                             const std::vector<std::string>& valueNames,
                             const std::vector<OpenMM::CustomGBForce::ComputationType>& valueTypes,
-                            const std::vector<Lepton::ExpressionProgram>& energyExpressions,
-                            const std::vector<std::vector<Lepton::ExpressionProgram> > energyDerivExpressions,
-                            const std::vector<std::vector<Lepton::ExpressionProgram> > energyGradientExpressions,
+                            const std::vector<Lepton::CompiledExpression>& energyExpressions,
+                            const std::vector<std::vector<Lepton::CompiledExpression> > energyDerivExpressions,
+                            const std::vector<std::vector<Lepton::CompiledExpression> > energyGradientExpressions,
                             const std::vector<OpenMM::CustomGBForce::ComputationType>& energyTypes,
                             const std::vector<std::string>& parameterNames);
 
@@ -284,7 +272,7 @@ class ReferenceCustomGBIxn {
          --------------------------------------------------------------------------------------- */
 
       void calculateIxn(int numberOfAtoms, std::vector<OpenMM::RealVec>& atomCoordinates, RealOpenMM** atomParameters, const std::vector<std::set<int> >& exclusions,
-                       std::map<std::string, double>& globalParameters, std::vector<OpenMM::RealVec>& forces, RealOpenMM* totalEnergy) const;
+                       std::map<std::string, double>& globalParameters, std::vector<OpenMM::RealVec>& forces, RealOpenMM* totalEnergy);
 
 // ---------------------------------------------------------------------------------------
 

--- a/platforms/reference/include/ReferenceCustomGBIxn.h
+++ b/platforms/reference/include/ReferenceCustomGBIxn.h
@@ -1,5 +1,5 @@
 
-/* Portions copyright (c) 2009 Stanford University and Simbios.
+/* Portions copyright (c) 2009-2016 Stanford University and Simbios.
  * Contributors: Peter Eastman
  *
  * Permission is hereby granted, free of charge, to any person obtaining
@@ -47,16 +47,20 @@ class ReferenceCustomGBIxn {
       std::vector<Lepton::CompiledExpression> valueExpressions;
       std::vector<std::vector<Lepton::CompiledExpression> > valueDerivExpressions;
       std::vector<std::vector<Lepton::CompiledExpression> > valueGradientExpressions;
+      std::vector<std::vector<Lepton::CompiledExpression> > valueParamDerivExpressions;
       std::vector<OpenMM::CustomGBForce::ComputationType> valueTypes;
       std::vector<Lepton::CompiledExpression> energyExpressions;
       std::vector<std::vector<Lepton::CompiledExpression> > energyDerivExpressions;
       std::vector<std::vector<Lepton::CompiledExpression> > energyGradientExpressions;
+      std::vector<std::vector<Lepton::CompiledExpression> > energyParamDerivExpressions;
       std::vector<OpenMM::CustomGBForce::ComputationType> energyTypes;
       std::vector<int> paramIndex;
       std::vector<int> valueIndex;
       std::vector<int> particleParamIndex;
       std::vector<int> particleValueIndex;
       int rIndex, xIndex, yIndex, zIndex;
+      std::vector<std::vector<RealOpenMM> > values, dEdV;
+      std::vector<std::vector<std::vector<RealOpenMM> > > dValuedParam;
 
       /**---------------------------------------------------------------------------------------
 
@@ -65,13 +69,11 @@ class ReferenceCustomGBIxn {
          @param index            the index of the value to compute
          @param numAtoms         number of atoms
          @param atomCoordinates  atom coordinates
-         @param values           the vector to store computed values into
          @param atomParameters   atomParameters[atomIndex][paramterIndex]
 
          --------------------------------------------------------------------------------------- */
 
-      void calculateSingleParticleValue(int index, int numAtoms, std::vector<OpenMM::RealVec>& atomCoordinates, std::vector<std::vector<RealOpenMM> >& values,
-                                        RealOpenMM** atomParameters);
+      void calculateSingleParticleValue(int index, int numAtoms, std::vector<OpenMM::RealVec>& atomCoordinates, RealOpenMM** atomParameters);
 
       /**---------------------------------------------------------------------------------------
 
@@ -81,14 +83,12 @@ class ReferenceCustomGBIxn {
          @param numAtoms         number of atoms
          @param atomCoordinates  atom coordinates
          @param atomParameters   atomParameters[atomIndex][paramterIndex]
-         @param values           the vector to store computed values into
          @param exclusions       exclusions[i] is the set of excluded indices for atom i
          @param useExclusions    specifies whether to use exclusions
 
          --------------------------------------------------------------------------------------- */
 
       void calculateParticlePairValue(int index, int numAtoms, std::vector<OpenMM::RealVec>& atomCoordinates, RealOpenMM** atomParameters,
-                                      std::vector<std::vector<RealOpenMM> >& values,
                                       const std::vector<std::set<int> >& exclusions, bool useExclusions);
 
       /**---------------------------------------------------------------------------------------
@@ -100,12 +100,10 @@ class ReferenceCustomGBIxn {
          @param atom2            the index of the second atom in the pair
          @param atomCoordinates  atom coordinates
          @param atomParameters   atomParameters[atomIndex][paramterIndex]
-         @param values           the vector to store computed values into
 
          --------------------------------------------------------------------------------------- */
 
-      void calculateOnePairValue(int index, int atom1, int atom2, std::vector<OpenMM::RealVec>& atomCoordinates, RealOpenMM** atomParameters,
-                                 std::vector<std::vector<RealOpenMM> >& values);
+      void calculateOnePairValue(int index, int atom1, int atom2, std::vector<OpenMM::RealVec>& atomCoordinates, RealOpenMM** atomParameters);
 
       /**---------------------------------------------------------------------------------------
 
@@ -114,17 +112,14 @@ class ReferenceCustomGBIxn {
          @param index            the index of the value to compute
          @param numAtoms         number of atoms
          @param atomCoordinates  atom coordinates
-         @param values           the vector containing computed values
          @param atomParameters   atomParameters[atomIndex][paramterIndex]
          @param forces           forces on atoms are added to this
          @param totalEnergy      the energy contribution is added to this
-         @param dEdV             the derivative of energy with respect to computed values is stored in this
 
          --------------------------------------------------------------------------------------- */
 
-      void calculateSingleParticleEnergyTerm(int index, int numAtoms, std::vector<OpenMM::RealVec>& atomCoordinates, const std::vector<std::vector<RealOpenMM> >& values,
-                                        RealOpenMM** atomParameters, std::vector<OpenMM::RealVec>& forces,
-                                        RealOpenMM* totalEnergy, std::vector<std::vector<RealOpenMM> >& dEdV);
+      void calculateSingleParticleEnergyTerm(int index, int numAtoms, std::vector<OpenMM::RealVec>& atomCoordinates,
+                        RealOpenMM** atomParameters, std::vector<OpenMM::RealVec>& forces, RealOpenMM* totalEnergy, double* energyParamDerivs);
 
       /**---------------------------------------------------------------------------------------
 
@@ -134,19 +129,16 @@ class ReferenceCustomGBIxn {
          @param numAtoms         number of atoms
          @param atomCoordinates  atom coordinates
          @param atomParameters   atomParameters[atomIndex][paramterIndex]
-         @param values           the vector containing computed values
          @param exclusions       exclusions[i] is the set of excluded indices for atom i
          @param useExclusions    specifies whether to use exclusions
          @param forces           forces on atoms are added to this
          @param totalEnergy      the energy contribution is added to this
-         @param dEdV             the derivative of energy with respect to computed values is stored in this
 
          --------------------------------------------------------------------------------------- */
 
       void calculateParticlePairEnergyTerm(int index, int numAtoms, std::vector<OpenMM::RealVec>& atomCoordinates, RealOpenMM** atomParameters,
-                                      const std::vector<std::vector<RealOpenMM> >& values,
                                       const std::vector<std::set<int> >& exclusions, bool useExclusions,
-                                      std::vector<OpenMM::RealVec>& forces, RealOpenMM* totalEnergy, std::vector<std::vector<RealOpenMM> >& dEdV);
+                                      std::vector<OpenMM::RealVec>& forces, RealOpenMM* totalEnergy, double* energyParamDerivs);
 
       /**---------------------------------------------------------------------------------------
 
@@ -157,16 +149,13 @@ class ReferenceCustomGBIxn {
          @param atom2            the index of the second atom in the pair
          @param atomCoordinates  atom coordinates
          @param atomParameters   atomParameters[atomIndex][paramterIndex]
-         @param values           the vector containing computed values
          @param forces           forces on atoms are added to this
          @param totalEnergy      the energy contribution is added to this
-         @param dEdV             the derivative of energy with respect to computed values is stored in this
 
          --------------------------------------------------------------------------------------- */
 
       void calculateOnePairEnergyTerm(int index, int atom1, int atom2, std::vector<OpenMM::RealVec>& atomCoordinates, RealOpenMM** atomParameters,
-                                 const std::vector<std::vector<RealOpenMM> >& values,
-                                 std::vector<OpenMM::RealVec>& forces, RealOpenMM* totalEnergy, std::vector<std::vector<RealOpenMM> >& dEdV);
+                                 std::vector<OpenMM::RealVec>& forces, RealOpenMM* totalEnergy, double* energyParamDerivs);
 
       /**---------------------------------------------------------------------------------------
 
@@ -175,17 +164,13 @@ class ReferenceCustomGBIxn {
          @param numAtoms         number of atoms
          @param atomCoordinates  atom coordinates
          @param atomParameters   atomParameters[atomIndex][paramterIndex]
-         @param values           the vector containing computed values
          @param exclusions       exclusions[i] is the set of excluded indices for atom i
          @param forces           forces on atoms are added to this
-         @param dEdV             the derivative of energy with respect to computed values is stored in this
 
          --------------------------------------------------------------------------------------- */
 
       void calculateChainRuleForces(int numAtoms, std::vector<OpenMM::RealVec>& atomCoordinates, RealOpenMM** atomParameters,
-                                      const std::vector<std::vector<RealOpenMM> >& values,
-                                      const std::vector<std::set<int> >& exclusions,
-                                      std::vector<OpenMM::RealVec>& forces, std::vector<std::vector<RealOpenMM> >& dEdV);
+                                      const std::vector<std::set<int> >& exclusions, std::vector<OpenMM::RealVec>& forces);
 
       /**---------------------------------------------------------------------------------------
 
@@ -195,17 +180,13 @@ class ReferenceCustomGBIxn {
          @param atom2            the index of the second atom in the pair
          @param atomCoordinates  atom coordinates
          @param atomParameters   atomParameters[atomIndex][paramterIndex]
-         @param values           the vector containing computed values
          @param forces           forces on atoms are added to this
-         @param dEdV             the derivative of energy with respect to computed values is stored in this
          @param isExcluded       specifies whether this is an excluded pair
 
          --------------------------------------------------------------------------------------- */
 
       void calculateOnePairChainRule(int atom1, int atom2, std::vector<OpenMM::RealVec>& atomCoordinates, RealOpenMM** atomParameters,
-                                 const std::vector<std::vector<RealOpenMM> >& values,
-                                 std::vector<OpenMM::RealVec>& forces, std::vector<std::vector<RealOpenMM> >& dEdV,
-                                 bool isExcluded);
+                                 std::vector<OpenMM::RealVec>& forces, bool isExcluded);
 
    public:
 
@@ -218,11 +199,13 @@ class ReferenceCustomGBIxn {
        ReferenceCustomGBIxn(const std::vector<Lepton::CompiledExpression>& valueExpressions,
                             const std::vector<std::vector<Lepton::CompiledExpression> > valueDerivExpressions,
                             const std::vector<std::vector<Lepton::CompiledExpression> > valueGradientExpressions,
+                            const std::vector<std::vector<Lepton::CompiledExpression> > valueParamDerivExpressions,
                             const std::vector<std::string>& valueNames,
                             const std::vector<OpenMM::CustomGBForce::ComputationType>& valueTypes,
                             const std::vector<Lepton::CompiledExpression>& energyExpressions,
                             const std::vector<std::vector<Lepton::CompiledExpression> > energyDerivExpressions,
                             const std::vector<std::vector<Lepton::CompiledExpression> > energyGradientExpressions,
+                            const std::vector<std::vector<Lepton::CompiledExpression> > energyParamDerivExpressions,
                             const std::vector<OpenMM::CustomGBForce::ComputationType>& energyTypes,
                             const std::vector<std::string>& parameterNames);
 
@@ -272,7 +255,7 @@ class ReferenceCustomGBIxn {
          --------------------------------------------------------------------------------------- */
 
       void calculateIxn(int numberOfAtoms, std::vector<OpenMM::RealVec>& atomCoordinates, RealOpenMM** atomParameters, const std::vector<std::set<int> >& exclusions,
-                       std::map<std::string, double>& globalParameters, std::vector<OpenMM::RealVec>& forces, RealOpenMM* totalEnergy);
+                       std::map<std::string, double>& globalParameters, std::vector<OpenMM::RealVec>& forces, RealOpenMM* totalEnergy, double* energyParamDerivs);
 
 // ---------------------------------------------------------------------------------------
 

--- a/platforms/reference/include/ReferenceCustomNonbondedIxn.h
+++ b/platforms/reference/include/ReferenceCustomNonbondedIxn.h
@@ -1,5 +1,5 @@
 
-/* Portions copyright (c) 2009-2013 Stanford University and Simbios.
+/* Portions copyright (c) 2009-2016 Stanford University and Simbios.
  * Contributors: Peter Eastman
  *
  * Permission is hereby granted, free of charge, to any person obtaining
@@ -27,7 +27,7 @@
 
 #include "ReferencePairIxn.h"
 #include "ReferenceNeighborList.h"
-#include "lepton/CompiledExpression.h"
+#include "openmm/internal/CompiledExpressionSet.h"
 #include <map>
 #include <set>
 #include <utility>
@@ -48,10 +48,10 @@ class ReferenceCustomNonbondedIxn {
       Lepton::CompiledExpression energyExpression;
       Lepton::CompiledExpression forceExpression;
       std::vector<std::string> paramNames;
-      std::vector<double*> energyParticleParams;
-      std::vector<double*> forceParticleParams;
-      double* energyR;
-      double* forceR;
+      std::vector<Lepton::CompiledExpression> energyParamDerivExpressions;
+      CompiledExpressionSet expressionSet;
+      std::vector<int> particleParamIndex;
+      int rIndex;
       std::vector<std::pair<std::set<int>, std::set<int> > > interactionGroups;
 
       /**---------------------------------------------------------------------------------------
@@ -69,7 +69,7 @@ class ReferenceCustomNonbondedIxn {
          --------------------------------------------------------------------------------------- */
 
       void calculateOneIxn(int atom1, int atom2, std::vector<OpenMM::RealVec>& atomCoordinates, std::vector<OpenMM::RealVec>& forces,
-                           RealOpenMM* energyByAtom, RealOpenMM* totalEnergy);
+                           RealOpenMM* energyByAtom, RealOpenMM* totalEnergy, double* energyParamDerivs);
 
 
    public:
@@ -81,7 +81,7 @@ class ReferenceCustomNonbondedIxn {
          --------------------------------------------------------------------------------------- */
 
        ReferenceCustomNonbondedIxn(const Lepton::CompiledExpression& energyExpression, const Lepton::CompiledExpression& forceExpression,
-                                   const std::vector<std::string>& parameterNames);
+                                   const std::vector<std::string>& parameterNames, const std::vector<Lepton::CompiledExpression> energyParamDerivExpressions);
 
       /**---------------------------------------------------------------------------------------
 
@@ -155,7 +155,8 @@ class ReferenceCustomNonbondedIxn {
       void calculatePairIxn(int numberOfAtoms, std::vector<OpenMM::RealVec>& atomCoordinates,
                             RealOpenMM** atomParameters, std::vector<std::set<int> >& exclusions,
                             RealOpenMM* fixedParameters, const std::map<std::string, double>& globalParameters,
-                            std::vector<OpenMM::RealVec>& forces, RealOpenMM* energyByAtom, RealOpenMM* totalEnergy);
+                            std::vector<OpenMM::RealVec>& forces, RealOpenMM* energyByAtom, RealOpenMM* totalEnergy,
+                            double* energyParamDerivs);
 
 // ---------------------------------------------------------------------------------------
 

--- a/platforms/reference/include/ReferenceCustomTorsionIxn.h
+++ b/platforms/reference/include/ReferenceCustomTorsionIxn.h
@@ -25,7 +25,7 @@
 #define __ReferenceCustomTorsionIxn_H__
 
 #include "ReferenceBondIxn.h"
-#include "lepton/CompiledExpression.h"
+#include "openmm/internal/CompiledExpressionSet.h"
 
 namespace OpenMM {
 
@@ -34,10 +34,10 @@ class ReferenceCustomTorsionIxn : public ReferenceBondIxn {
    private:
       Lepton::CompiledExpression energyExpression;
       Lepton::CompiledExpression forceExpression;
-      std::vector<double*> energyParams;
-      std::vector<double*> forceParams;
-      double* energyTheta;
-      double* forceTheta;
+      std::vector<Lepton::CompiledExpression> energyParamDerivExpressions;
+      CompiledExpressionSet expressionSet;
+      std::vector<int> torsionParamIndex;
+      int thetaIndex;
       int numParameters;
       bool usePeriodic;
       RealVec boxVectors[3];
@@ -51,7 +51,8 @@ class ReferenceCustomTorsionIxn : public ReferenceBondIxn {
          --------------------------------------------------------------------------------------- */
 
        ReferenceCustomTorsionIxn(const Lepton::CompiledExpression& energyExpression, const Lepton::CompiledExpression& forceExpression,
-                              const std::vector<std::string>& parameterNames, std::map<std::string, double> globalParameters);
+                              const std::vector<std::string>& parameterNames, std::map<std::string, double> globalParameters,
+                              const std::vector<Lepton::CompiledExpression> energyParamDerivExpressions);
 
       /**---------------------------------------------------------------------------------------
 

--- a/platforms/reference/include/ReferenceCustomTorsionIxn.h
+++ b/platforms/reference/include/ReferenceCustomTorsionIxn.h
@@ -85,7 +85,7 @@ class ReferenceCustomTorsionIxn : public ReferenceBondIxn {
 
       void calculateBondIxn(int* atomIndices, std::vector<OpenMM::RealVec>& atomCoordinates,
                             RealOpenMM* parameters, std::vector<OpenMM::RealVec>& forces,
-                            RealOpenMM* totalEnergy) const;
+                            RealOpenMM* totalEnergy, double* energyParamDerivs);
 
 
 };

--- a/platforms/reference/include/ReferenceHarmonicBondIxn.h
+++ b/platforms/reference/include/ReferenceHarmonicBondIxn.h
@@ -79,7 +79,7 @@ class ReferenceHarmonicBondIxn : public ReferenceBondIxn {
       
       void calculateBondIxn(int* atomIndices, std::vector<OpenMM::RealVec>& atomCoordinates,
                             RealOpenMM* parameters, std::vector<OpenMM::RealVec>& forces,
-                            RealOpenMM* totalEnergy) const;
+                            RealOpenMM* totalEnergy, double* energyParamDerivs);
 
 };
 

--- a/platforms/reference/include/ReferenceKernels.h
+++ b/platforms/reference/include/ReferenceKernels.h
@@ -38,7 +38,6 @@
 #include "ReferenceNeighborList.h"
 #include "lepton/CompiledExpression.h"
 #include "lepton/CustomFunction.h"
-#include "lepton/ExpressionProgram.h"
 
 namespace OpenMM {
 
@@ -739,13 +738,13 @@ private:
     RealOpenMM nonbondedCutoff;
     std::vector<std::set<int> > exclusions;
     std::vector<std::string> particleParameterNames, globalParameterNames, valueNames;
-    std::vector<Lepton::ExpressionProgram> valueExpressions;
-    std::vector<std::vector<Lepton::ExpressionProgram> > valueDerivExpressions;
-    std::vector<std::vector<Lepton::ExpressionProgram> > valueGradientExpressions;
+    std::vector<Lepton::CompiledExpression> valueExpressions;
+    std::vector<std::vector<Lepton::CompiledExpression> > valueDerivExpressions;
+    std::vector<std::vector<Lepton::CompiledExpression> > valueGradientExpressions;
     std::vector<OpenMM::CustomGBForce::ComputationType> valueTypes;
-    std::vector<Lepton::ExpressionProgram> energyExpressions;
-    std::vector<std::vector<Lepton::ExpressionProgram> > energyDerivExpressions;
-    std::vector<std::vector<Lepton::ExpressionProgram> > energyGradientExpressions;
+    std::vector<Lepton::CompiledExpression> energyExpressions;
+    std::vector<std::vector<Lepton::CompiledExpression> > energyDerivExpressions;
+    std::vector<std::vector<Lepton::CompiledExpression> > energyGradientExpressions;
     std::vector<OpenMM::CustomGBForce::ComputationType> energyTypes;
     NonbondedMethod nonbondedMethod;
     NeighborList* neighborList;

--- a/platforms/reference/include/ReferenceKernels.h
+++ b/platforms/reference/include/ReferenceKernels.h
@@ -158,6 +158,12 @@ public:
      */
     void getForces(ContextImpl& context, std::vector<Vec3>& forces);
     /**
+     * Get the current derivatives of the energy with respect to context parameters.
+     *
+     * @param derivs  on exit, this contains the derivatives
+     */
+    void getEnergyParameterDerivatives(ContextImpl& context, std::map<std::string, double>& derivs);
+    /**
      * Get the current periodic box vectors.
      *
      * @param a      on exit, this contains the vector defining the first edge of the periodic box
@@ -319,7 +325,8 @@ private:
     int **bondIndexArray;
     RealOpenMM **bondParamArray;
     Lepton::CompiledExpression energyExpression, forceExpression;
-    std::vector<std::string> parameterNames, globalParameterNames;
+    std::vector<Lepton::CompiledExpression> energyParamDerivExpressions;
+    std::vector<std::string> parameterNames, globalParameterNames, energyParamDerivNames;
     bool usePeriodic;
 };
 

--- a/platforms/reference/include/ReferenceKernels.h
+++ b/platforms/reference/include/ReferenceKernels.h
@@ -737,14 +737,16 @@ private:
     RealOpenMM **particleParamArray;
     RealOpenMM nonbondedCutoff;
     std::vector<std::set<int> > exclusions;
-    std::vector<std::string> particleParameterNames, globalParameterNames, valueNames;
+    std::vector<std::string> particleParameterNames, globalParameterNames, energyParamDerivNames, valueNames;
     std::vector<Lepton::CompiledExpression> valueExpressions;
     std::vector<std::vector<Lepton::CompiledExpression> > valueDerivExpressions;
     std::vector<std::vector<Lepton::CompiledExpression> > valueGradientExpressions;
+    std::vector<std::vector<Lepton::CompiledExpression> > valueParamDerivExpressions;
     std::vector<OpenMM::CustomGBForce::ComputationType> valueTypes;
     std::vector<Lepton::CompiledExpression> energyExpressions;
     std::vector<std::vector<Lepton::CompiledExpression> > energyDerivExpressions;
     std::vector<std::vector<Lepton::CompiledExpression> > energyGradientExpressions;
+    std::vector<std::vector<Lepton::CompiledExpression> > energyParamDerivExpressions;
     std::vector<OpenMM::CustomGBForce::ComputationType> energyTypes;
     NonbondedMethod nonbondedMethod;
     NeighborList* neighborList;

--- a/platforms/reference/include/ReferenceKernels.h
+++ b/platforms/reference/include/ReferenceKernels.h
@@ -878,7 +878,7 @@ private:
     int numBonds, numParticles;
     RealOpenMM **bondParamArray;
     ReferenceCustomCentroidBondIxn* ixn;
-    std::vector<std::string> globalParameterNames;
+    std::vector<std::string> globalParameterNames, energyParamDerivNames;
     bool usePeriodic;
 };
 
@@ -917,7 +917,7 @@ private:
     int numBonds;
     RealOpenMM **bondParamArray;
     ReferenceCustomCompoundBondIxn* ixn;
-    std::vector<std::string> globalParameterNames;
+    std::vector<std::string> globalParameterNames, energyParamDerivNames;
     bool usePeriodic;
 };
 

--- a/platforms/reference/include/ReferenceKernels.h
+++ b/platforms/reference/include/ReferenceKernels.h
@@ -404,7 +404,8 @@ private:
     int **angleIndexArray;
     RealOpenMM **angleParamArray;
     Lepton::CompiledExpression energyExpression, forceExpression;
-    std::vector<std::string> parameterNames, globalParameterNames;
+    std::vector<Lepton::CompiledExpression> energyParamDerivExpressions;
+    std::vector<std::string> parameterNames, globalParameterNames, energyParamDerivNames;
     bool usePeriodic;
 };
 
@@ -557,7 +558,8 @@ private:
     int **torsionIndexArray;
     RealOpenMM **torsionParamArray;
     Lepton::CompiledExpression energyExpression, forceExpression;
-    std::vector<std::string> parameterNames, globalParameterNames;
+    std::vector<Lepton::CompiledExpression> energyParamDerivExpressions;
+    std::vector<std::string> parameterNames, globalParameterNames, energyParamDerivNames;
     bool usePeriodic;
 };
 
@@ -654,8 +656,10 @@ private:
     std::map<std::string, double> globalParamValues;
     std::vector<std::set<int> > exclusions;
     Lepton::CompiledExpression energyExpression, forceExpression;
-    std::vector<std::string> parameterNames, globalParameterNames;
+    std::vector<Lepton::CompiledExpression> energyParamDerivExpressions;
+    std::vector<std::string> parameterNames, globalParameterNames, energyParamDerivNames;
     std::vector<std::pair<std::set<int>, std::set<int> > > interactionGroups;
+    std::vector<double> longRangeCoefficientDerivs;
     NonbondedMethod nonbondedMethod;
     NeighborList* neighborList;
 };

--- a/platforms/reference/include/ReferenceLJCoulomb14.h
+++ b/platforms/reference/include/ReferenceLJCoulomb14.h
@@ -1,5 +1,5 @@
 
-/* Portions copyright (c) 2006 Stanford University and Simbios.
+/* Portions copyright (c) 2006-2016 Stanford University and Simbios.
  * Contributors: Pande Group
  *
  * Permission is hereby granted, free of charge, to any person obtaining
@@ -64,7 +64,7 @@ class OPENMM_EXPORT ReferenceLJCoulomb14 : public ReferenceBondIxn {
       
       void calculateBondIxn(int* atomIndices, std::vector<OpenMM::RealVec>& atomCoordinates,
                             RealOpenMM* parameters, std::vector<OpenMM::RealVec>& forces,
-                            RealOpenMM* totalEnergy) const;
+                            RealOpenMM* totalEnergy, double* energyParamDerivs);
 
 };
 

--- a/platforms/reference/include/ReferencePlatform.h
+++ b/platforms/reference/include/ReferencePlatform.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008 Stanford University and the Authors.           *
+ * Portions copyright (c) 2008-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -68,6 +68,7 @@ public:
     void* periodicBoxSize;
     void* periodicBoxVectors;
     void* constraints;
+    void* energyParameterDerivatives;
 };
 } // namespace OpenMM
 

--- a/platforms/reference/include/ReferenceProperDihedralBond.h
+++ b/platforms/reference/include/ReferenceProperDihedralBond.h
@@ -80,7 +80,7 @@ class OPENMM_EXPORT ReferenceProperDihedralBond : public ReferenceBondIxn {
       
       void calculateBondIxn(int* atomIndices, std::vector<OpenMM::RealVec>& atomCoordinates,
                             RealOpenMM* parameters, std::vector<OpenMM::RealVec>& forces,
-                            RealOpenMM* totalEnergy) const;
+                            RealOpenMM* totalEnergy, double* energyParamDerivs);
 
 };
 

--- a/platforms/reference/include/ReferenceRbDihedralBond.h
+++ b/platforms/reference/include/ReferenceRbDihedralBond.h
@@ -78,7 +78,7 @@ class OPENMM_EXPORT ReferenceRbDihedralBond : public ReferenceBondIxn {
       
       void calculateBondIxn(int* atomIndices, std::vector<OpenMM::RealVec>& atomCoordinates,
                             RealOpenMM* parameters, std::vector<OpenMM::RealVec>& forces,
-                            RealOpenMM* totalEnergy) const;
+                            RealOpenMM* totalEnergy, double* energyParamDerivs);
 
 };
 

--- a/platforms/reference/src/ReferenceKernels.cpp
+++ b/platforms/reference/src/ReferenceKernels.cpp
@@ -1376,19 +1376,19 @@ void ReferenceCalcCustomGBForceKernel::initialize(const System& system, const Cu
         CustomGBForce::ComputationType type;
         force.getComputedValueParameters(i, name, expression, type);
         Lepton::ParsedExpression ex = Lepton::Parser::parse(expression, functions).optimize();
-        valueExpressions.push_back(ex.createProgram());
+        valueExpressions.push_back(ex.createCompiledExpression());
         valueTypes.push_back(type);
         valueNames.push_back(name);
         if (i == 0) {
-            valueDerivExpressions[i].push_back(ex.differentiate("r").optimize().createProgram());
+            valueDerivExpressions[i].push_back(ex.differentiate("r").optimize().createCompiledExpression());
             validateVariables(ex.getRootNode(), pairVariables);
         }
         else {
-            valueGradientExpressions[i].push_back(ex.differentiate("x").optimize().createProgram());
-            valueGradientExpressions[i].push_back(ex.differentiate("y").optimize().createProgram());
-            valueGradientExpressions[i].push_back(ex.differentiate("z").optimize().createProgram());
+            valueGradientExpressions[i].push_back(ex.differentiate("x").optimize().createCompiledExpression());
+            valueGradientExpressions[i].push_back(ex.differentiate("y").optimize().createCompiledExpression());
+            valueGradientExpressions[i].push_back(ex.differentiate("z").optimize().createCompiledExpression());
             for (int j = 0; j < i; j++)
-                valueDerivExpressions[i].push_back(ex.differentiate(valueNames[j]).optimize().createProgram());
+                valueDerivExpressions[i].push_back(ex.differentiate(valueNames[j]).optimize().createCompiledExpression());
             validateVariables(ex.getRootNode(), particleVariables);
         }
         particleVariables.insert(name);
@@ -1405,21 +1405,21 @@ void ReferenceCalcCustomGBForceKernel::initialize(const System& system, const Cu
         CustomGBForce::ComputationType type;
         force.getEnergyTermParameters(i, expression, type);
         Lepton::ParsedExpression ex = Lepton::Parser::parse(expression, functions).optimize();
-        energyExpressions.push_back(ex.createProgram());
+        energyExpressions.push_back(ex.createCompiledExpression());
         energyTypes.push_back(type);
         if (type != CustomGBForce::SingleParticle)
-            energyDerivExpressions[i].push_back(ex.differentiate("r").optimize().createProgram());
+            energyDerivExpressions[i].push_back(ex.differentiate("r").optimize().createCompiledExpression());
         for (int j = 0; j < force.getNumComputedValues(); j++) {
             if (type == CustomGBForce::SingleParticle) {
-                energyDerivExpressions[i].push_back(ex.differentiate(valueNames[j]).optimize().createProgram());
-                energyGradientExpressions[i].push_back(ex.differentiate("x").optimize().createProgram());
-                energyGradientExpressions[i].push_back(ex.differentiate("y").optimize().createProgram());
-                energyGradientExpressions[i].push_back(ex.differentiate("z").optimize().createProgram());
+                energyDerivExpressions[i].push_back(ex.differentiate(valueNames[j]).optimize().createCompiledExpression());
+                energyGradientExpressions[i].push_back(ex.differentiate("x").optimize().createCompiledExpression());
+                energyGradientExpressions[i].push_back(ex.differentiate("y").optimize().createCompiledExpression());
+                energyGradientExpressions[i].push_back(ex.differentiate("z").optimize().createCompiledExpression());
                 validateVariables(ex.getRootNode(), particleVariables);
             }
             else {
-                energyDerivExpressions[i].push_back(ex.differentiate(valueNames[j]+"1").optimize().createProgram());
-                energyDerivExpressions[i].push_back(ex.differentiate(valueNames[j]+"2").optimize().createProgram());
+                energyDerivExpressions[i].push_back(ex.differentiate(valueNames[j]+"1").optimize().createCompiledExpression());
+                energyDerivExpressions[i].push_back(ex.differentiate(valueNames[j]+"2").optimize().createCompiledExpression());
                 validateVariables(ex.getRootNode(), pairVariables);
             }
         }

--- a/platforms/reference/src/ReferencePlatform.cpp
+++ b/platforms/reference/src/ReferencePlatform.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008 Stanford University and the Authors.           *
+ * Portions copyright (c) 2008-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -36,6 +36,7 @@
 #include "openmm/internal/ContextImpl.h"
 #include "SimTKOpenMMRealType.h"
 #include "RealVec.h"
+#include <map>
 #include <vector>
 
 using namespace OpenMM;
@@ -99,6 +100,7 @@ ReferencePlatform::PlatformData::PlatformData(const System& system) : time(0.0),
     periodicBoxSize = new RealVec();
     periodicBoxVectors = new RealVec[3];
     constraints = new ReferenceConstraints(system);
+    energyParameterDerivatives = new map<string, double>();
 }
 
 ReferencePlatform::PlatformData::~PlatformData() {
@@ -108,4 +110,5 @@ ReferencePlatform::PlatformData::~PlatformData() {
     delete (RealVec*) periodicBoxSize;
     delete[] (RealVec*) periodicBoxVectors;
     delete (ReferenceConstraints*) constraints;
+    delete (map<string, double>*) energyParameterDerivatives;
 }

--- a/platforms/reference/src/SimTKReference/ReferenceAngleBondIxn.cpp
+++ b/platforms/reference/src/SimTKReference/ReferenceAngleBondIxn.cpp
@@ -1,5 +1,5 @@
 
-/* Portions copyright (c) 2006 Stanford University and Simbios.
+/* Portions copyright (c) 2006-2016 Stanford University and Simbios.
  * Contributors: Pande Group
  *
  * Permission is hereby granted, free of charge, to any person obtaining
@@ -129,7 +129,7 @@ void ReferenceAngleBondIxn::calculateBondIxn(int* atomIndices,
                                              vector<RealVec>& atomCoordinates,
                                              RealOpenMM* parameters,
                                              vector<RealVec>& forces,
-                                             RealOpenMM* totalEnergy) const {
+                                             RealOpenMM* totalEnergy, double* energyParamDerivs) {
 
    // constants -- reduce Visual Studio warnings regarding conversions between float & double
 

--- a/platforms/reference/src/SimTKReference/ReferenceBondForce.cpp
+++ b/platforms/reference/src/SimTKReference/ReferenceBondForce.cpp
@@ -1,5 +1,5 @@
 
-/* Portions copyright (c) 2006 Stanford University and Simbios.
+/* Portions copyright (c) 2006-2016 Stanford University and Simbios.
  * Contributors: Pande Group
  *
  * Permission is hereby granted, free of charge, to any person obtaining
@@ -97,7 +97,7 @@ void ReferenceBondForce::calculateForce(int numberOfBonds, int** atomIndices,
       // calculate bond ixn
 
       referenceBondIxn.calculateBondIxn(atomIndices[ii], atomCoordinates, parameters[ii], 
-                                        forces, totalEnergy);
+                                        forces, totalEnergy, NULL);
    }
 }
 

--- a/platforms/reference/src/SimTKReference/ReferenceBondIxn.cpp
+++ b/platforms/reference/src/SimTKReference/ReferenceBondIxn.cpp
@@ -1,5 +1,5 @@
 
-/* Portions copyright (c) 2006-2009 Stanford University and Simbios.
+/* Portions copyright (c) 2006-2016 Stanford University and Simbios.
  * Contributors: Pande Group
  *
  * Permission is hereby granted, free of charge, to any person obtaining
@@ -78,7 +78,7 @@ ReferenceBondIxn::~ReferenceBondIxn() {
      
    void ReferenceBondIxn::calculateBondIxn(int* atomIndices, vector<RealVec>& atomCoordinates,
                                            RealOpenMM* parameters, vector<RealVec>& forces,
-                                           RealOpenMM* totalEnergy) const {
+                                           RealOpenMM* totalEnergy, double* energyParamDerivs) {
    // ---------------------------------------------------------------------------------------
 
    // static const std::string methodName = "\nReferenceBondIxn::calculateBondIxn";

--- a/platforms/reference/src/SimTKReference/ReferenceCMAPTorsionIxn.cpp
+++ b/platforms/reference/src/SimTKReference/ReferenceCMAPTorsionIxn.cpp
@@ -207,5 +207,5 @@ void ReferenceCMAPTorsionIxn::calculateOneIxn(int index, vector<RealVec>& atomCo
    --------------------------------------------------------------------------------------- */
 
 void ReferenceCMAPTorsionIxn::calculateBondIxn(int* atomIndices, vector<RealVec>& atomCoordinates,
-        RealOpenMM* parameters, vector<RealVec>& forces, RealOpenMM* totalEnergy) const {
+        RealOpenMM* parameters, vector<RealVec>& forces, RealOpenMM* totalEnergy, double* energyParamDerivs) {
 }

--- a/platforms/reference/src/SimTKReference/ReferenceCustomAngleIxn.cpp
+++ b/platforms/reference/src/SimTKReference/ReferenceCustomAngleIxn.cpp
@@ -38,20 +38,19 @@ using namespace std;
    --------------------------------------------------------------------------------------- */
 
 ReferenceCustomAngleIxn::ReferenceCustomAngleIxn(const Lepton::CompiledExpression& energyExpression,
-        const Lepton::CompiledExpression& forceExpression, const vector<string>& parameterNames, map<string, double> globalParameters) :
-        energyExpression(energyExpression), forceExpression(forceExpression), usePeriodic(false) {
-    
-    energyTheta = ReferenceForce::getVariablePointer(this->energyExpression, "theta");
-    forceTheta = ReferenceForce::getVariablePointer(this->forceExpression, "theta");
+        const Lepton::CompiledExpression& forceExpression, const vector<string>& parameterNames, map<string, double> globalParameters,
+        const vector<Lepton::CompiledExpression> energyParamDerivExpressions) :
+        energyExpression(energyExpression), forceExpression(forceExpression), usePeriodic(false), energyParamDerivExpressions(energyParamDerivExpressions) {
+    expressionSet.registerExpression(this->energyExpression);
+    expressionSet.registerExpression(this->forceExpression);
+    for (int i = 0; i < this->energyParamDerivExpressions.size(); i++)
+        expressionSet.registerExpression(this->energyParamDerivExpressions[i]);
+    thetaIndex = expressionSet.getVariableIndex("theta");
     numParameters = parameterNames.size();
-    for (int i = 0; i < (int) numParameters; i++) {
-        energyParams.push_back(ReferenceForce::getVariablePointer(this->energyExpression, parameterNames[i]));
-        forceParams.push_back(ReferenceForce::getVariablePointer(this->forceExpression, parameterNames[i]));
-    }
-    for (map<string, double>::const_iterator iter = globalParameters.begin(); iter != globalParameters.end(); ++iter) {
-        ReferenceForce::setVariable(ReferenceForce::getVariablePointer(this->energyExpression, iter->first), iter->second);
-        ReferenceForce::setVariable(ReferenceForce::getVariablePointer(this->forceExpression, iter->first), iter->second);
-    }
+    for (int i = 0; i < (int) numParameters; i++)
+        angleParamIndex.push_back(expressionSet.getVariableIndex(parameterNames[i]));
+    for (map<string, double>::const_iterator iter = globalParameters.begin(); iter != globalParameters.end(); ++iter)
+        expressionSet.setVariable(expressionSet.getVariableIndex(iter->first), iter->second);
 }
 
 /**---------------------------------------------------------------------------------------
@@ -87,17 +86,9 @@ void ReferenceCustomAngleIxn::calculateBondIxn(int* atomIndices,
                                                RealOpenMM* parameters,
                                                vector<RealVec>& forces,
                                                RealOpenMM* totalEnergy, double* energyParamDerivs) {
-
-   static const std::string methodName = "\nReferenceCustomAngleIxn::calculateAngleIxn";
-
-   static const RealOpenMM zero        = 0.0;
-   static const RealOpenMM one         = 1.0;
-
    RealOpenMM deltaR[2][ReferenceForce::LastDeltaRIndex];
-   for (int i = 0; i < numParameters; i++) {
-       ReferenceForce::setVariable(energyParams[i], parameters[i]);
-       ReferenceForce::setVariable(forceParams[i], parameters[i]);
-   }
+   for (int i = 0; i < numParameters; i++)
+       expressionSet.setVariable(angleParamIndex[i], parameters[i]);
 
    // ---------------------------------------------------------------------------------------
 
@@ -122,14 +113,13 @@ void ReferenceCustomAngleIxn::calculateBondIxn(int* atomIndices,
    RealOpenMM dot = DOT3(deltaR[0], deltaR[1]);
    RealOpenMM cosine = dot/SQRT((deltaR[0][ReferenceForce::R2Index]*deltaR[1][ReferenceForce::R2Index]));
    RealOpenMM angle;
-   if (cosine >= one)
-      angle = zero;
-   else if (cosine <= -one)
+   if (cosine >= 1.0)
+      angle = 0.0;
+   else if (cosine <= -1.0)
       angle = PI_M;
    else
       angle = ACOS(cosine);
-   ReferenceForce::setVariable(energyTheta, angle);
-   ReferenceForce::setVariable(forceTheta, angle);
+   expressionSet.setVariable(thetaIndex, angle);
 
    // Compute the force and energy, and apply them to the atoms.
    
@@ -156,6 +146,11 @@ void ReferenceCustomAngleIxn::calculateBondIxn(int* atomIndices,
       }
    }
 
+   // Record parameter derivatives.
+
+   for (int i = 0; i < energyParamDerivExpressions.size(); i++)
+       energyParamDerivs[i] += energyParamDerivExpressions[i].evaluate();
+   
    // accumulate energies
 
    if (totalEnergy != NULL)

--- a/platforms/reference/src/SimTKReference/ReferenceCustomAngleIxn.cpp
+++ b/platforms/reference/src/SimTKReference/ReferenceCustomAngleIxn.cpp
@@ -86,7 +86,7 @@ void ReferenceCustomAngleIxn::calculateBondIxn(int* atomIndices,
                                                vector<RealVec>& atomCoordinates,
                                                RealOpenMM* parameters,
                                                vector<RealVec>& forces,
-                                               RealOpenMM* totalEnergy) const {
+                                               RealOpenMM* totalEnergy, double* energyParamDerivs) {
 
    static const std::string methodName = "\nReferenceCustomAngleIxn::calculateAngleIxn";
 

--- a/platforms/reference/src/SimTKReference/ReferenceCustomCompoundBondIxn.cpp
+++ b/platforms/reference/src/SimTKReference/ReferenceCustomCompoundBondIxn.cpp
@@ -45,23 +45,47 @@ using namespace OpenMM;
 
 ReferenceCustomCompoundBondIxn::ReferenceCustomCompoundBondIxn(int numParticlesPerBond, const vector<vector<int> >& bondAtoms,
             const Lepton::ParsedExpression& energyExpression, const vector<string>& bondParameterNames,
-            const map<string, vector<int> >& distances, const map<string, vector<int> >& angles, const map<string, vector<int> >& dihedrals) :
-            bondAtoms(bondAtoms), energyExpression(energyExpression.createProgram()), bondParamNames(bondParameterNames), usePeriodic(false) {
+            const map<string, vector<int> >& distances, const map<string, vector<int> >& angles, const map<string, vector<int> >& dihedrals,
+            const std::vector<Lepton::CompiledExpression> energyParamDerivExpressions) :
+            bondAtoms(bondAtoms), energyExpression(energyExpression.createCompiledExpression()), usePeriodic(false),
+            energyParamDerivExpressions(energyParamDerivExpressions) {
+    expressionSet.registerExpression(this->energyExpression);
+    for (int i = 0; i < this->energyParamDerivExpressions.size(); i++)
+        expressionSet.registerExpression(this->energyParamDerivExpressions[i]);
     for (int i = 0; i < numParticlesPerBond; i++) {
         stringstream xname, yname, zname;
         xname << 'x' << (i+1);
         yname << 'y' << (i+1);
         zname << 'z' << (i+1);
-        particleTerms.push_back(ReferenceCustomCompoundBondIxn::ParticleTermInfo(xname.str(), i, 0, energyExpression.differentiate(xname.str()).optimize().createProgram()));
-        particleTerms.push_back(ReferenceCustomCompoundBondIxn::ParticleTermInfo(yname.str(), i, 1, energyExpression.differentiate(yname.str()).optimize().createProgram()));
-        particleTerms.push_back(ReferenceCustomCompoundBondIxn::ParticleTermInfo(zname.str(), i, 2, energyExpression.differentiate(zname.str()).optimize().createProgram()));
+        particleTerms.push_back(ReferenceCustomCompoundBondIxn::ParticleTermInfo(xname.str(), i, 0, energyExpression.differentiate(xname.str()).createCompiledExpression()));
+        particleTerms.push_back(ReferenceCustomCompoundBondIxn::ParticleTermInfo(yname.str(), i, 1, energyExpression.differentiate(yname.str()).createCompiledExpression()));
+        particleTerms.push_back(ReferenceCustomCompoundBondIxn::ParticleTermInfo(zname.str(), i, 2, energyExpression.differentiate(zname.str()).createCompiledExpression()));
     }
     for (map<string, vector<int> >::const_iterator iter = distances.begin(); iter != distances.end(); ++iter)
-        distanceTerms.push_back(ReferenceCustomCompoundBondIxn::DistanceTermInfo(iter->first, iter->second, energyExpression.differentiate(iter->first).optimize().createProgram()));
+        distanceTerms.push_back(ReferenceCustomCompoundBondIxn::DistanceTermInfo(iter->first, iter->second, energyExpression.differentiate(iter->first).createCompiledExpression()));
     for (map<string, vector<int> >::const_iterator iter = angles.begin(); iter != angles.end(); ++iter)
-        angleTerms.push_back(ReferenceCustomCompoundBondIxn::AngleTermInfo(iter->first, iter->second, energyExpression.differentiate(iter->first).optimize().createProgram()));
+        angleTerms.push_back(ReferenceCustomCompoundBondIxn::AngleTermInfo(iter->first, iter->second, energyExpression.differentiate(iter->first).createCompiledExpression()));
     for (map<string, vector<int> >::const_iterator iter = dihedrals.begin(); iter != dihedrals.end(); ++iter)
-        dihedralTerms.push_back(ReferenceCustomCompoundBondIxn::DihedralTermInfo(iter->first, iter->second, energyExpression.differentiate(iter->first).optimize().createProgram()));
+        dihedralTerms.push_back(ReferenceCustomCompoundBondIxn::DihedralTermInfo(iter->first, iter->second, energyExpression.differentiate(iter->first).createCompiledExpression()));
+    for (int i = 0; i < particleTerms.size(); i++) {
+        expressionSet.registerExpression(particleTerms[i].forceExpression);
+        particleTerms[i].index = expressionSet.getVariableIndex(particleTerms[i].name);
+    }
+    for (int i = 0; i < distanceTerms.size(); i++) {
+        expressionSet.registerExpression(distanceTerms[i].forceExpression);
+        distanceTerms[i].index = expressionSet.getVariableIndex(distanceTerms[i].name);
+    }
+    for (int i = 0; i < angleTerms.size(); i++) {
+        expressionSet.registerExpression(angleTerms[i].forceExpression);
+        angleTerms[i].index = expressionSet.getVariableIndex(angleTerms[i].name);
+    }
+    for (int i = 0; i < dihedralTerms.size(); i++) {
+        expressionSet.registerExpression(dihedralTerms[i].forceExpression);
+        dihedralTerms[i].index = expressionSet.getVariableIndex(dihedralTerms[i].name);
+    }
+    numParameters = bondParameterNames.size();
+    for (int i = 0; i < numParameters; i++)
+        bondParamIndex.push_back(expressionSet.getVariableIndex(bondParameterNames[i]));
 }
 
 /**---------------------------------------------------------------------------------------
@@ -94,14 +118,14 @@ void ReferenceCustomCompoundBondIxn::setPeriodic(OpenMM::RealVec* vectors) {
 
 void ReferenceCustomCompoundBondIxn::calculatePairIxn(vector<RealVec>& atomCoordinates, RealOpenMM** bondParameters,
                                              const map<string, double>& globalParameters, vector<RealVec>& forces,
-                                             RealOpenMM* totalEnergy) const {
-
-    map<string, double> variables = globalParameters;
+                                             RealOpenMM* totalEnergy, double* energyParamDerivs) {
+    for (map<string, double>::const_iterator iter = globalParameters.begin(); iter != globalParameters.end(); ++iter)
+        expressionSet.setVariable(expressionSet.getVariableIndex(iter->first), iter->second);
     int numBonds = bondAtoms.size();
     for (int bond = 0; bond < numBonds; bond++) {
-        for (int j = 0; j < (int) bondParamNames.size(); j++)
-            variables[bondParamNames[j]] = bondParameters[bond][j];
-        calculateOneIxn(bond, atomCoordinates, variables, forces, totalEnergy);
+        for (int i = 0; i < numParameters; i++)
+            expressionSet.setVariable(bondParamIndex[i], bondParameters[bond][i]);
+        calculateOneIxn(bond, atomCoordinates, forces, totalEnergy, energyParamDerivs);
     }
 }
 
@@ -111,7 +135,6 @@ void ReferenceCustomCompoundBondIxn::calculatePairIxn(vector<RealVec>& atomCoord
 
      @param bond             the index of the bond
      @param atomCoordinates  atom coordinates
-     @param variables        the values of variables that may appear in expressions
      @param forces           force array (forces added)
      @param energyByAtom     atom energy
      @param totalEnergy      total energy
@@ -119,31 +142,24 @@ void ReferenceCustomCompoundBondIxn::calculatePairIxn(vector<RealVec>& atomCoord
      --------------------------------------------------------------------------------------- */
 
 void ReferenceCustomCompoundBondIxn::calculateOneIxn(int bond, vector<RealVec>& atomCoordinates,
-                        map<string, double>& variables, vector<RealVec>& forces, RealOpenMM* totalEnergy) const {
-
-    // ---------------------------------------------------------------------------------------
-
-    static const std::string methodName = "\nReferenceCustomCompoundBondIxn::calculateOneIxn";
-
-    // ---------------------------------------------------------------------------------------
-
+                        vector<RealVec>& forces, RealOpenMM* totalEnergy, double* energyParamDerivs) {
     // Compute all of the variables the energy can depend on.
 
     const vector<int>& atoms = bondAtoms[bond];
     for (int i = 0; i < (int) particleTerms.size(); i++) {
         const ParticleTermInfo& term = particleTerms[i];
-        variables[term.name] = atomCoordinates[atoms[term.atom]][term.component];
+        expressionSet.setVariable(term.index, atomCoordinates[atoms[term.atom]][term.component]);
     }
     for (int i = 0; i < (int) distanceTerms.size(); i++) {
         const DistanceTermInfo& term = distanceTerms[i];
         computeDelta(atoms[term.p1], atoms[term.p2], term.delta, atomCoordinates);
-        variables[term.name] = term.delta[ReferenceForce::RIndex];
+        expressionSet.setVariable(term.index, term.delta[ReferenceForce::RIndex]);
     }
     for (int i = 0; i < (int) angleTerms.size(); i++) {
         const AngleTermInfo& term = angleTerms[i];
         computeDelta(atoms[term.p1], atoms[term.p2], term.delta1, atomCoordinates);
         computeDelta(atoms[term.p3], atoms[term.p2], term.delta2, atomCoordinates);
-        variables[term.name] = computeAngle(term.delta1, term.delta2);
+        expressionSet.setVariable(term.index, computeAngle(term.delta1, term.delta2));
     }
     for (int i = 0; i < (int) dihedralTerms.size(); i++) {
         const DihedralTermInfo& term = dihedralTerms[i];
@@ -152,21 +168,21 @@ void ReferenceCustomCompoundBondIxn::calculateOneIxn(int bond, vector<RealVec>& 
         computeDelta(atoms[term.p4], atoms[term.p3], term.delta3, atomCoordinates);
         RealOpenMM dotDihedral, signOfDihedral;
         RealOpenMM* crossProduct[] = {term.cross1, term.cross2};
-        variables[term.name] = getDihedralAngleBetweenThreeVectors(term.delta1, term.delta2, term.delta3, crossProduct, &dotDihedral, term.delta1, &signOfDihedral, 1);
+        expressionSet.setVariable(term.index,getDihedralAngleBetweenThreeVectors(term.delta1, term.delta2, term.delta3, crossProduct, &dotDihedral, term.delta1, &signOfDihedral, 1));
     }
     
     // Apply forces based on individual particle coordinates.
     
     for (int i = 0; i < (int) particleTerms.size(); i++) {
         const ParticleTermInfo& term = particleTerms[i];
-        forces[atoms[term.atom]][term.component] -= term.forceExpression.evaluate(variables);
+        forces[atoms[term.atom]][term.component] -= term.forceExpression.evaluate();
     }
 
     // Apply forces based on distances.
 
     for (int i = 0; i < (int) distanceTerms.size(); i++) {
         const DistanceTermInfo& term = distanceTerms[i];
-        RealOpenMM dEdR = (RealOpenMM) (term.forceExpression.evaluate(variables)/(term.delta[ReferenceForce::RIndex]));
+        RealOpenMM dEdR = (RealOpenMM) (term.forceExpression.evaluate()/(term.delta[ReferenceForce::RIndex]));
         for (int i = 0; i < 3; i++) {
            RealOpenMM force  = -dEdR*term.delta[i];
            forces[atoms[term.p1]][i] -= force;
@@ -178,7 +194,7 @@ void ReferenceCustomCompoundBondIxn::calculateOneIxn(int bond, vector<RealVec>& 
 
     for (int i = 0; i < (int) angleTerms.size(); i++) {
         const AngleTermInfo& term = angleTerms[i];
-        RealOpenMM dEdTheta = (RealOpenMM) term.forceExpression.evaluate(variables);
+        RealOpenMM dEdTheta = (RealOpenMM) term.forceExpression.evaluate();
         RealOpenMM thetaCross[ReferenceForce::LastDeltaRIndex];
         SimTKOpenMMUtilities::crossProductVector3(term.delta1, term.delta2, thetaCross);
         RealOpenMM lengthThetaCross = SQRT(DOT3(thetaCross, thetaCross));
@@ -205,7 +221,7 @@ void ReferenceCustomCompoundBondIxn::calculateOneIxn(int bond, vector<RealVec>& 
 
     for (int i = 0; i < (int) dihedralTerms.size(); i++) {
         const DihedralTermInfo& term = dihedralTerms[i];
-        RealOpenMM dEdTheta = (RealOpenMM) term.forceExpression.evaluate(variables);
+        RealOpenMM dEdTheta = (RealOpenMM) term.forceExpression.evaluate();
         RealOpenMM internalF[4][3];
         RealOpenMM forceFactors[4];
         RealOpenMM normCross1 = DOT3(term.cross1, term.cross1);
@@ -235,7 +251,12 @@ void ReferenceCustomCompoundBondIxn::calculateOneIxn(int bond, vector<RealVec>& 
     // Add the energy
 
     if (totalEnergy)
-        *totalEnergy += (RealOpenMM) energyExpression.evaluate(variables);
+        *totalEnergy += (RealOpenMM) energyExpression.evaluate();
+    
+    // Compute derivatives of the energy.
+    
+    for (int i = 0; i < energyParamDerivExpressions.size(); i++)
+        energyParamDerivs[i] += energyParamDerivExpressions[i].evaluate();
 }
 
 void ReferenceCustomCompoundBondIxn::computeDelta(int atom1, int atom2, RealOpenMM* delta, vector<RealVec>& atomCoordinates) const {

--- a/platforms/reference/src/SimTKReference/ReferenceCustomTorsionIxn.cpp
+++ b/platforms/reference/src/SimTKReference/ReferenceCustomTorsionIxn.cpp
@@ -86,7 +86,7 @@ void ReferenceCustomTorsionIxn::calculateBondIxn(int* atomIndices,
                                                 vector<RealVec>& atomCoordinates,
                                                 RealOpenMM* parameters,
                                                 vector<RealVec>& forces,
-                                                RealOpenMM* totalEnergy) const {
+                                                RealOpenMM* totalEnergy, double* energyParamDerivs) {
 
    static const std::string methodName = "\nReferenceCustomTorsionIxn::calculateTorsionIxn";
 

--- a/platforms/reference/src/SimTKReference/ReferenceCustomTorsionIxn.cpp
+++ b/platforms/reference/src/SimTKReference/ReferenceCustomTorsionIxn.cpp
@@ -38,20 +38,19 @@ using namespace OpenMM;
    --------------------------------------------------------------------------------------- */
 
 ReferenceCustomTorsionIxn::ReferenceCustomTorsionIxn(const Lepton::CompiledExpression& energyExpression,
-        const Lepton::CompiledExpression& forceExpression, const vector<string>& parameterNames, map<string, double> globalParameters) :
-        energyExpression(energyExpression), forceExpression(forceExpression), usePeriodic(false) {
-
-    energyTheta = ReferenceForce::getVariablePointer(this->energyExpression, "theta");
-    forceTheta = ReferenceForce::getVariablePointer(this->forceExpression, "theta");
+        const Lepton::CompiledExpression& forceExpression, const vector<string>& parameterNames, map<string, double> globalParameters,
+        const vector<Lepton::CompiledExpression> energyParamDerivExpressions) :
+        energyExpression(energyExpression), forceExpression(forceExpression), usePeriodic(false), energyParamDerivExpressions(energyParamDerivExpressions) {
+    expressionSet.registerExpression(this->energyExpression);
+    expressionSet.registerExpression(this->forceExpression);
+    for (int i = 0; i < this->energyParamDerivExpressions.size(); i++)
+        expressionSet.registerExpression(this->energyParamDerivExpressions[i]);
+    thetaIndex = expressionSet.getVariableIndex("theta");
     numParameters = parameterNames.size();
-    for (int i = 0; i < (int) numParameters; i++) {
-        energyParams.push_back(ReferenceForce::getVariablePointer(this->energyExpression, parameterNames[i]));
-        forceParams.push_back(ReferenceForce::getVariablePointer(this->forceExpression, parameterNames[i]));
-    }
-    for (map<string, double>::const_iterator iter = globalParameters.begin(); iter != globalParameters.end(); ++iter) {
-        ReferenceForce::setVariable(ReferenceForce::getVariablePointer(this->energyExpression, iter->first), iter->second);
-        ReferenceForce::setVariable(ReferenceForce::getVariablePointer(this->forceExpression, iter->first), iter->second);
-    }
+    for (int i = 0; i < (int) numParameters; i++)
+        torsionParamIndex.push_back(expressionSet.getVariableIndex(parameterNames[i]));
+    for (map<string, double>::const_iterator iter = globalParameters.begin(); iter != globalParameters.end(); ++iter)
+        expressionSet.setVariable(expressionSet.getVariableIndex(iter->first), iter->second);
 }
 
 /**---------------------------------------------------------------------------------------
@@ -87,17 +86,9 @@ void ReferenceCustomTorsionIxn::calculateBondIxn(int* atomIndices,
                                                 RealOpenMM* parameters,
                                                 vector<RealVec>& forces,
                                                 RealOpenMM* totalEnergy, double* energyParamDerivs) {
-
-   static const std::string methodName = "\nReferenceCustomTorsionIxn::calculateTorsionIxn";
-
-   static const RealOpenMM zero        = 0.0;
-   static const RealOpenMM one         = 1.0;
-
    RealOpenMM deltaR[3][ReferenceForce::LastDeltaRIndex];
-   for (int i = 0; i < numParameters; i++) {
-       ReferenceForce::setVariable(energyParams[i], parameters[i]);
-       ReferenceForce::setVariable(forceParams[i], parameters[i]);
-   }
+   for (int i = 0; i < numParameters; i++)
+       expressionSet.setVariable(torsionParamIndex[i], parameters[i]);
 
    // ---------------------------------------------------------------------------------------
 
@@ -130,8 +121,7 @@ void ReferenceCustomTorsionIxn::calculateBondIxn(int* atomIndices,
    RealOpenMM dotDihedral;
    RealOpenMM signOfAngle;
    RealOpenMM angle = getDihedralAngleBetweenThreeVectors(deltaR[0], deltaR[1], deltaR[2], crossProduct, &dotDihedral, deltaR[0], &signOfAngle, 1);
-   ReferenceForce::setVariable(energyTheta, angle);
-   ReferenceForce::setVariable(forceTheta, angle);
+   expressionSet.setVariable(thetaIndex, angle);
 
    // evaluate delta angle, dE/d(angle)
 
@@ -173,6 +163,11 @@ void ReferenceCustomTorsionIxn::calculateBondIxn(int* atomIndices,
       forces[atomCIndex][ii] -= internalF[2][ii];
       forces[atomDIndex][ii] += internalF[3][ii];
    }
+
+   // Record parameter derivatives.
+
+   for (int i = 0; i < energyParamDerivExpressions.size(); i++)
+       energyParamDerivs[i] += energyParamDerivExpressions[i].evaluate();
 
    // accumulate energies
 

--- a/platforms/reference/src/SimTKReference/ReferenceHarmonicBondIxn.cpp
+++ b/platforms/reference/src/SimTKReference/ReferenceHarmonicBondIxn.cpp
@@ -74,7 +74,7 @@ void ReferenceHarmonicBondIxn::calculateBondIxn(int* atomIndices,
                                                 vector<RealVec>& atomCoordinates,
                                                 RealOpenMM* parameters,
                                                 vector<RealVec>& forces,
-                                                RealOpenMM* totalEnergy) const {
+                                                RealOpenMM* totalEnergy, double* energyParamDerivs) {
 
    static const std::string methodName = "\nReferenceHarmonicBondIxn::calculateBondIxn";
 

--- a/platforms/reference/src/SimTKReference/ReferenceLJCoulomb14.cpp
+++ b/platforms/reference/src/SimTKReference/ReferenceLJCoulomb14.cpp
@@ -1,5 +1,5 @@
 
-/* Portions copyright (c) 2006 Stanford University and Simbios.
+/* Portions copyright (c) 2006-2016 Stanford University and Simbios.
  * Contributors: Pande Group
  *
  * Permission is hereby granted, free of charge, to any person obtaining
@@ -81,7 +81,7 @@ ReferenceLJCoulomb14::~ReferenceLJCoulomb14() {
 
 void ReferenceLJCoulomb14::calculateBondIxn(int* atomIndices, vector<RealVec>& atomCoordinates,
                                      RealOpenMM* parameters, vector<RealVec>& forces,
-                                     RealOpenMM* totalEnergy) const {
+                                     RealOpenMM* totalEnergy, double* energyParamDerivs) {
 
    static const std::string methodName = "\nReferenceLJCoulomb14::calculateBondIxn";
 

--- a/platforms/reference/src/SimTKReference/ReferenceProperDihedralBond.cpp
+++ b/platforms/reference/src/SimTKReference/ReferenceProperDihedralBond.cpp
@@ -75,7 +75,7 @@ void ReferenceProperDihedralBond::calculateBondIxn(int* atomIndices,
                                                    vector<RealVec>& atomCoordinates,
                                                    RealOpenMM* parameters,
                                                    vector<RealVec>& forces,
-                                                   RealOpenMM* totalEnergy) const {
+                                                   RealOpenMM* totalEnergy, double* energyParamDerivs) {
 
    static const std::string methodName = "\nReferenceProperDihedralBond::calculateBondIxn";
 

--- a/platforms/reference/src/SimTKReference/ReferenceRbDihedralBond.cpp
+++ b/platforms/reference/src/SimTKReference/ReferenceRbDihedralBond.cpp
@@ -73,7 +73,7 @@ void ReferenceRbDihedralBond::calculateBondIxn(int* atomIndices,
                                                vector<RealVec>& atomCoordinates,
                                                RealOpenMM* parameters,
                                                vector<RealVec>& forces,
-                                               RealOpenMM* totalEnergy) const {
+                                               RealOpenMM* totalEnergy, double* energyParamDerivs) {
 
    static const std::string methodName = "\nReferenceRbDihedralBond::calculateBondIxn";
 

--- a/serialization/src/CustomCompoundBondForceProxy.cpp
+++ b/serialization/src/CustomCompoundBondForceProxy.cpp
@@ -42,7 +42,7 @@ CustomCompoundBondForceProxy::CustomCompoundBondForceProxy() : SerializationProx
 }
 
 void CustomCompoundBondForceProxy::serialize(const void* object, SerializationNode& node) const {
-    node.setIntProperty("version", 2);
+    node.setIntProperty("version", 3);
     const CustomCompoundBondForce& force = *reinterpret_cast<const CustomCompoundBondForce*>(object);
     node.setIntProperty("forceGroup", force.getForceGroup());
     node.setBoolProperty("usesPeriodic", force.usesPeriodicBoundaryConditions());
@@ -55,6 +55,10 @@ void CustomCompoundBondForceProxy::serialize(const void* object, SerializationNo
     SerializationNode& globalParams = node.createChildNode("GlobalParameters");
     for (int i = 0; i < force.getNumGlobalParameters(); i++) {
         globalParams.createChildNode("Parameter").setStringProperty("name", force.getGlobalParameterName(i)).setDoubleProperty("default", force.getGlobalParameterDefaultValue(i));
+    }
+    SerializationNode& energyDerivs = node.createChildNode("EnergyParameterDerivatives");
+    for (int i = 0; i < force.getNumEnergyParameterDerivatives(); i++) {
+        energyDerivs.createChildNode("Parameter").setStringProperty("name", force.getEnergyParameterDerivativeName(i));
     }
     SerializationNode& bonds = node.createChildNode("Bonds");
     for (int i = 0; i < force.getNumBonds(); i++) {
@@ -82,7 +86,7 @@ void CustomCompoundBondForceProxy::serialize(const void* object, SerializationNo
 
 void* CustomCompoundBondForceProxy::deserialize(const SerializationNode& node) const {
     int version = node.getIntProperty("version");
-    if (version < 1 || version > 2)
+    if (version < 1 || version > 3)
         throw OpenMMException("Unsupported version number");
     CustomCompoundBondForce* force = NULL;
     try {
@@ -99,6 +103,13 @@ void* CustomCompoundBondForceProxy::deserialize(const SerializationNode& node) c
         for (int i = 0; i < (int) globalParams.getChildren().size(); i++) {
             const SerializationNode& parameter = globalParams.getChildren()[i];
             force->addGlobalParameter(parameter.getStringProperty("name"), parameter.getDoubleProperty("default"));
+        }
+        if (version > 2) {
+            const SerializationNode& energyDerivs = node.getChildNode("EnergyParameterDerivatives");
+            for (int i = 0; i < (int) energyDerivs.getChildren().size(); i++) {
+                const SerializationNode& parameter = energyDerivs.getChildren()[i];
+                force->addEnergyParameterDerivative(parameter.getStringProperty("name"));
+            }
         }
         const SerializationNode& bonds = node.getChildNode("Bonds");
         vector<int> particles(force->getNumParticlesPerBond());

--- a/serialization/tests/TestSerializeCustomAngleForce.cpp
+++ b/serialization/tests/TestSerializeCustomAngleForce.cpp
@@ -46,6 +46,7 @@ void testSerialization() {
     force.addGlobalParameter("x", 1.3);
     force.addGlobalParameter("y", 2.221);
     force.addPerAngleParameter("z");
+    force.addEnergyParameterDerivative("y");
     vector<double> params(1);
     params[0] = 1.0;
     force.addAngle(1, 2, 3, params);
@@ -74,6 +75,9 @@ void testSerialization() {
         ASSERT_EQUAL(force.getGlobalParameterName(i), force2.getGlobalParameterName(i));
         ASSERT_EQUAL(force.getGlobalParameterDefaultValue(i), force2.getGlobalParameterDefaultValue(i));
     }
+    ASSERT_EQUAL(force.getNumEnergyParameterDerivatives(), force2.getNumEnergyParameterDerivatives());
+    for (int i = 0; i < force.getNumEnergyParameterDerivatives(); i++)
+        ASSERT_EQUAL(force.getEnergyParameterDerivativeName(i), force2.getEnergyParameterDerivativeName(i));
     ASSERT_EQUAL(force.usesPeriodicBoundaryConditions(), force2.usesPeriodicBoundaryConditions());
     ASSERT_EQUAL(force.getNumAngles(), force2.getNumAngles());
     for (int i = 0; i < force.getNumAngles(); i++) {

--- a/serialization/tests/TestSerializeCustomBondForce.cpp
+++ b/serialization/tests/TestSerializeCustomBondForce.cpp
@@ -46,6 +46,7 @@ void testSerialization() {
     force.addGlobalParameter("x", 1.3);
     force.addGlobalParameter("y", 2.221);
     force.addPerBondParameter("z");
+    force.addEnergyParameterDerivative("y");
     vector<double> params(1);
     params[0] = 1.0;
     force.addBond(1, 2, params);
@@ -74,6 +75,9 @@ void testSerialization() {
         ASSERT_EQUAL(force.getGlobalParameterName(i), force2.getGlobalParameterName(i));
         ASSERT_EQUAL(force.getGlobalParameterDefaultValue(i), force2.getGlobalParameterDefaultValue(i));
     }
+    ASSERT_EQUAL(force.getNumEnergyParameterDerivatives(), force2.getNumEnergyParameterDerivatives());
+    for (int i = 0; i < force.getNumEnergyParameterDerivatives(); i++)
+        ASSERT_EQUAL(force.getEnergyParameterDerivativeName(i), force2.getEnergyParameterDerivativeName(i));
     ASSERT_EQUAL(force.usesPeriodicBoundaryConditions(), force2.usesPeriodicBoundaryConditions());
     ASSERT_EQUAL(force.getNumBonds(), force2.getNumBonds());
     for (int i = 0; i < force.getNumBonds(); i++) {

--- a/serialization/tests/TestSerializeCustomCentroidBondForce.cpp
+++ b/serialization/tests/TestSerializeCustomCentroidBondForce.cpp
@@ -46,6 +46,7 @@ void testSerialization() {
     force.addGlobalParameter("x", 1.3);
     force.addGlobalParameter("y", 2.221);
     force.addPerBondParameter("z");
+    force.addEnergyParameterDerivative("y");
     for (int i = 0; i < 3; i++) {
         vector<int> particles;
         vector<double> weights;
@@ -99,6 +100,9 @@ void testSerialization() {
         ASSERT_EQUAL(force.getGlobalParameterName(i), force2.getGlobalParameterName(i));
         ASSERT_EQUAL(force.getGlobalParameterDefaultValue(i), force2.getGlobalParameterDefaultValue(i));
     }
+    ASSERT_EQUAL(force.getNumEnergyParameterDerivatives(), force2.getNumEnergyParameterDerivatives());
+    for (int i = 0; i < force.getNumEnergyParameterDerivatives(); i++)
+        ASSERT_EQUAL(force.getEnergyParameterDerivativeName(i), force2.getEnergyParameterDerivativeName(i));
     ASSERT_EQUAL(force.usesPeriodicBoundaryConditions(), force2.usesPeriodicBoundaryConditions());
     ASSERT_EQUAL(force.getNumGroups(), force2.getNumGroups());
     for (int i = 0; i < force.getNumGroups(); i++) {

--- a/serialization/tests/TestSerializeCustomCompoundBondForce.cpp
+++ b/serialization/tests/TestSerializeCustomCompoundBondForce.cpp
@@ -46,6 +46,7 @@ void testSerialization() {
     force.addGlobalParameter("x", 1.3);
     force.addGlobalParameter("y", 2.221);
     force.addPerBondParameter("z");
+    force.addEnergyParameterDerivative("y");
     vector<int> particles(3);
     vector<double> params(1);
     particles[0] = 0;
@@ -89,6 +90,9 @@ void testSerialization() {
         ASSERT_EQUAL(force.getGlobalParameterName(i), force2.getGlobalParameterName(i));
         ASSERT_EQUAL(force.getGlobalParameterDefaultValue(i), force2.getGlobalParameterDefaultValue(i));
     }
+    ASSERT_EQUAL(force.getNumEnergyParameterDerivatives(), force2.getNumEnergyParameterDerivatives());
+    for (int i = 0; i < force.getNumEnergyParameterDerivatives(); i++)
+        ASSERT_EQUAL(force.getEnergyParameterDerivativeName(i), force2.getEnergyParameterDerivativeName(i));
     ASSERT_EQUAL(force.usesPeriodicBoundaryConditions(), force2.usesPeriodicBoundaryConditions());
     ASSERT_EQUAL(force.getNumBonds(), force2.getNumBonds());
     for (int i = 0; i < force.getNumBonds(); i++) {

--- a/serialization/tests/TestSerializeCustomGBForce.cpp
+++ b/serialization/tests/TestSerializeCustomGBForce.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2010-2014 Stanford University and the Authors.      *
+ * Portions copyright (c) 2010-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -48,6 +48,7 @@ void testSerialization() {
     force.addGlobalParameter("x", 1.3);
     force.addGlobalParameter("y", 2.221);
     force.addPerParticleParameter("z");
+    force.addEnergyParameterDerivative("y");
     force.addComputedValue("a", "x+1", CustomGBForce::ParticlePairNoExclusions);
     force.addComputedValue("b", "y-1", CustomGBForce::SingleParticle);
     force.addEnergyTerm("a*b", CustomGBForce::SingleParticle);
@@ -86,6 +87,9 @@ void testSerialization() {
         ASSERT_EQUAL(force.getGlobalParameterName(i), force2.getGlobalParameterName(i));
         ASSERT_EQUAL(force.getGlobalParameterDefaultValue(i), force2.getGlobalParameterDefaultValue(i));
     }
+    ASSERT_EQUAL(force.getNumEnergyParameterDerivatives(), force2.getNumEnergyParameterDerivatives());
+    for (int i = 0; i < force.getNumEnergyParameterDerivatives(); i++)
+        ASSERT_EQUAL(force.getEnergyParameterDerivativeName(i), force2.getEnergyParameterDerivativeName(i));
     ASSERT_EQUAL(force.getNumComputedValues(), force2.getNumComputedValues());
     for (int i = 0; i < force.getNumComputedValues(); i++) {
         string name1, name2, expression1, expression2;

--- a/serialization/tests/TestSerializeCustomNonbondedForce.cpp
+++ b/serialization/tests/TestSerializeCustomNonbondedForce.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2010-2014 Stanford University and the Authors.      *
+ * Portions copyright (c) 2010-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -51,6 +51,7 @@ void testSerialization() {
     force.addGlobalParameter("x", 1.3);
     force.addGlobalParameter("y", 2.221);
     force.addPerParticleParameter("z");
+    force.addEnergyParameterDerivative("y");
     vector<double> params(1);
     params[0] = 1.0;
     force.addParticle(params);
@@ -94,6 +95,9 @@ void testSerialization() {
         ASSERT_EQUAL(force.getGlobalParameterName(i), force2.getGlobalParameterName(i));
         ASSERT_EQUAL(force.getGlobalParameterDefaultValue(i), force2.getGlobalParameterDefaultValue(i));
     }
+    ASSERT_EQUAL(force.getNumEnergyParameterDerivatives(), force2.getNumEnergyParameterDerivatives());
+    for (int i = 0; i < force.getNumEnergyParameterDerivatives(); i++)
+        ASSERT_EQUAL(force.getEnergyParameterDerivativeName(i), force2.getEnergyParameterDerivativeName(i));
     ASSERT_EQUAL(force.getNumParticles(), force2.getNumParticles());
     for (int i = 0; i < force.getNumParticles(); i++) {
         vector<double> params1, params2;

--- a/serialization/tests/TestSerializeCustomTorsionForce.cpp
+++ b/serialization/tests/TestSerializeCustomTorsionForce.cpp
@@ -46,6 +46,7 @@ void testSerialization() {
     force.addGlobalParameter("x", 1.3);
     force.addGlobalParameter("y", 2.221);
     force.addPerTorsionParameter("z");
+    force.addEnergyParameterDerivative("y");
     vector<double> params(1);
     params[0] = 1.0;
     force.addTorsion(1, 2, 3, 4, params);
@@ -74,6 +75,9 @@ void testSerialization() {
         ASSERT_EQUAL(force.getGlobalParameterName(i), force2.getGlobalParameterName(i));
         ASSERT_EQUAL(force.getGlobalParameterDefaultValue(i), force2.getGlobalParameterDefaultValue(i));
     }
+    ASSERT_EQUAL(force.getNumEnergyParameterDerivatives(), force2.getNumEnergyParameterDerivatives());
+    for (int i = 0; i < force.getNumEnergyParameterDerivatives(); i++)
+        ASSERT_EQUAL(force.getEnergyParameterDerivativeName(i), force2.getEnergyParameterDerivativeName(i));
     ASSERT_EQUAL(force.usesPeriodicBoundaryConditions(), force2.usesPeriodicBoundaryConditions());
     ASSERT_EQUAL(force.getNumTorsions(), force2.getNumTorsions());
     for (int i = 0; i < force.getNumTorsions(); i++) {

--- a/tests/TestCustomAngleForce.h
+++ b/tests/TestCustomAngleForce.h
@@ -181,6 +181,41 @@ void testPeriodic() {
     ASSERT_EQUAL_TOL(0.5*1.1*(M_PI/6)*(M_PI/6), state.getPotentialEnergy(), TOL);
 }
 
+void testEnergyParameterDerivatives() {
+    System system;
+    system.addParticle(1.0);
+    system.addParticle(1.0);
+    system.addParticle(1.0);
+    VerletIntegrator integrator(0.01);
+    CustomAngleForce* angles = new CustomAngleForce("k*(theta-theta0)^2");
+    angles->addGlobalParameter("theta0", 0.0);
+    angles->addGlobalParameter("k", 0.0);
+    angles->addEnergyParameterDerivative("theta0");
+    angles->addEnergyParameterDerivative("k");
+    vector<double> parameters;
+    angles->addAngle(0, 1, 2, parameters);
+    system.addForce(angles);
+    Context context(system, integrator, platform);
+    vector<Vec3> positions(3);
+    positions[0] = Vec3(0, 2, 0);
+    positions[1] = Vec3(0, 0, 0);
+    positions[2] = Vec3(1, 1, 0);
+    context.setPositions(positions);
+    double theta = M_PI/4;
+    for (int i = 0; i < 10; i++) {
+        double theta0 = 0.1*i;
+        double k = 10-i;
+        context.setParameter("theta0", theta0);
+        context.setParameter("k", k);
+        State state = context.getState(State::ParameterDerivatives);
+        map<string, double> derivs = state.getEnergyParameterDerivatives();
+        double dEdtheta0 = -2*k*(theta-theta0);
+        double dEdk = (theta-theta0)*(theta-theta0);
+        ASSERT_EQUAL_TOL(dEdtheta0, derivs["theta0"], 1e-5);
+        ASSERT_EQUAL_TOL(dEdk, derivs["k"], 1e-5);
+    }
+}
+
 void runPlatformTests();
 
 int main(int argc, char* argv[]) {
@@ -189,6 +224,7 @@ int main(int argc, char* argv[]) {
         testAngles();
         testIllegalVariable();
         testPeriodic();
+        testEnergyParameterDerivatives();
         runPlatformTests();
     }
     catch(const exception& e) {

--- a/tests/TestCustomBondForce.h
+++ b/tests/TestCustomBondForce.h
@@ -187,8 +187,8 @@ void testEnergyParameterDerivatives() {
     CustomBondForce* bonds = new CustomBondForce("k*(r-r0)^2");
     bonds->addGlobalParameter("r0", 0.0);
     bonds->addGlobalParameter("k", 0.0);
-    bonds->addEnergyParameterDerivative("r0");
     bonds->addEnergyParameterDerivative("k");
+    bonds->addEnergyParameterDerivative("r0");
     vector<double> parameters;
     bonds->addBond(0, 1, parameters);
     bonds->addBond(1, 2, parameters);

--- a/tests/TestCustomBondForce.h
+++ b/tests/TestCustomBondForce.h
@@ -212,6 +212,7 @@ void testEnergyParameterDerivatives() {
         ASSERT_EQUAL_TOL(dEdk, derivs["k"], 1e-5);
     }
 }
+
 void runPlatformTests();
 
 int main(int argc, char* argv[]) {

--- a/tests/TestCustomBondForce.h
+++ b/tests/TestCustomBondForce.h
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2015 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -178,6 +178,40 @@ void testPeriodic() {
     ASSERT_EQUAL_TOL(0.5*0.8*0.9*0.9, state.getPotentialEnergy(), TOL);
 }
 
+void testEnergyParameterDerivatives() {
+    System system;
+    system.addParticle(1.0);
+    system.addParticle(1.0);
+    system.addParticle(1.0);
+    VerletIntegrator integrator(0.01);
+    CustomBondForce* bonds = new CustomBondForce("k*(r-r0)^2");
+    bonds->addGlobalParameter("r0", 0.0);
+    bonds->addGlobalParameter("k", 0.0);
+    bonds->addEnergyParameterDerivative("r0");
+    bonds->addEnergyParameterDerivative("k");
+    vector<double> parameters;
+    bonds->addBond(0, 1, parameters);
+    bonds->addBond(1, 2, parameters);
+    system.addForce(bonds);
+    Context context(system, integrator, platform);
+    vector<Vec3> positions(3);
+    positions[0] = Vec3(0, 2, 0);
+    positions[1] = Vec3(0, 0, 0);
+    positions[2] = Vec3(1, 0, 0);
+    context.setPositions(positions);
+    for (int i = 0; i < 10; i++) {
+        double r0 = 0.1*i;
+        double k = 10-i;
+        context.setParameter("r0", r0);
+        context.setParameter("k", k);
+        State state = context.getState(State::ParameterDerivatives);
+        map<string, double> derivs = state.getEnergyParameterDerivatives();
+        double dEdr0 = -2*k*((2-r0)+(1-r0));
+        double dEdk = (2-r0)*(2-r0) + (1-r0)*(1-r0);
+        ASSERT_EQUAL_TOL(dEdr0, derivs["r0"], 1e-5);
+        ASSERT_EQUAL_TOL(dEdk, derivs["k"], 1e-5);
+    }
+}
 void runPlatformTests();
 
 int main(int argc, char* argv[]) {
@@ -187,6 +221,7 @@ int main(int argc, char* argv[]) {
         testManyParameters();
         testIllegalVariable();
         testPeriodic();
+        testEnergyParameterDerivatives();
         runPlatformTests();
     }
     catch(const exception& e) {

--- a/tests/TestCustomGBForce.h
+++ b/tests/TestCustomGBForce.h
@@ -7,7 +7,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2015 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -488,6 +488,54 @@ void testIllegalVariable() {
     ASSERT(threwException);
 }
 
+void testEnergyParameterDerivatives() {
+    // Create a box of particles.
+    
+    const int numParticles = 30;
+    const int numParameters = 4;
+    const double boxSize = 2.0;
+    const double delta = 1e-3;
+    const string paramNames[] = {"A", "B", "C", "D"};
+    const double paramValues[] = {0.8, 2.1, 3.2, 1.3};
+    System system;
+    system.setDefaultPeriodicBoxVectors(Vec3(boxSize, 0, 0), Vec3(0, boxSize, 0), Vec3(0, 0, boxSize));
+    CustomGBForce* force = new CustomGBForce();
+    system.addForce(force);
+    force->addComputedValue("a", "0.5*(r-A)^2", CustomGBForce::ParticlePair);
+    force->addComputedValue("b", "a+B", CustomGBForce::SingleParticle);
+    force->addEnergyTerm("C*(a1+b1+a2+b2+r)^0.8", CustomGBForce::ParticlePair);
+    force->addEnergyTerm("(D-B)*b", CustomGBForce::SingleParticle);
+    for (int i = 0; i < numParameters; i++) {
+        force->addGlobalParameter(paramNames[i], paramValues[i]);
+        force->addEnergyParameterDerivative(paramNames[i]);
+    }
+    force->setNonbondedMethod(CustomGBForce::CutoffPeriodic);
+    force->setCutoffDistance(1.0);
+    vector<Vec3> positions;
+    vector<double> parameters;
+    OpenMM_SFMT::SFMT sfmt;
+    init_gen_rand(0, sfmt);
+    for (int i = 0; i < numParticles; i++) {
+        system.addParticle(1.0);
+        force->addParticle(parameters);
+        positions.push_back(Vec3(genrand_real2(sfmt), genrand_real2(sfmt), genrand_real2(sfmt))*boxSize);
+    }
+    
+    // Compute the energy derivative and compare it to a finite difference approximation.
+    
+    VerletIntegrator integrator(0.01);
+    Context context(system, integrator, platform);
+    context.setPositions(positions);
+    map<string, double> derivs = context.getState(State::ParameterDerivatives).getEnergyParameterDerivatives();
+    for (int i = 0; i < numParameters; i++) {
+        context.setParameter(paramNames[i], paramValues[i]+delta);
+        double energy1 = context.getState(State::Energy).getPotentialEnergy();
+        context.setParameter(paramNames[i], paramValues[i]-delta);
+        double energy2 = context.getState(State::Energy).getPotentialEnergy();
+        ASSERT_EQUAL_TOL((energy1-energy2)/(2*delta), derivs[paramNames[i]], 5e-3);
+    }
+}
+
 void runPlatformTests();
 
 int main(int argc, char* argv[]) {
@@ -502,6 +550,7 @@ int main(int argc, char* argv[]) {
         testPositionDependence();
         testExclusions();
         testIllegalVariable();
+        testEnergyParameterDerivatives();
         runPlatformTests();
     }
     catch(const exception& e) {

--- a/tests/TestCustomGBForce.h
+++ b/tests/TestCustomGBForce.h
@@ -505,10 +505,10 @@ void testEnergyParameterDerivatives() {
     force->addComputedValue("b", "a+B", CustomGBForce::SingleParticle);
     force->addEnergyTerm("C*(a1+b1+a2+b2+r)^0.8", CustomGBForce::ParticlePair);
     force->addEnergyTerm("(D-B)*b", CustomGBForce::SingleParticle);
-    for (int i = 0; i < numParameters; i++) {
+    for (int i = 0; i < numParameters; i++)
         force->addGlobalParameter(paramNames[i], paramValues[i]);
+    for (int i = numParameters-1; i >= 0; i--)
         force->addEnergyParameterDerivative(paramNames[i]);
-    }
     force->setNonbondedMethod(CustomGBForce::CutoffPeriodic);
     force->setCutoffDistance(1.0);
     vector<Vec3> positions;

--- a/tests/TestCustomGBForce.h
+++ b/tests/TestCustomGBForce.h
@@ -491,7 +491,7 @@ void testIllegalVariable() {
 void testEnergyParameterDerivatives() {
     // Create a box of particles.
     
-    const int numParticles = 30;
+    const int numParticles = 40;
     const int numParameters = 4;
     const double boxSize = 2.0;
     const double delta = 1e-3;

--- a/tests/TestCustomIntegrator.h
+++ b/tests/TestCustomIntegrator.h
@@ -810,20 +810,20 @@ void testEnergyParameterDerivatives() {
     CustomIntegrator integrator(0.1);
     integrator.addGlobalVariable("dEdK", 0.0);
     integrator.addGlobalVariable("dEdr0", 0.0);
-    integrator.addGlobalVariable("dEdtheta0", 0.0);
+    integrator.addPerDofVariable("dEdtheta0", 0.0);
     integrator.addGlobalVariable("dEdK_0", 0.0);
-    integrator.addGlobalVariable("dEdr0_0", 0.0);
+    integrator.addPerDofVariable("dEdr0_0", 0.0);
     integrator.addGlobalVariable("dEdtheta0_0", 0.0);
-    integrator.addGlobalVariable("dEdK_1", 0.0);
+    integrator.addPerDofVariable("dEdK_1", 0.0);
     integrator.addGlobalVariable("dEdr0_1", 0.0);
     integrator.addGlobalVariable("dEdtheta0_1", 0.0);
     integrator.addComputeGlobal("dEdK", "deriv(energy, K)");
     integrator.addComputeGlobal("dEdr0", "deriv(energy, r0)");
-    integrator.addComputeGlobal("dEdtheta0", "deriv(energy, theta0)");
+    integrator.addComputePerDof("dEdtheta0", "deriv(energy, theta0)");
     integrator.addComputeGlobal("dEdK_0", "deriv(energy0, K)");
-    integrator.addComputeGlobal("dEdr0_0", "deriv(energy0, r0)");
+    integrator.addComputePerDof("dEdr0_0", "deriv(energy0, r0)");
     integrator.addComputeGlobal("dEdtheta0_0", "deriv(energy0, theta0)");
-    integrator.addComputeGlobal("dEdK_1", "deriv(energy1, K)");
+    integrator.addComputePerDof("dEdK_1", "deriv(energy1, K)");
     integrator.addComputeGlobal("dEdr0_1", "deriv(energy1, r0)");
     integrator.addComputeGlobal("dEdtheta0_1", "deriv(energy1, theta0)");
     
@@ -839,19 +839,23 @@ void testEnergyParameterDerivatives() {
     // Check the results.
     
     integrator.step(1);
+    vector<Vec3> values;
     double dEdK_0 = (1.0-1.5)*(1.0-1.5);
     double dEdK_1 = (M_PI/2-M_PI/3)*(M_PI/2-M_PI/3);
     ASSERT_EQUAL_TOL(dEdK_0, integrator.getGlobalVariableByName("dEdK_0"), 1e-5);
-    ASSERT_EQUAL_TOL(dEdK_1, integrator.getGlobalVariableByName("dEdK_1"), 1e-5);
+    integrator.getPerDofVariableByName("dEdK_1", values);
+    ASSERT_EQUAL_TOL(dEdK_1, values[0][2], 1e-5);
     ASSERT_EQUAL_TOL(dEdK_0+dEdK_1, integrator.getGlobalVariableByName("dEdK"), 1e-5);
     double dEdr0 = -2.0*2.0*(1.0-1.5);
-    ASSERT_EQUAL_TOL(dEdr0, integrator.getGlobalVariableByName("dEdr0_0"), 1e-5);
+    integrator.getPerDofVariableByName("dEdr0_0", values);
+    ASSERT_EQUAL_TOL(dEdr0, values[1][0], 1e-5);
     ASSERT_EQUAL_TOL(0.0, integrator.getGlobalVariableByName("dEdr0_1"), 1e-5);
     ASSERT_EQUAL_TOL(dEdr0, integrator.getGlobalVariableByName("dEdr0"), 1e-5);
     double dEdtheta0 = -2.0*2.0*(M_PI/2-M_PI/3);
     ASSERT_EQUAL_TOL(0.0, integrator.getGlobalVariableByName("dEdtheta0_0"), 1e-5);
     ASSERT_EQUAL_TOL(dEdtheta0, integrator.getGlobalVariableByName("dEdtheta0_1"), 1e-5);
-    ASSERT_EQUAL_TOL(dEdtheta0, integrator.getGlobalVariableByName("dEdtheta0"), 1e-5);
+    integrator.getPerDofVariableByName("dEdtheta0", values);
+    ASSERT_EQUAL_TOL(dEdtheta0, values[2][1], 1e-5);
 }
 
 void runPlatformTests();

--- a/tests/TestCustomNonbondedForce.h
+++ b/tests/TestCustomNonbondedForce.h
@@ -1050,8 +1050,8 @@ void testEnergyParameterDerivatives() {
     CustomNonbondedForce* nonbonded = new CustomNonbondedForce("k*(r-r0)^2");
     nonbonded->addGlobalParameter("r0", 0.0);
     nonbonded->addGlobalParameter("k", 0.0);
-    nonbonded->addEnergyParameterDerivative("r0");
     nonbonded->addEnergyParameterDerivative("k");
+    nonbonded->addEnergyParameterDerivative("r0");
     vector<double> parameters;
     nonbonded->addParticle(parameters);
     nonbonded->addParticle(parameters);

--- a/tests/TestCustomNonbondedForce.h
+++ b/tests/TestCustomNonbondedForce.h
@@ -7,7 +7,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2015 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2016 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -1041,6 +1041,84 @@ void testIllegalVariable() {
     ASSERT(threwException);
 }
 
+void testEnergyParameterDerivatives() {
+    System system;
+    system.addParticle(1.0);
+    system.addParticle(1.0);
+    system.addParticle(1.0);
+    VerletIntegrator integrator(0.01);
+    CustomNonbondedForce* nonbonded = new CustomNonbondedForce("k*(r-r0)^2");
+    nonbonded->addGlobalParameter("r0", 0.0);
+    nonbonded->addGlobalParameter("k", 0.0);
+    nonbonded->addEnergyParameterDerivative("r0");
+    nonbonded->addEnergyParameterDerivative("k");
+    vector<double> parameters;
+    nonbonded->addParticle(parameters);
+    nonbonded->addParticle(parameters);
+    nonbonded->addParticle(parameters);
+    nonbonded->addExclusion(0, 2);
+    system.addForce(nonbonded);
+    Context context(system, integrator, platform);
+    vector<Vec3> positions(3);
+    positions[0] = Vec3(0, 2, 0);
+    positions[1] = Vec3(0, 0, 0);
+    positions[2] = Vec3(1, 0, 0);
+    context.setPositions(positions);
+    for (int i = 0; i < 10; i++) {
+        double r0 = 0.1*i;
+        double k = 10-i;
+        context.setParameter("r0", r0);
+        context.setParameter("k", k);
+        State state = context.getState(State::ParameterDerivatives);
+        map<string, double> derivs = state.getEnergyParameterDerivatives();
+        double dEdr0 = -2*k*((2-r0)+(1-r0));
+        double dEdk = (2-r0)*(2-r0) + (1-r0)*(1-r0);
+        ASSERT_EQUAL_TOL(dEdr0, derivs["r0"], 1e-5);
+        ASSERT_EQUAL_TOL(dEdk, derivs["k"], 1e-5);
+    }
+}
+
+void testEnergyParameterDerivatives2() {
+    // Create a box of particles.
+    
+    const int numParticles = 30;
+    const double boxSize = 2.0;
+    const double a = 1.0;
+    const double delta = 1e-3;
+    System system;
+    system.setDefaultPeriodicBoxVectors(Vec3(boxSize, 0, 0), Vec3(0, boxSize, 0), Vec3(0, 0, boxSize));
+    CustomNonbondedForce* nonbonded = new CustomNonbondedForce("(r+a)^-4");
+    system.addForce(nonbonded);
+    nonbonded->addGlobalParameter("a", a);
+    nonbonded->addEnergyParameterDerivative("a");
+    nonbonded->setNonbondedMethod(CustomNonbondedForce::CutoffPeriodic);
+    nonbonded->setCutoffDistance(1.0);
+    nonbonded->setSwitchingDistance(0.9);
+    nonbonded->setUseSwitchingFunction(true);
+    nonbonded->setUseLongRangeCorrection(true);
+    vector<Vec3> positions;
+    vector<double> parameters;
+    OpenMM_SFMT::SFMT sfmt;
+    init_gen_rand(0, sfmt);
+    for (int i = 0; i < numParticles; i++) {
+        system.addParticle(1.0);
+        nonbonded->addParticle(parameters);
+        positions.push_back(Vec3(genrand_real2(sfmt), genrand_real2(sfmt), genrand_real2(sfmt))*boxSize);
+    }
+    
+    // Compute the energy derivative and compare it to a finite difference approximation.
+    
+    VerletIntegrator integrator(0.01);
+    Context context(system, integrator, platform);
+    context.setPositions(positions);
+    map<string, double> derivs = context.getState(State::ParameterDerivatives).getEnergyParameterDerivatives();
+    context.setParameter("a", a+delta);
+    double energy1 = context.getState(State::Energy).getPotentialEnergy();
+    context.setParameter("a", a-delta);
+    double energy2 = context.getState(State::Energy).getPotentialEnergy();
+    ASSERT_EQUAL_TOL((energy1-energy2)/(2*delta), derivs["a"], 1e-4);
+}
+
 void runPlatformTests();
 
 int main(int argc, char* argv[]) {
@@ -1067,6 +1145,8 @@ int main(int argc, char* argv[]) {
         testInteractionGroupTabulatedFunction();
         testMultipleCutoffs();
         testIllegalVariable();
+        testEnergyParameterDerivatives();
+        testEnergyParameterDerivatives2();
         runPlatformTests();
     }
     catch(const exception& e) {


### PR DESCRIPTION
This implements part of #1451.  You can compute derivatives of the potential energy with respect to global parameters, and either query them directly or use them in a CustomIntegrator.  Currently the following forces support it: CustomBondForce, CustomAngleForce, CustomTorsionForce, CustomNonbondedForce, CustomGBForce, CustomCompoundBondForce, CustomCentroidBondForce.