### PR TITLE
Dispersion PME

### DIFF
--- a/openmmapi/include/OpenMM.h
+++ b/openmmapi/include/OpenMM.h
@@ -48,6 +48,7 @@
 #include "openmm/CustomIntegrator.h"
 #include "openmm/CustomManyParticleForce.h"
 #include "openmm/CustomNonbondedForce.h"
+#include "openmm/DPMENonbondedForce.h"
 #include "openmm/Force.h"
 #include "openmm/GayBerneForce.h"
 #include "openmm/GBSAOBCForce.h"

--- a/openmmapi/include/openmm/DPMENonbondedForce.h
+++ b/openmmapi/include/openmm/DPMENonbondedForce.h
@@ -1,0 +1,394 @@
+#ifndef OPENMM_DPMENONBONDEDFORCE_H_
+#define OPENMM_DPMENONBONDEDFORCE_H_
+
+/* -------------------------------------------------------------------------- *
+ *                                   OpenMM                                   *
+ * -------------------------------------------------------------------------- *
+ * This is part of the OpenMM molecular simulation toolkit originating from   *
+ * Simbios, the NIH National Center for Physics-Based Simulation of           *
+ * Biological Structures at Stanford, funded under the NIH Roadmap for        *
+ * Medical Research, grant U54 GM072970. See https://simtk.org.               *
+ *                                                                            *
+ * Portions copyright (c) 2008-2014 Stanford University and the Authors.      *
+ * Authors: Peter Eastman                                                     *
+ * Contributors:                                                              *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included in *
+ * all copies or substantial portions of the Software.                        *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS, CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,    *
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR      *
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE  *
+ * USE OR OTHER DEALINGS IN THE SOFTWARE.                                     *
+ * -------------------------------------------------------------------------- */
+
+#include "Context.h"
+#include "Force.h"
+#include <map>
+#include <set>
+#include <utility>
+#include <vector>
+#include "internal/windowsExport.h"
+
+namespace OpenMM {
+
+/**
+ * This class implements DPMEnonbonded interactions between particles, including a Coulomb force to represent
+ * electrostatics and a Lennard-Jones force to represent van der Waals interactions.  Periodic boundary conditions
+ * are used and PME is used for both electrostatics and dispersion.  Lennard-Jones interactions are
+ * calculated with the Lorentz-Berthelot combining rule for reals space terms: it uses the arithmetic mean of the
+ * sigmas and the geometric mean of the epsilons for the two interacting particles.  The reciprocal space terms
+ * are effectively computed using geometric mean sigmas, following the method described in DOI: 10.1021/acs.jctc.5b00726.
+ *
+ * To use this class, create a DPMENonbondedForce object, then call addParticle() once for each particle in the
+ * System to define its parameters.  The number of particles for which you define DPMEnonbonded parameters must
+ * be exactly equal to the number of particles in the System, or else an exception will be thrown when you
+ * try to create a Context.  After a particle has been added, you can modify its force field parameters
+ * by calling setParticleParameters().  This will have no effect on Contexts that already exist unless you
+ * call updateParametersInContext().
+ *
+ * DPMENonbondedForce also lets you specify "exceptions", particular pairs of particles whose interactions should be
+ * computed based on different parameters than those defined for the individual particles.  This can be used to
+ * completely exclude certain interactions from the force calculation, or to alter how they interact with each other.
+ *
+ * Many molecular force fields omit Coulomb and Lennard-Jones interactions between particles separated by one
+ * or two bonds, while using modified parameters for those separated by three bonds (known as "1-4 interactions").
+ * This class provides a convenience method for this case called createExceptionsFromBonds().  You pass to it
+ * a list of bonds and the scale factors to use for 1-4 interactions.  It identifies all pairs of particles which
+ * are separated by 1, 2, or 3 bonds, then automatically creates exceptions for them.
+ *
+ * Because PME is used for all nonbonded terms, no switching is implemented and the dispersion correction implemented
+ * in NonbondedForce is not necessary.
+ *
+ */
+
+class OPENMM_EXPORT DPMENonbondedForce : public Force {
+public:
+    /**
+     * This is an enumeration of the different methods that may be used for handling long range DPMEnonbonded forces.
+     */
+    enum DPMENonbondedMethod {
+        /**
+         * Periodic boundary conditions are used, and Particle-Mesh Ewald (PME) summation is used to compute the interaction
+         * of each particle with all periodic copies of every other particle, for both electrostatics and dispersion.  The
+         * electrostatic interactions are modified by the reaction field.
+         */
+        PME = 1
+    };
+    /**
+     * Create a DPMENonbondedForce.
+     */
+    DPMENonbondedForce();
+    /**
+     * Get the number of particles for which force field parameters have been defined.
+     */
+    int getNumParticles() const {
+        return particles.size();
+    }
+    /**
+     * Get the number of special interactions that should be calculated differently from other interactions.
+     */
+    int getNumExceptions() const {
+        return exceptions.size();
+    }
+    /**
+     * Get the method used for handling long range nonbonded interactions.
+     */
+    DPMENonbondedMethod getNonbondedMethod() const;
+    /**
+     * Set the method used for handling long range nonbonded interactions.
+     */
+    void setNonbondedMethod(DPMENonbondedMethod method);
+    /**
+     * Get the cutoff distance (in nm) being used for nonbonded interactions.  If the NonbondedMethod in use
+     * is NoCutoff, this value will have no effect.
+     *
+     * @return the cutoff distance, measured in nm
+     */
+    double getCutoffDistance() const;
+    /**
+     * Set the cutoff distance (in nm) being used for nonbonded interactions.  If the NonbondedMethod in use
+     * is NoCutoff, this value will have no effect.
+     *
+     * @param distance    the cutoff distance, measured in nm
+     */
+    void setCutoffDistance(double distance);
+    /**
+     * Get the dielectric constant to use for the solvent in the reaction field approximation.
+     */
+    double getReactionFieldDielectric() const;
+    /**
+     * Set the dielectric constant to use for the solvent in the reaction field approximation.
+     */
+    void setReactionFieldDielectric(double dielectric);
+    /**
+     * Get the error tolerance for Ewald summation.  This corresponds to the fractional error in the forces
+     * which is acceptable.  This value is used to select the reciprocal space cutoff and separation
+     * parameter so that the average error level will be less than the tolerance.  There is not a
+     * rigorous guarantee that all forces on all atoms will be less than the tolerance, however.
+     *
+     * For PME calculations, if setPMEParameters() is used to set alpha to something other than 0,
+     * this value is ignored.
+     */
+    double getEwaldErrorTolerance() const;
+    /**
+     * Set the error tolerance for Ewald summation.  This corresponds to the fractional error in the forces
+     * which is acceptable.  This value is used to select the reciprocal space cutoff and separation
+     * parameter so that the average error level will be less than the tolerance.  There is not a
+     * rigorous guarantee that all forces on all atoms will be less than the tolerance, however.
+     *
+     * For PME calculations, if setPMEParameters() is used to set alpha to something other than 0,
+     * this value is ignored.
+     */
+    void setEwaldErrorTolerance(double tol);
+    /**
+     * Get the parameters to use for PME calculations.  If alpha is 0 (the default), these parameters are
+     * ignored and instead their values are chosen based on the Ewald error tolerance.
+     *
+     * @param[out] alpha   the separation parameter
+     * @param[out] nx      the number of grid points along the X axis
+     * @param[out] ny      the number of grid points along the Y axis
+     * @param[out] nz      the number of grid points along the Z axis
+     */
+    void getPMEParameters(double& alpha, int& nx, int& ny, int& nz) const;
+    /**
+     * Get the parameters to use for PME calculations.  If alpha is 0 (the default), these parameters are
+     * ignored and instead their values are chosen based on the Ewald error tolerance.
+     *
+     * @param[out] dalpha   the dispersion separation parameter
+     * @param[out] dnx      the number of dispersion grid points along the X axis
+     * @param[out] dny      the number of dispersion grid points along the Y axis
+     * @param[out] dnz      the number of dispersion grid points along the Z axis
+     */
+    void getDispersionPMEParameters(double& dalpha, int& dnx, int& dny, int& dnz) const;
+    /**
+     * Set the parameters to use for PME calculations.  If alpha is 0 (the default), these parameters are
+     * ignored and instead their values are chosen based on the Ewald error tolerance.
+     *
+     * @param alpha   the separation parameter
+     * @param nx      the number of grid points along the X axis
+     * @param ny      the number of grid points along the Y axis
+     * @param nz      the number of grid points along the Z axis
+     */
+    void setPMEParameters(double alpha, int nx, int ny, int nz);
+    /**
+     * Set the dispersion parameters to use for PME calculations.  If dalpha is 0 (the default), these parameters are
+     * ignored and instead their values are chosen based on the Ewald error tolerance.
+     *
+     * @param dalpha   the dispersion separation parameter
+     * @param dnx      the number of disperesion grid points along the X axis
+     * @param dny      the number of disperesion grid points along the Y axis
+     * @param dnz      the number of disperesion grid points along the Z axis
+     */
+    void setDispersionPMEParameters(double dalpha, int dnx, int dny, int dnz);
+    /**
+     * Get the parameters being used for PME in a particular Context.  Because some platforms have restrictions
+     * on the allowed grid sizes, the values that are actually used may be slightly different from those
+     * specified with setPMEParameters(), or the standard values calculated based on the Ewald error tolerance.
+     * See the manual for details.
+     *
+     * @param context      the Context for which to get the parameters
+     * @param[out] alpha   the separation parameter
+     * @param[out] nx      the number of grid points along the X axis
+     * @param[out] ny      the number of grid points along the Y axis
+     * @param[out] nz      the number of grid points along the Z axis
+     */
+    void getPMEParametersInContext(const Context& context, double& alpha, int& nx, int& ny, int& nz) const;
+    /**
+     * Get the parameters being used for Dispersion PME in a particular Context.  Because some platforms have restrictions
+     * on the allowed grid sizes, the values that are actually used may be slightly different from those
+     * specified with setPMEParameters(), or the standard values calculated based on the Ewald error tolerance.
+     * See the manual for details.
+     *
+     * @param context      the Context for which to get the parameters
+     * @param[out] dalpha   the dispersion separation parameter
+     * @param[out] dnx      the number of dispersion grid points along the X axis
+     * @param[out] dny      the number of dispersion grid points along the Y axis
+     * @param[out] dnz      the number of dispersion grid points along the Z axis
+     */
+    void getDispersionPMEParametersInContext(const Context& context, double& dalpha, int& dnx, int& dny, int& dnz) const;
+    /**
+     * Add the nonbonded force parameters for a particle.  This should be called once for each particle
+     * in the System.  When it is called for the i'th time, it specifies the parameters for the i'th particle.
+     * For calculating the Lennard-Jones interaction between two particles, the arithmetic mean of the sigmas
+     * and the geometric mean of the epsilons for the two interacting particles is used (the Lorentz-Berthelot
+     * combining rule).
+     *
+     * @param charge    the charge of the particle, measured in units of the proton charge
+     * @param sigma     the sigma parameter of the Lennard-Jones potential (corresponding to the van der Waals radius of the particle), measured in nm
+     * @param epsilon   the epsilon parameter of the Lennard-Jones potential (corresponding to the well depth of the van der Waals interaction), measured in kJ/mol
+     * @return the index of the particle that was added
+     */
+    int addParticle(double charge, double sigma, double epsilon);
+    /**
+     * Get the nonbonded force parameters for a particle.
+     *
+     * @param index          the index of the particle for which to get parameters
+     * @param[out] charge    the charge of the particle, measured in units of the proton charge
+     * @param[out] sigma     the sigma parameter of the Lennard-Jones potential (corresponding to the van der Waals radius of the particle), measured in nm
+     * @param[out] epsilon   the epsilon parameter of the Lennard-Jones potential (corresponding to the well depth of the van der Waals interaction), measured in kJ/mol
+     */
+    void getParticleParameters(int index, double& charge, double& sigma, double& epsilon) const;
+    /**
+     * Set the nonbonded force parameters for a particle.  When calculating the Lennard-Jones interaction between two particles,
+     * it uses the arithmetic mean of the sigmas and the geometric mean of the epsilons for the two interacting particles
+     * (the Lorentz-Berthelot combining rule).
+     *
+     * @param index     the index of the particle for which to set parameters
+     * @param charge    the charge of the particle, measured in units of the proton charge
+     * @param sigma     the sigma parameter of the Lennard-Jones potential (corresponding to the van der Waals radius of the particle), measured in nm
+     * @param epsilon   the epsilon parameter of the Lennard-Jones potential (corresponding to the well depth of the van der Waals interaction), measured in kJ/mol
+     */
+    void setParticleParameters(int index, double charge, double sigma, double epsilon);
+    /**
+     * Add an interaction to the list of exceptions that should be calculated differently from other interactions.
+     * If chargeProd and epsilon are both equal to 0, this will cause the interaction to be completely omitted from
+     * force and energy calculations.
+     *
+     * In many cases, you can use createExceptionsFromBonds() rather than adding each exception explicitly.
+     *
+     * @param particle1  the index of the first particle involved in the interaction
+     * @param particle2  the index of the second particle involved in the interaction
+     * @param chargeProd the scaled product of the atomic charges (i.e. the strength of the Coulomb interaction), measured in units of the proton charge squared
+     * @param sigma      the sigma parameter of the Lennard-Jones potential (corresponding to the van der Waals radius of the particle), measured in nm
+     * @param epsilon    the epsilon parameter of the Lennard-Jones potential (corresponding to the well depth of the van der Waals interaction), measured in kJ/mol
+     * @param replace    determines the behavior if there is already an exception for the same two particles.  If true, the existing one is replaced.  If false,
+     *                   an exception is thrown.
+     * @return the index of the exception that was added
+     */
+    int addException(int particle1, int particle2, double chargeProd, double sigma, double epsilon, bool replace = false);
+    /**
+     * Get the force field parameters for an interaction that should be calculated differently from others.
+     *
+     * @param index           the index of the interaction for which to get parameters
+     * @param[out] particle1  the index of the first particle involved in the interaction
+     * @param[out] particle2  the index of the second particle involved in the interaction
+     * @param[out] chargeProd the scaled product of the atomic charges (i.e. the strength of the Coulomb interaction), measured in units of the proton charge squared
+     * @param[out] sigma      the sigma parameter of the Lennard-Jones potential (corresponding to the van der Waals radius of the particle), measured in nm
+     * @param[out] epsilon    the epsilon parameter of the Lennard-Jones potential (corresponding to the well depth of the van der Waals interaction), measured in kJ/mol
+     */
+    void getExceptionParameters(int index, int& particle1, int& particle2, double& chargeProd, double& sigma, double& epsilon) const;
+    /**
+     * Set the force field parameters for an interaction that should be calculated differently from others.
+     * If chargeProd and epsilon are both equal to 0, this will cause the interaction to be completely omitted from
+     * force and energy calculations.
+     *
+     * @param index      the index of the interaction for which to get parameters
+     * @param particle1  the index of the first particle involved in the interaction
+     * @param particle2  the index of the second particle involved in the interaction
+     * @param chargeProd the scaled product of the atomic charges (i.e. the strength of the Coulomb interaction), measured in units of the proton charge squared
+     * @param sigma      the sigma parameter of the Lennard-Jones potential (corresponding to the van der Waals radius of the particle), measured in nm
+     * @param epsilon    the epsilon parameter of the Lennard-Jones potential (corresponding to the well depth of the van der Waals interaction), measured in kJ/mol
+     */
+    void setExceptionParameters(int index, int particle1, int particle2, double chargeProd, double sigma, double epsilon);
+    /**
+     * Identify exceptions based on the molecular topology.  Particles which are separated by one or two bonds are set
+     * to not interact at all, while pairs of particles separated by three bonds (known as "1-4 interactions") have
+     * their Coulomb and Lennard-Jones interactions reduced by a fixed factor.
+     *
+     * @param bonds           the set of bonds based on which to construct exceptions.  Each element specifies the indices of
+     *                        two particles that are bonded to each other.
+     * @param coulomb14Scale  pairs of particles separated by three bonds will have the strength of their Coulomb interaction
+     *                        multiplied by this factor
+     * @param lj14Scale       pairs of particles separated by three bonds will have the strength of their Lennard-Jones interaction
+     *                        multiplied by this factor
+     */
+    void createExceptionsFromBonds(const std::vector<std::pair<int, int> >& bonds, double coulomb14Scale, double lj14Scale);
+    /**
+     * Get the force group that reciprocal space interactions for Ewald or PME are included in.  This allows multiple
+     * time step integrators to evaluate direct and reciprocal space interactions at different intervals: getForceGroup()
+     * specifies the group for direct space, and getReciprocalSpaceForceGroup() specifies the group for reciprocal space.
+     * If this is -1 (the default value), the same force group is used for reciprocal space as for direct space.
+     */
+    int getReciprocalSpaceForceGroup() const;
+    /**
+     * Set the force group that reciprocal space interactions for Ewald or PME are included in.  This allows multiple
+     * time step integrators to evaluate direct and reciprocal space interactions at different intervals: setForceGroup()
+     * specifies the group for direct space, and setReciprocalSpaceForceGroup() specifies the group for reciprocal space.
+     * If this is -1 (the default value), the same force group is used for reciprocal space as for direct space.
+     *
+     * @param group    the group index.  Legal values are between 0 and 31 (inclusive), or -1 to use the same force group
+     *                 that is specified for direct space.
+     */
+    void setReciprocalSpaceForceGroup(int group);
+    /**
+     * Update the particle and exception parameters in a Context to match those stored in this Force object.  This method
+     * provides an efficient method to update certain parameters in an existing Context without needing to reinitialize it.
+     * Simply call setParticleParameters() and setExceptionParameters() to modify this object's parameters, then call
+     * updateParametersInContext() to copy them over to the Context.
+     *
+     * This method has several limitations.  The only information it updates is the parameters of particles and exceptions.
+     * All other aspects of the Force (the nonbonded method, the cutoff distance, etc.) are unaffected and can only be
+     * changed by reinitializing the Context.  Furthermore, only the chargeProd, sigma, and epsilon values of an exception
+     * can be changed; the pair of particles involved in the exception cannot change.  Finally, this method cannot be used
+     * to add new particles or exceptions, only to change the parameters of existing ones.
+     */
+    void updateParametersInContext(Context& context);
+    /**
+     * Returns whether or not this force makes use of periodic boundary
+     * conditions.  N.B. The current implementation always uses PBC.
+     *
+     * @returns true if force uses PBC and false otherwise
+     */
+    bool usesPeriodicBoundaryConditions() const {
+        return true;
+    }
+protected:
+    ForceImpl* createImpl() const;
+private:
+    class ParticleInfo;
+    class ExceptionInfo;
+    DPMENonbondedMethod nonbondedMethod;
+    double rfDielectric, ewaldErrorTol, alpha, dalpha, cutoffDistance;
+    int recipForceGroup, nx, ny, nz, dnx, dny, dnz;
+    void addExclusionsToSet(const std::vector<std::set<int> >& bonded12, std::set<int>& exclusions, int baseParticle, int fromParticle, int currentLevel) const;
+    std::vector<ParticleInfo> particles;
+    std::vector<ExceptionInfo> exceptions;
+    std::map<std::pair<int, int>, int> exceptionMap;
+};
+
+/**
+ * This is an internal class used to record information about a particle.
+ * @private
+ */
+class DPMENonbondedForce::ParticleInfo {
+public:
+    double charge, sigma, epsilon;
+    ParticleInfo() {
+        charge = sigma = epsilon = 0.0;
+    }
+    ParticleInfo(double charge, double sigma, double epsilon) :
+        charge(charge), sigma(sigma), epsilon(epsilon) {
+    }
+};
+
+/**
+ * This is an internal class used to record information about an exception.
+ * @private
+ */
+class DPMENonbondedForce::ExceptionInfo {
+public:
+    int particle1, particle2;
+    double chargeProd, sigma, epsilon;
+    ExceptionInfo() {
+        particle1 = particle2 = -1;
+        chargeProd = sigma = epsilon = 0.0;
+    }
+    ExceptionInfo(int particle1, int particle2, double chargeProd, double sigma, double epsilon) :
+        particle1(particle1), particle2(particle2), chargeProd(chargeProd), sigma(sigma), epsilon(epsilon) {
+    }
+};
+
+} // namespace OpenMM
+
+#endif /*OPENMM_DPMENONBONDEDFORCE_H_*/

--- a/openmmapi/include/openmm/internal/DPMENonbondedForceImpl.h
+++ b/openmmapi/include/openmm/internal/DPMENonbondedForceImpl.h
@@ -1,3 +1,6 @@
+#ifndef OPENMM_DPMENONBONDEDFORCEIMPL_H_
+#define OPENMM_DPMENONBONDEDFORCEIMPL_H_
+
 /* -------------------------------------------------------------------------- *
  *                                   OpenMM                                   *
  * -------------------------------------------------------------------------- *
@@ -6,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2013-2016 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2010 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -29,39 +32,52 @@
  * USE OR OTHER DEALINGS IN THE SOFTWARE.                                     *
  * -------------------------------------------------------------------------- */
 
-#include "CpuKernelFactory.h"
-#include "CpuKernels.h"
-#include "CpuPlatform.h"
-#include "openmm/internal/ContextImpl.h"
-#include "openmm/OpenMMException.h"
+#include "ForceImpl.h"
+#include "openmm/DPMENonbondedForce.h"
+#include "openmm/Kernel.h"
+#include <utility>
+#include <set>
+#include <string>
 
-using namespace OpenMM;
+namespace OpenMM {
 
-KernelImpl* CpuKernelFactory::createKernelImpl(std::string name, const Platform& platform, ContextImpl& context) const {
-    CpuPlatform::PlatformData& data = CpuPlatform::getPlatformData(context);
-    if (name == CalcForcesAndEnergyKernel::Name())
-        return new CpuCalcForcesAndEnergyKernel(name, platform, data, context);
-    if (name == CalcHarmonicAngleForceKernel::Name())
-        return new CpuCalcHarmonicAngleForceKernel(name, platform, data);
-    if (name == CalcPeriodicTorsionForceKernel::Name())
-        return new CpuCalcPeriodicTorsionForceKernel(name, platform, data);
-    if (name == CalcRBTorsionForceKernel::Name())
-        return new CpuCalcRBTorsionForceKernel(name, platform, data);
-    if (name == CalcNonbondedForceKernel::Name())
-        return new CpuCalcNonbondedForceKernel(name, platform, data);
-    if (name == CalcDPMENonbondedForceKernel::Name())
-        return new CpuCalcDPMENonbondedForceKernel(name, platform, data);
-    if (name == CalcCustomNonbondedForceKernel::Name())
-        return new CpuCalcCustomNonbondedForceKernel(name, platform, data);
-    if (name == CalcCustomManyParticleForceKernel::Name())
-        return new CpuCalcCustomManyParticleForceKernel(name, platform, data);
-    if (name == CalcGBSAOBCForceKernel::Name())
-        return new CpuCalcGBSAOBCForceKernel(name, platform, data);
-    if (name == CalcCustomGBForceKernel::Name())
-        return new CpuCalcCustomGBForceKernel(name, platform, data);
-    if (name == CalcGayBerneForceKernel::Name())
-        return new CpuCalcGayBerneForceKernel(name, platform, data);
-    if (name == IntegrateLangevinStepKernel::Name())
-        return new CpuIntegrateLangevinStepKernel(name, platform, data);
-    throw OpenMMException((std::string("Tried to create kernel with illegal kernel name '") + name + "'").c_str());
-}
+class System;
+
+/**
+ * This is the internal implementation of DPMENonbondedForce.
+ */
+
+class OPENMM_EXPORT DPMENonbondedForceImpl : public ForceImpl {
+public:
+    DPMENonbondedForceImpl(const DPMENonbondedForce& owner);
+    ~DPMENonbondedForceImpl();
+    void initialize(ContextImpl& context);
+    const DPMENonbondedForce& getOwner() const {
+        return owner;
+    }
+    void updateContextState(ContextImpl& context) {
+        // This force field doesn't update the state directly.
+    }
+    double calcForcesAndEnergy(ContextImpl& context, bool includeForces, bool includeEnergy, int groups);
+    std::map<std::string, double> getDefaultParameters() {
+        return std::map<std::string, double>(); // This force field doesn't define any parameters.
+    }
+    std::vector<std::string> getKernelNames();
+    void updateParametersInContext(ContextImpl& context);
+    void getPMEParameters(double& alpha, int& nx, int& ny, int& nz) const;
+    void getDispersionPMEParameters(double& dalpha, int& dnx, int& dny, int& dnz) const;
+    /**
+     * This is a utility routine that calculates the values to use for alpha and grid size when using
+     * Particle Mesh Ewald.
+     */
+    static void calcPMEParameters(const System& system, const DPMENonbondedForce& force, double& alpha, int& xsize, int& ysize, int& zsize, bool dispersion);
+private:
+    class ErrorFunction;
+    class EwaldErrorFunction;
+    const DPMENonbondedForce& owner;
+    Kernel kernel;
+};
+
+} // namespace OpenMM
+
+#endif /*OPENMM_DPMENONBONDEDFORCEIMPL_H_*/

--- a/openmmapi/src/DPMENonbondedForce.cpp
+++ b/openmmapi/src/DPMENonbondedForce.cpp
@@ -1,0 +1,251 @@
+/* -------------------------------------------------------------------------- *
+ *                                   OpenMM                                   *
+ * -------------------------------------------------------------------------- *
+ * This is part of the OpenMM molecular simulation toolkit originating from   *
+ * Simbios, the NIH National Center for Physics-Based Simulation of           *
+ * Biological Structures at Stanford, funded under the NIH Roadmap for        *
+ * Medical Research, grant U54 GM072970. See https://simtk.org.               *
+ *                                                                            *
+ * Portions copyright (c) 2008-2016 Stanford University and the Authors.      *
+ * Authors: Peter Eastman                                                     *
+ * Contributors:                                                              *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included in *
+ * all copies or substantial portions of the Software.                        *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS, CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,    *
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR      *
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE  *
+ * USE OR OTHER DEALINGS IN THE SOFTWARE.                                     *
+ * -------------------------------------------------------------------------- */
+
+#include "openmm/Force.h"
+#include "openmm/OpenMMException.h"
+#include "openmm/DPMENonbondedForce.h"
+#include "openmm/internal/AssertionUtilities.h"
+#include "openmm/internal/DPMENonbondedForceImpl.h"
+#include <cmath>
+#include <map>
+#include <sstream>
+#include <utility>
+
+using namespace OpenMM;
+using std::map;
+using std::pair;
+using std::set;
+using std::string;
+using std::stringstream;
+using std::vector;
+
+DPMENonbondedForce::DPMENonbondedForce() : nonbondedMethod(PME), cutoffDistance(1.0), rfDielectric(78.3),
+        ewaldErrorTol(5e-4), alpha(0.0), recipForceGroup(-1), nx(0), ny(0), nz(0) {
+}
+
+DPMENonbondedForce::DPMENonbondedMethod DPMENonbondedForce::getNonbondedMethod() const {
+    return nonbondedMethod;
+}
+
+void DPMENonbondedForce::setNonbondedMethod(DPMENonbondedMethod method) {
+    nonbondedMethod = method;
+}
+
+double DPMENonbondedForce::getCutoffDistance() const {
+    return cutoffDistance;
+}
+
+void DPMENonbondedForce::setCutoffDistance(double distance) {
+    cutoffDistance = distance;
+}
+
+double DPMENonbondedForce::getReactionFieldDielectric() const {
+    return rfDielectric;
+}
+
+void DPMENonbondedForce::setReactionFieldDielectric(double dielectric) {
+    rfDielectric = dielectric;
+}
+
+double DPMENonbondedForce::getEwaldErrorTolerance() const {
+    return ewaldErrorTol;
+}
+
+void DPMENonbondedForce::setEwaldErrorTolerance(double tol) {
+    ewaldErrorTol = tol;
+}
+
+void DPMENonbondedForce::getPMEParameters(double& alpha, int& nx, int& ny, int& nz) const {
+    alpha = this->alpha;
+    nx = this->nx;
+    ny = this->ny;
+    nz = this->nz;
+}
+
+void DPMENonbondedForce::getDispersionPMEParameters(double &dalpha, int &dnx, int &dny, int &dnz) const {
+    dalpha = this->dalpha;
+    dnx = this->dnx;
+    dny = this->dny;
+    dnz = this->dnz;
+}
+
+void DPMENonbondedForce::setPMEParameters(double alpha, int nx, int ny, int nz) {
+    this->alpha = alpha;
+    this->nx = nx;
+    this->ny = ny;
+    this->nz = nz;
+}
+
+void DPMENonbondedForce::setDispersionPMEParameters(double dalpha, int dnx, int dny, int dnz) {
+    this->dalpha = dalpha;
+    this->dnx = dnx;
+    this->dny = dny;
+    this->dnz = dnz;
+}
+
+void DPMENonbondedForce::getPMEParametersInContext(const Context& context, double& alpha, int& nx, int& ny, int& nz) const {
+    dynamic_cast<const DPMENonbondedForceImpl&>(getImplInContext(context)).getPMEParameters(alpha, nx, ny, nz);
+}
+
+void DPMENonbondedForce::getDispersionPMEParametersInContext(const Context& context, double& dalpha, int& dnx, int& dny, int& dnz) const {
+    dynamic_cast<const DPMENonbondedForceImpl&>(getImplInContext(context)).getDispersionPMEParameters(dalpha, dnx, dny, dnz);
+}
+
+int DPMENonbondedForce::addParticle(double charge, double sigma, double epsilon) {
+    particles.push_back(ParticleInfo(charge, sigma, epsilon));
+    return particles.size()-1;
+}
+
+void DPMENonbondedForce::getParticleParameters(int index, double& charge, double& sigma, double& epsilon) const {
+    ASSERT_VALID_INDEX(index, particles);
+    charge = particles[index].charge;
+    sigma = particles[index].sigma;
+    epsilon = particles[index].epsilon;
+}
+
+void DPMENonbondedForce::setParticleParameters(int index, double charge, double sigma, double epsilon) {
+    ASSERT_VALID_INDEX(index, particles);
+    particles[index].charge = charge;
+    particles[index].sigma = sigma;
+    particles[index].epsilon = epsilon;
+}
+
+int DPMENonbondedForce::addException(int particle1, int particle2, double chargeProd, double sigma, double epsilon, bool replace) {
+    map<pair<int, int>, int>::iterator iter = exceptionMap.find(pair<int, int>(particle1, particle2));
+    int newIndex;
+    if (iter == exceptionMap.end())
+        iter = exceptionMap.find(pair<int, int>(particle2, particle1));
+    if (iter != exceptionMap.end()) {
+        if (!replace) {
+            stringstream msg;
+            msg << "DPMENonbondedForce: There is already an exception for particles ";
+            msg << particle1;
+            msg << " and ";
+            msg << particle2;
+            throw OpenMMException(msg.str());
+        }
+        exceptions[iter->second] = ExceptionInfo(particle1, particle2, chargeProd, sigma, epsilon);
+        newIndex = iter->second;
+        exceptionMap.erase(iter->first);
+    }
+    else {
+        exceptions.push_back(ExceptionInfo(particle1, particle2, chargeProd, sigma, epsilon));
+        newIndex = exceptions.size()-1;
+    }
+    exceptionMap[pair<int, int>(particle1, particle2)] = newIndex;
+    return newIndex;
+}
+void DPMENonbondedForce::getExceptionParameters(int index, int& particle1, int& particle2, double& chargeProd, double& sigma, double& epsilon) const {
+    ASSERT_VALID_INDEX(index, exceptions);
+    particle1 = exceptions[index].particle1;
+    particle2 = exceptions[index].particle2;
+    chargeProd = exceptions[index].chargeProd;
+    sigma = exceptions[index].sigma;
+    epsilon = exceptions[index].epsilon;
+}
+
+void DPMENonbondedForce::setExceptionParameters(int index, int particle1, int particle2, double chargeProd, double sigma, double epsilon) {
+    ASSERT_VALID_INDEX(index, exceptions);
+    exceptions[index].particle1 = particle1;
+    exceptions[index].particle2 = particle2;
+    exceptions[index].chargeProd = chargeProd;
+    exceptions[index].sigma = sigma;
+    exceptions[index].epsilon = epsilon;
+}
+
+ForceImpl* DPMENonbondedForce::createImpl() const {
+    return new DPMENonbondedForceImpl(*this);
+}
+
+void DPMENonbondedForce::createExceptionsFromBonds(const vector<pair<int, int> >& bonds, double coulomb14Scale, double lj14Scale) {
+    for (int i = 0; i < (int) bonds.size(); ++i)
+        if (bonds[i].first < 0 || bonds[i].second < 0 || bonds[i].first >= particles.size() || bonds[i].second >= particles.size())
+            throw OpenMMException("createExceptionsFromBonds: Illegal particle index in list of bonds");
+
+    // Find particles separated by 1, 2, or 3 bonds.
+
+    vector<set<int> > exclusions(particles.size());
+    vector<set<int> > bonded12(exclusions.size());
+    for (int i = 0; i < (int) bonds.size(); ++i) {
+        bonded12[bonds[i].first].insert(bonds[i].second);
+        bonded12[bonds[i].second].insert(bonds[i].first);
+    }
+    for (int i = 0; i < (int) exclusions.size(); ++i)
+        addExclusionsToSet(bonded12, exclusions[i], i, i, 2);
+
+    // Find particles separated by 1 or 2 bonds and create the exceptions.
+
+    for (int i = 0; i < (int) exclusions.size(); ++i) {
+        set<int> bonded13;
+        addExclusionsToSet(bonded12, bonded13, i, i, 1);
+        for (set<int>::const_iterator iter = exclusions[i].begin(); iter != exclusions[i].end(); ++iter)
+            if (*iter < i) {
+                if (bonded13.find(*iter) == bonded13.end()) {
+                    // This is a 1-4 interaction.
+
+                    const ParticleInfo& particle1 = particles[*iter];
+                    const ParticleInfo& particle2 = particles[i];
+                    const double chargeProd = coulomb14Scale*particle1.charge*particle2.charge;
+                    const double sigma = 0.5*(particle1.sigma+particle2.sigma);
+                    const double epsilon = lj14Scale*std::sqrt(particle1.epsilon*particle2.epsilon);
+                    addException(*iter, i, chargeProd, sigma, epsilon);
+                }
+                else {
+                    // This interaction should be completely excluded.
+
+                    addException(*iter, i, 0.0, 1.0, 0.0);
+                }
+            }
+    }
+}
+
+void DPMENonbondedForce::addExclusionsToSet(const vector<set<int> >& bonded12, set<int>& exclusions, int baseParticle, int fromParticle, int currentLevel) const {
+    for (set<int>::const_iterator iter = bonded12[fromParticle].begin(); iter != bonded12[fromParticle].end(); ++iter) {
+        if (*iter != baseParticle)
+            exclusions.insert(*iter);
+        if (currentLevel > 0)
+            addExclusionsToSet(bonded12, exclusions, baseParticle, *iter, currentLevel-1);
+    }
+}
+
+int DPMENonbondedForce::getReciprocalSpaceForceGroup() const {
+    return recipForceGroup;
+}
+
+void DPMENonbondedForce::setReciprocalSpaceForceGroup(int group) {
+    if (group < -1 || group > 31)
+        throw OpenMMException("Force group must be between -1 and 31");
+    recipForceGroup = group;
+}
+
+void DPMENonbondedForce::updateParametersInContext(Context& context) {
+    dynamic_cast<DPMENonbondedForceImpl&>(getImplInContext(context)).updateParametersInContext(getContextImpl(context));
+}

--- a/openmmapi/src/DPMENonbondedForceImpl.cpp
+++ b/openmmapi/src/DPMENonbondedForceImpl.cpp
@@ -1,0 +1,160 @@
+/* -------------------------------------------------------------------------- *
+ *                                   OpenMM                                   *
+ * -------------------------------------------------------------------------- *
+ * This is part of the OpenMM molecular simulation toolkit originating from   *
+ * Simbios, the NIH National Center for Physics-Based Simulation of           *
+ * Biological Structures at Stanford, funded under the NIH Roadmap for        *
+ * Medical Research, grant U54 GM072970. See https://simtk.org.               *
+ *                                                                            *
+ * Portions copyright (c) 2008-2015 Stanford University and the Authors.      *
+ * Authors: Peter Eastman                                                     *
+ * Contributors:                                                              *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included in *
+ * all copies or substantial portions of the Software.                        *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS, CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,    *
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR      *
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE  *
+ * USE OR OTHER DEALINGS IN THE SOFTWARE.                                     *
+ * -------------------------------------------------------------------------- */
+
+#ifdef WIN32
+  #define _USE_MATH_DEFINES // Needed to get M_PI
+#endif
+#include "openmm/OpenMMException.h"
+#include "openmm/internal/ContextImpl.h"
+#include "openmm/internal/DPMENonbondedForceImpl.h"
+#include "openmm/kernels.h"
+#include <cmath>
+#include <map>
+#include <sstream>
+#include <algorithm>
+
+using namespace OpenMM;
+using namespace std;
+
+DPMENonbondedForceImpl::DPMENonbondedForceImpl(const DPMENonbondedForce& owner) : owner(owner) {
+}
+
+DPMENonbondedForceImpl::~DPMENonbondedForceImpl() {
+}
+
+void DPMENonbondedForceImpl::initialize(ContextImpl& context) {
+    kernel = context.getPlatform().createKernel(CalcDPMENonbondedForceKernel::Name(), context);
+
+    // Check for errors in the specification of exceptions.
+
+    const System& system = context.getSystem();
+    if (owner.getNumParticles() != system.getNumParticles())
+        throw OpenMMException("DPMENonbondedForce must have exactly as many particles as the System it belongs to.");
+    vector<set<int> > exceptions(owner.getNumParticles());
+    for (int i = 0; i < owner.getNumExceptions(); i++) {
+        int particle1, particle2;
+        double chargeProd, sigma, epsilon;
+        owner.getExceptionParameters(i, particle1, particle2, chargeProd, sigma, epsilon);
+        if (particle1 < 0 || particle1 >= owner.getNumParticles()) {
+            stringstream msg;
+            msg << "DPMENonbondedForce: Illegal particle index for an exception: ";
+            msg << particle1;
+            throw OpenMMException(msg.str());
+        }
+        if (particle2 < 0 || particle2 >= owner.getNumParticles()) {
+            stringstream msg;
+            msg << "DPMENonbondedForce: Illegal particle index for an exception: ";
+            msg << particle2;
+            throw OpenMMException(msg.str());
+        }
+        if (exceptions[particle1].count(particle2) > 0 || exceptions[particle2].count(particle1) > 0) {
+            stringstream msg;
+            msg << "DPMENonbondedForce: Multiple exceptions are specified for particles ";
+            msg << particle1;
+            msg << " and ";
+            msg << particle2;
+            throw OpenMMException(msg.str());
+        }
+        exceptions[particle1].insert(particle2);
+        exceptions[particle2].insert(particle1);
+    }
+    Vec3 boxVectors[3];
+    system.getDefaultPeriodicBoxVectors(boxVectors[0], boxVectors[1], boxVectors[2]);
+    double cutoff = owner.getCutoffDistance();
+    if (cutoff > 0.5*boxVectors[0][0] || cutoff > 0.5*boxVectors[1][1] || cutoff > 0.5*boxVectors[2][2])
+        throw OpenMMException("DPMENonbondedForce: The cutoff distance cannot be greater than half the periodic box size.");
+    kernel.getAs<CalcDPMENonbondedForceKernel>().initialize(context.getSystem(), owner);
+}
+
+double DPMENonbondedForceImpl::calcForcesAndEnergy(ContextImpl& context, bool includeForces, bool includeEnergy, int groups) {
+    bool includeDirect = ((groups&(1<<owner.getForceGroup())) != 0);
+    bool includeReciprocal = includeDirect;
+    if (owner.getReciprocalSpaceForceGroup() >= 0)
+        includeReciprocal = ((groups&(1<<owner.getReciprocalSpaceForceGroup())) != 0);
+    return kernel.getAs<CalcDPMENonbondedForceKernel>().execute(context, includeForces, includeEnergy, includeDirect, includeReciprocal);
+}
+
+std::vector<std::string> DPMENonbondedForceImpl::getKernelNames() {
+    std::vector<std::string> names;
+    names.push_back(CalcDPMENonbondedForceKernel::Name());
+    return names;
+}
+
+class DPMENonbondedForceImpl::ErrorFunction {
+public:
+    virtual double getValue(int arg) const = 0;
+};
+
+class DPMENonbondedForceImpl::EwaldErrorFunction : public ErrorFunction {
+public:
+    EwaldErrorFunction(double width, double alpha, double target) : width(width), alpha(alpha), target(target) {
+    }
+    double getValue(int arg) const {
+        double temp = arg*M_PI/(width*alpha);
+        return target-0.05*sqrt(width*alpha)*arg*exp(-temp*temp);
+    }
+private:
+    double width, alpha, target;
+};
+
+
+void DPMENonbondedForceImpl::calcPMEParameters(const System& system, const DPMENonbondedForce& force, double& alpha, int& xsize, int& ysize, int& zsize, bool dispersion) {
+    if(dispersion) {
+        force.getDispersionPMEParameters(alpha, xsize, ysize, zsize);
+    } else {
+        force.getPMEParameters(alpha, xsize, ysize, zsize);
+    }
+    // The electrostatic grid dimensions
+    if (alpha == 0.0) {
+        Vec3 boxVectors[3];
+        system.getDefaultPeriodicBoxVectors(boxVectors[0], boxVectors[1], boxVectors[2]);
+        double tol = force.getEwaldErrorTolerance();
+        alpha = (1.0/force.getCutoffDistance())*std::sqrt(-log(2.0*tol));
+        xsize = (int) ceil(2*alpha*boxVectors[0][0]/(3*pow(tol, 0.2)));
+        ysize = (int) ceil(2*alpha*boxVectors[1][1]/(3*pow(tol, 0.2)));
+        zsize = (int) ceil(2*alpha*boxVectors[2][2]/(3*pow(tol, 0.2)));
+        xsize = max(xsize, 5);
+        ysize = max(ysize, 5);
+        zsize = max(zsize, 5);
+    }
+}
+
+
+void DPMENonbondedForceImpl::updateParametersInContext(ContextImpl& context) {
+    kernel.getAs<CalcDPMENonbondedForceKernel>().copyParametersToContext(context, owner);
+}
+
+void DPMENonbondedForceImpl::getPMEParameters(double& alpha, int& nx, int& ny, int& nz) const {
+    kernel.getAs<CalcDPMENonbondedForceKernel>().getPMEParameters(alpha, nx, ny, nz);
+}
+void DPMENonbondedForceImpl::getDispersionPMEParameters(double& dalpha, int& dnx, int& dny, int& dnz) const {
+    kernel.getAs<CalcDPMENonbondedForceKernel>().getDispersionPMEParameters(dalpha, dnx, dny, dnz);
+}

--- a/platforms/cpu/include/CpuDPMENonbondedForce.h
+++ b/platforms/cpu/include/CpuDPMENonbondedForce.h
@@ -1,0 +1,252 @@
+
+/* Portions copyright (c) 2006-2015 Stanford University and Simbios.
+ * Contributors: Pande Group
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject
+ * to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS, CONTRIBUTORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef OPENMM_CPU_DPMENONBONDED_FORCE_H__
+#define OPENMM_CPU_DPMENONBONDED_FORCE_H__
+
+#include "AlignedArray.h"
+#include "CpuNeighborList.h"
+#include "ReferencePairIxn.h"
+#include "CpuNonbondedForce.h"
+#include "openmm/internal/ThreadPool.h"
+#include "openmm/internal/vectorize.h"
+#include <set>
+#include <utility>
+#include <vector>
+// ---------------------------------------------------------------------------------------
+
+namespace OpenMM {
+
+class CpuDPMENonbondedForce {
+    public:
+        class ComputeDirectTask;
+
+      /**---------------------------------------------------------------------------------------
+      
+         Constructor
+      
+         --------------------------------------------------------------------------------------- */
+
+       CpuDPMENonbondedForce();
+       
+        /**
+         * Virtual destructor.
+         */
+
+        virtual ~CpuDPMENonbondedForce();
+        
+      /**---------------------------------------------------------------------------------------
+      
+         Set the force to use a cutoff.
+      
+         @param distance            the cutoff distance
+         @param neighbors           the neighbor list to use
+         @param solventDielectric   the dielectric constant of the bulk solvent
+      
+         --------------------------------------------------------------------------------------- */
+      
+      void setUseCutoff(float distance, const CpuNeighborList& neighbors, float solventDielectric);
+
+      /**---------------------------------------------------------------------------------------
+      
+         Set the force to use a switching function on the Lennard-Jones interaction.
+      
+         @param distance            the switching distance
+      
+         --------------------------------------------------------------------------------------- */
+      
+      void setUseSwitchingFunction(float distance);
+      
+      /**---------------------------------------------------------------------------------------
+      
+         Set the force to use periodic boundary conditions.  This requires that a cutoff has
+         already been set, and the smallest side of the periodic box is at least twice the cutoff
+         distance.
+      
+         @param periodicBoxVectors    the vectors defining the periodic box
+      
+         --------------------------------------------------------------------------------------- */
+      
+      void setPeriodic(RealVec* periodicBoxVectors);
+       
+      /**---------------------------------------------------------------------------------------
+      
+         Set the force to use Ewald summation.
+      
+         @param alpha  the Ewald separation parameter
+         @param kmaxx  the largest wave vector in the x direction
+         @param kmaxy  the largest wave vector in the y direction
+         @param kmaxz  the largest wave vector in the z direction
+      
+         --------------------------------------------------------------------------------------- */
+      
+      void setUseEwald(float alpha, int kmaxx, int kmaxy, int kmaxz);
+
+     
+      /**---------------------------------------------------------------------------------------
+      
+         Set the force to use Particle-Mesh Ewald (PME) summation.
+      
+         @param alpha    the Ewald separation parameter
+         @param gridSize the dimensions of the mesh
+      
+         --------------------------------------------------------------------------------------- */
+      
+      void setUsePME(float alpha, int meshSize[3]);
+
+      /**---------------------------------------------------------------------------------------
+      
+         Calculate Ewald ixn
+      
+         @param numberOfAtoms    number of atoms
+         @param posq             atom coordinates and charges
+         @param atomCoordinates  atom coordinates (in format needed by PME)
+         @param atomParameters   atom parameters (sigma/2, 2*sqrt(epsilon))
+         @param exclusions       atom exclusion indices
+                                 exclusions[atomIndex] contains the list of exclusions for that atom
+         @param forces           force array (forces added)
+         @param totalEnergy      total energy
+            
+         --------------------------------------------------------------------------------------- */
+          
+      void calculateReciprocalIxn(int numberOfAtoms, float* posq, const std::vector<RealVec>& atomCoordinates,
+                            const std::vector<std::pair<float, float> >& atomParameters, const std::vector<std::set<int> >& exclusions,
+                            std::vector<RealVec>& forces, double* totalEnergy) const;
+      
+      /**---------------------------------------------------------------------------------------
+      
+         Calculate LJ Coulomb pair ixn
+      
+         @param numberOfAtoms    number of atoms
+         @param posq             atom coordinates and charges
+         @param atomCoordinates  atom coordinates (periodic boundary conditions not applied)
+         @param atomParameters   atom parameters (sigma/2, 2*sqrt(epsilon))
+         @param exclusions       atom exclusion indices
+                                 exclusions[atomIndex] contains the list of exclusions for that atom
+         @param forces           force array (forces added)
+         @param totalEnergy      total energy
+         @param threads          the thread pool to use
+      
+         --------------------------------------------------------------------------------------- */
+          
+      void calculateDirectIxn(int numberOfAtoms, float* posq, const std::vector<RealVec>& atomCoordinates, const std::vector<std::pair<float, float> >& atomParameters,
+            const std::vector<std::set<int> >& exclusions, std::vector<AlignedArray<float> >& threadForce, double* totalEnergy, ThreadPool& threads);
+
+    /**
+     * This routine contains the code executed by each thread.
+     */
+    void threadComputeDirect(ThreadPool& threads, int threadIndex);
+
+protected:
+        bool cutoff;
+        bool useSwitch;
+        bool periodic;
+        bool triclinic;
+        bool ewald;
+        bool pme;
+        bool tableIsValid;
+        const CpuNeighborList* neighborList;
+        float recipBoxSize[3];
+        RealVec periodicBoxVectors[3];
+        AlignedArray<fvec4> periodicBoxVec4;
+        float cutoffDistance, switchingDistance;
+        float krf, crf;
+        float alphaEwald;
+        int numRx, numRy, numRz;
+        int meshDim[3];
+        std::vector<float> erfcTable, ewaldScaleTable;
+        float ewaldDX, ewaldDXInv, erfcDXInv;
+        std::vector<double> threadEnergy;
+        // The following variables are used to make information accessible to the individual threads.
+        int numberOfAtoms;
+        float* posq;
+        RealVec const* atomCoordinates;
+        std::pair<float, float> const* atomParameters;        
+        std::set<int> const* exclusions;
+        std::vector<AlignedArray<float> >* threadForce;
+        bool includeEnergy;
+        void* atomicCounter;
+
+        static const float TWO_OVER_SQRT_PI;
+        static const int NUM_TABLE_POINTS;
+            
+      /**---------------------------------------------------------------------------------------
+      
+         Calculate LJ Coulomb pair ixn between two atoms
+      
+         @param atom1            the index of the first atom
+         @param atom2            the index of the second atom
+         @param forces           force array (forces added)
+         @param totalEnergy      total energy
+            
+         --------------------------------------------------------------------------------------- */
+          
+      void calculateOneIxn(int atom1, int atom2, float* forces, double* totalEnergy, const fvec4& boxSize, const fvec4& invBoxSize);
+            
+      /**---------------------------------------------------------------------------------------
+      
+         Calculate all the interactions for one atom block.
+      
+         @param blockIndex       the index of the atom block
+         @param forces           force array (forces added)
+         @param totalEnergy      total energy
+            
+         --------------------------------------------------------------------------------------- */
+          
+      virtual void calculateBlockIxn(int blockIndex, float* forces, double* totalEnergy, const fvec4& boxSize, const fvec4& invBoxSize) = 0;
+            
+      /**---------------------------------------------------------------------------------------
+      
+         Calculate all the interactions for one atom block.
+      
+         @param blockIndex       the index of the atom block
+         @param forces           force array (forces added)
+         @param totalEnergy      total energy
+            
+         --------------------------------------------------------------------------------------- */
+          
+      virtual void calculateBlockEwaldIxn(int blockIndex, float* forces, double* totalEnergy, const fvec4& boxSize, const fvec4& invBoxSize) = 0;
+
+      /**
+       * Compute the displacement and squared distance between two points, optionally using
+       * periodic boundary conditions.
+       */
+      void getDeltaR(const fvec4& posI, const fvec4& posJ, fvec4& deltaR, float& r2, bool periodic, const fvec4& boxSize, const fvec4& invBoxSize) const;
+
+      /**
+       * Create a lookup table for the scale factor used with Ewald and PME.
+       */
+      void tabulateEwaldScaleFactor();
+
+      /**
+       * Compute a fast approximation to erfc(x).
+       */
+      float erfcApprox(float x);
+};
+
+} // namespace OpenMM
+
+// ---------------------------------------------------------------------------------------
+
+#endif // OPENMM_CPU_DPMENONBONDED_FORCE_H__

--- a/platforms/cpu/include/CpuDPMENonbondedForceVec4.h
+++ b/platforms/cpu/include/CpuDPMENonbondedForceVec4.h
@@ -1,0 +1,102 @@
+
+/* Portions copyright (c) 2006-2015 Stanford University and Simbios.
+ * Contributors: Pande Group
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject
+ * to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS, CONTRIBUTORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef OPENMM_CPU_DPME_NONBONDED_FORCE_VEC4_H__
+#define OPENMM_CPU_DPME_NONBONDED_FORCE_VEC4_H__
+
+#include "CpuDPMENonbondedForce.h"
+// ---------------------------------------------------------------------------------------
+
+namespace OpenMM {
+
+class CpuDPMENonbondedForceVec4 : public CpuDPMENonbondedForce {
+public:
+      /**---------------------------------------------------------------------------------------
+      
+         Constructor
+      
+         --------------------------------------------------------------------------------------- */
+
+       CpuDPMENonbondedForceVec4();
+
+protected:
+      /**---------------------------------------------------------------------------------------
+      
+         Calculate all the interactions for one atom block.
+      
+         @param blockIndex       the index of the atom block
+         @param forces           force array (forces added)
+         @param totalEnergy      total energy
+            
+         --------------------------------------------------------------------------------------- */
+          
+      void calculateBlockIxn(int blockIndex, float* forces, double* totalEnergy, const fvec4& boxSize, const fvec4& invBoxSize);
+
+      /**
+       * Templatized implementation of calculateBlockIxn.
+       */
+      template <int PERIODIC_TYPE>
+      void calculateBlockIxnImpl(int blockIndex, float* forces, double* totalEnergy, const fvec4& boxSize, const fvec4& invBoxSize, const fvec4& blockCenter);
+            
+      /**---------------------------------------------------------------------------------------
+      
+         Calculate all the interactions for one atom block.
+      
+         @param blockIndex       the index of the atom block
+         @param forces           force array (forces added)
+         @param totalEnergy      total energy
+            
+         --------------------------------------------------------------------------------------- */
+          
+      void calculateBlockEwaldIxn(int blockIndex, float* forces, double* totalEnergy, const fvec4& boxSize, const fvec4& invBoxSize);
+
+      /**
+       * Templatized implementation of calculateBlockEwaldIxn.
+       */
+      template <int PERIODIC_TYPE>
+      void calculateBlockEwaldIxnImpl(int blockIndex, float* forces, double* totalEnergy, const fvec4& boxSize, const fvec4& invBoxSize, const fvec4& blockCenter);
+
+      /**
+       * Compute the displacement and squared distance between a collection of points, optionally using
+       * periodic boundary conditions.
+       */
+      template <int PERIODIC_TYPE>
+      void getDeltaR(const fvec4& posI, const fvec4& x, const fvec4& y, const fvec4& z, fvec4& dx, fvec4& dy, fvec4& dz, fvec4& r2, bool periodic, const fvec4& boxSize, const fvec4& invBoxSize) const;
+
+      /**
+       * Compute a fast approximation to erfc(x).
+       */
+      fvec4 erfcApprox(const fvec4& x);
+      
+      /**
+       * Evaluate the scale factor used with Ewald and PME: erfc(alpha*r) + 2*alpha*r*exp(-alpha*alpha*r*r)/sqrt(PI)
+       */
+      fvec4 ewaldScaleFunction(const fvec4& x);
+};
+
+} // namespace OpenMM
+
+// ---------------------------------------------------------------------------------------
+
+#endif // OPENMM_CPU_DPME_NONBONDED_FORCE_VEC4_H__

--- a/platforms/cpu/src/CpuDPMENonbondedForce.cpp
+++ b/platforms/cpu/src/CpuDPMENonbondedForce.cpp
@@ -1,0 +1,504 @@
+
+/* Portions copyright (c) 2006-2015 Stanford University and Simbios.
+ * Contributors: Pande Group
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject
+ * to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS, CONTRIBUTORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <complex>
+
+#include "SimTKOpenMMUtilities.h"
+#include "CpuDPMENonbondedForce.h"
+#include "ReferenceForce.h"
+#include "ReferencePME.h"
+#include "openmm/internal/gmx_atomic.h"
+#include <algorithm>
+
+// In case we're using some primitive version of Visual Studio this will
+// make sure that erf() and erfc() are defined.
+#include "openmm/internal/MSVC_erfc.h"
+
+using namespace std;
+using namespace OpenMM;
+
+const float CpuDPMENonbondedForce::TWO_OVER_SQRT_PI = (float) (2/sqrt(PI_M));
+const int CpuDPMENonbondedForce::NUM_TABLE_POINTS = 2048;
+
+class CpuDPMENonbondedForce::ComputeDirectTask : public ThreadPool::Task {
+public:
+    ComputeDirectTask(CpuDPMENonbondedForce& owner) : owner(owner) {
+    }
+    void execute(ThreadPool& threads, int threadIndex) {
+        owner.threadComputeDirect(threads, threadIndex);
+    }
+    CpuDPMENonbondedForce& owner;
+};
+
+/**---------------------------------------------------------------------------------------
+
+   CpuDPMENonbondedForce constructor
+
+   --------------------------------------------------------------------------------------- */
+
+CpuDPMENonbondedForce::CpuDPMENonbondedForce() : cutoff(false), useSwitch(false), periodic(false), ewald(false), pme(false), tableIsValid(false), cutoffDistance(0.0f), alphaEwald(0.0f) {
+}
+
+CpuDPMENonbondedForce::~CpuDPMENonbondedForce() {
+}
+
+/**---------------------------------------------------------------------------------------
+
+   Set the force to use a cutoff.
+
+   @param distance            the cutoff distance
+   @param neighbors           the neighbor list to use
+   @param solventDielectric   the dielectric constant of the bulk solvent
+
+     --------------------------------------------------------------------------------------- */
+
+void CpuDPMENonbondedForce::setUseCutoff(float distance, const CpuNeighborList& neighbors, float solventDielectric) {
+    if (distance != cutoffDistance)
+        tableIsValid = false;
+    cutoff = true;
+    cutoffDistance = distance;
+    neighborList = &neighbors;
+    krf = pow(cutoffDistance, -3.0f)*(solventDielectric-1.0)/(2.0*solventDielectric+1.0);
+    crf = (1.0/cutoffDistance)*(3.0*solventDielectric)/(2.0*solventDielectric+1.0);
+  }
+
+/**---------------------------------------------------------------------------------------
+
+   Set the force to use a switching function on the Lennard-Jones interaction.
+
+   @param distance            the switching distance
+
+   --------------------------------------------------------------------------------------- */
+
+void CpuDPMENonbondedForce::setUseSwitchingFunction(float distance) {
+    useSwitch = true;
+    switchingDistance = distance;
+}
+
+  /**---------------------------------------------------------------------------------------
+
+     Set the force to use periodic boundary conditions.  This requires that a cutoff has
+     also been set, and the smallest side of the periodic box is at least twice the cutoff
+     distance.
+
+     @param periodicBoxVectors    the vectors defining the periodic box
+
+     --------------------------------------------------------------------------------------- */
+
+  void CpuDPMENonbondedForce::setPeriodic(RealVec* periodicBoxVectors) {
+
+    assert(cutoff);
+    assert(periodicBoxVectors[0][0] >= 2.0*cutoffDistance);
+    assert(periodicBoxVectors[1][1] >= 2.0*cutoffDistance);
+    assert(periodicBoxVectors[2][2] >= 2.0*cutoffDistance);
+    periodic = true;
+    this->periodicBoxVectors[0] = periodicBoxVectors[0];
+    this->periodicBoxVectors[1] = periodicBoxVectors[1];
+    this->periodicBoxVectors[2] = periodicBoxVectors[2];
+    recipBoxSize[0] = (float) (1.0/periodicBoxVectors[0][0]);
+    recipBoxSize[1] = (float) (1.0/periodicBoxVectors[1][1]);
+    recipBoxSize[2] = (float) (1.0/periodicBoxVectors[2][2]);
+    periodicBoxVec4.resize(3);
+    periodicBoxVec4[0] = fvec4(periodicBoxVectors[0][0], periodicBoxVectors[0][1], periodicBoxVectors[0][2], 0);
+    periodicBoxVec4[1] = fvec4(periodicBoxVectors[1][0], periodicBoxVectors[1][1], periodicBoxVectors[1][2], 0);
+    periodicBoxVec4[2] = fvec4(periodicBoxVectors[2][0], periodicBoxVectors[2][1], periodicBoxVectors[2][2], 0);
+    triclinic = (periodicBoxVectors[0][1] != 0.0 || periodicBoxVectors[0][2] != 0.0 ||
+                 periodicBoxVectors[1][0] != 0.0 || periodicBoxVectors[1][2] != 0.0 ||
+                 periodicBoxVectors[2][0] != 0.0 || periodicBoxVectors[2][1] != 0.0);
+  }
+
+  /**---------------------------------------------------------------------------------------
+
+     Set the force to use Ewald summation.
+
+     @param alpha  the Ewald separation parameter
+     @param kmaxx  the largest wave vector in the x direction
+     @param kmaxy  the largest wave vector in the y direction
+     @param kmaxz  the largest wave vector in the z direction
+
+     --------------------------------------------------------------------------------------- */
+
+  void CpuDPMENonbondedForce::setUseEwald(float alpha, int kmaxx, int kmaxy, int kmaxz) {
+      if (alpha != alphaEwald)
+          tableIsValid = false;
+      alphaEwald = alpha;
+      numRx = kmaxx;
+      numRy = kmaxy;
+      numRz = kmaxz;
+      ewald = true;
+      tabulateEwaldScaleFactor();
+  }
+
+  /**---------------------------------------------------------------------------------------
+
+     Set the force to use Particle-Mesh Ewald (PME) summation.
+
+     @param alpha  the Ewald separation parameter
+     @param gridSize the dimensions of the mesh
+
+     --------------------------------------------------------------------------------------- */
+
+  void CpuDPMENonbondedForce::setUsePME(float alpha, int meshSize[3]) {
+      if (alpha != alphaEwald)
+          tableIsValid = false;
+      alphaEwald = alpha;
+      meshDim[0] = meshSize[0];
+      meshDim[1] = meshSize[1];
+      meshDim[2] = meshSize[2];
+      pme = true;
+      tabulateEwaldScaleFactor();
+  }
+
+  
+  void CpuDPMENonbondedForce::tabulateEwaldScaleFactor() {
+    if (tableIsValid)
+        return;
+    tableIsValid = true;
+    ewaldDX = cutoffDistance/NUM_TABLE_POINTS;
+    ewaldDXInv = 1.0f/ewaldDX;
+    erfcDXInv = 1.0f/(ewaldDX*alphaEwald);
+    erfcTable.resize(NUM_TABLE_POINTS+4);
+    ewaldScaleTable.resize(NUM_TABLE_POINTS+4);
+    for (int i = 0; i < NUM_TABLE_POINTS+4; i++) {
+        double r = i*ewaldDX;
+        double alphaR = alphaEwald*r;
+        erfcTable[i] = erfc(alphaR);
+        ewaldScaleTable[i] = erfcTable[i] + TWO_OVER_SQRT_PI*alphaR*exp(-alphaR*alphaR);
+    }
+}
+  
+void CpuDPMENonbondedForce::calculateReciprocalIxn(int numberOfAtoms, float* posq, const vector<RealVec>& atomCoordinates,
+                                             const vector<pair<float, float> >& atomParameters, const vector<set<int> >& exclusions,
+                                             vector<RealVec>& forces, double* totalEnergy) const {
+    typedef std::complex<float> d_complex;
+
+    static const float epsilon     =  1.0;
+
+    int kmax                       = (ewald ? max(numRx, max(numRy,numRz)) : 0);
+    float factorEwald              = -1 / (4*alphaEwald*alphaEwald);
+    float TWO_PI                   = 2.0 * PI_M;
+    float recipCoeff               = (float)(ONE_4PI_EPS0*4*PI_M/(periodicBoxVectors[0][0] * periodicBoxVectors[1][1] * periodicBoxVectors[2][2]) /epsilon);
+
+    if (pme) {
+        pme_t pmedata;
+        pme_init(&pmedata, alphaEwald, numberOfAtoms, meshDim, 5, 1);
+        vector<RealOpenMM> charges(numberOfAtoms);
+        for (int i = 0; i < numberOfAtoms; i++)
+            charges[i] = posq[4*i+3];
+        RealOpenMM recipEnergy = 0.0;
+        pme_exec(pmedata, atomCoordinates, forces, charges, periodicBoxVectors, &recipEnergy);
+        if (totalEnergy)
+            *totalEnergy += recipEnergy;
+        pme_destroy(pmedata);
+    }
+
+    // Ewald method
+
+    else if (ewald) {
+
+        // setup reciprocal box
+
+        float recipBoxSize[3] = {(float) (TWO_PI/periodicBoxVectors[0][0]), (float) (TWO_PI/periodicBoxVectors[1][1]), (float) (TWO_PI/periodicBoxVectors[2][2])};
+
+
+        // setup K-vectors
+
+        #define EIR(x, y, z) eir[(x)*numberOfAtoms*3+(y)*3+z]
+        vector<d_complex> eir(kmax*numberOfAtoms*3);
+        vector<d_complex> tab_xy(numberOfAtoms);
+        vector<d_complex> tab_qxyz(numberOfAtoms);
+
+        for (int i = 0; (i < numberOfAtoms); i++) {
+            float* pos = posq+4*i;
+            for (int m = 0; (m < 3); m++)
+              EIR(0, i, m) = d_complex(1,0);
+
+            for (int m=0; (m<3); m++)
+              EIR(1, i, m) = d_complex(cos(pos[m]*recipBoxSize[m]),
+                                       sin(pos[m]*recipBoxSize[m]));
+
+            for (int j=2; (j<kmax); j++)
+              for (int m=0; (m<3); m++)
+                EIR(j, i, m) = EIR(j-1, i, m) * EIR(1, i, m);
+        }
+
+        // calculate reciprocal space energy and forces
+
+        int lowry = 0;
+        int lowrz = 1;
+
+        for (int rx = 0; rx < numRx; rx++) {
+            float kx = rx * recipBoxSize[0];
+            for (int ry = lowry; ry < numRy; ry++) {
+                float ky = ry * recipBoxSize[1];
+                if (ry >= 0) {
+                    for (int n = 0; n < numberOfAtoms; n++)
+                      tab_xy[n] = EIR(rx, n, 0) * EIR(ry, n, 1);
+                }
+                else {
+                    for (int n = 0; n < numberOfAtoms; n++)
+                      tab_xy[n]= EIR(rx, n, 0) * conj (EIR(-ry, n, 1));
+                }
+                for (int rz = lowrz; rz < numRz; rz++) {
+                    if (rz >= 0) {
+                        for (int n = 0; n < numberOfAtoms; n++)
+                            tab_qxyz[n] = posq[4*n+3] * (tab_xy[n] * EIR(rz, n, 2));
+                    }
+                    else {
+                        for (int n = 0; n < numberOfAtoms; n++)
+                            tab_qxyz[n] = posq[4*n+3] * (tab_xy[n] * conj(EIR(-rz, n, 2)));
+                    }
+                    float cs = 0.0f;
+                    float ss = 0.0f;
+
+                    for (int n = 0; n < numberOfAtoms; n++) {
+                        cs += tab_qxyz[n].real();
+                        ss += tab_qxyz[n].imag();
+                    }
+
+                    float kz = rz * recipBoxSize[2];
+                    float k2 = kx * kx + ky * ky + kz * kz;
+                    float ak = exp(k2*factorEwald) / k2;
+
+                    for (int n = 0; n < numberOfAtoms; n++) {
+                        float force = ak * (cs * tab_qxyz[n].imag() - ss * tab_qxyz[n].real());
+                        forces[n][0] += 2 * recipCoeff * force * kx;
+                        forces[n][1] += 2 * recipCoeff * force * ky;
+                        forces[n][2] += 2 * recipCoeff * force * kz;
+                    }
+
+                    if (totalEnergy)
+                        *totalEnergy += recipCoeff * ak * (cs * cs + ss * ss);
+
+                    lowrz = 1 - numRz;
+                }
+                lowry = 1 - numRy;
+            }
+        }
+    }
+}
+
+
+void CpuDPMENonbondedForce::calculateDirectIxn(int numberOfAtoms, float* posq, const vector<RealVec>& atomCoordinates, const vector<pair<float, float> >& atomParameters,
+                const vector<set<int> >& exclusions, vector<AlignedArray<float> >& threadForce, double* totalEnergy, ThreadPool& threads) {
+    // Record the parameters for the threads.
+    
+    this->numberOfAtoms = numberOfAtoms;
+    this->posq = posq;
+    this->atomCoordinates = &atomCoordinates[0];
+    this->atomParameters = &atomParameters[0];
+    this->exclusions = &exclusions[0];
+    this->threadForce = &threadForce;
+    includeEnergy = (totalEnergy != NULL);
+    threadEnergy.resize(threads.getNumThreads());
+    gmx_atomic_t counter;
+    gmx_atomic_set(&counter, 0);
+    this->atomicCounter = &counter;
+    
+    // Signal the threads to start running and wait for them to finish.
+    
+    ComputeDirectTask task(*this);
+    threads.execute(task);
+    threads.waitForThreads();
+    
+    // Signal the threads to subtract the exclusions.
+    
+    if (ewald || pme) {
+        gmx_atomic_set(&counter, 0);
+        threads.resumeThreads();
+        threads.waitForThreads();
+    }
+    
+    // Combine the energies from all the threads.
+    
+    if (totalEnergy != NULL) {
+        double directEnergy = 0;
+        int numThreads = threads.getNumThreads();
+        for (int i = 0; i < numThreads; i++)
+            directEnergy += threadEnergy[i];
+        *totalEnergy += directEnergy;
+    }
+}
+
+void CpuDPMENonbondedForce::threadComputeDirect(ThreadPool& threads, int threadIndex) {
+    // Compute this thread's subset of interactions.
+
+    int numThreads = threads.getNumThreads();
+    threadEnergy[threadIndex] = 0;
+    double* energyPtr = (includeEnergy ? &threadEnergy[threadIndex] : NULL);
+    float* forces = &(*threadForce)[threadIndex][0];
+    fvec4 boxSize(periodicBoxVectors[0][0], periodicBoxVectors[1][1], periodicBoxVectors[2][2], 0);
+    fvec4 invBoxSize(recipBoxSize[0], recipBoxSize[1], recipBoxSize[2], 0);
+    if (ewald || pme) {
+        // Compute the interactions from the neighbor list.
+
+        while (true) {
+            int nextBlock = gmx_atomic_fetch_add(reinterpret_cast<gmx_atomic_t*>(atomicCounter), 1);
+            if (nextBlock >= neighborList->getNumBlocks())
+                break;
+            calculateBlockEwaldIxn(nextBlock, forces, energyPtr, boxSize, invBoxSize);
+        }
+
+        // Now subtract off the exclusions, since they were implicitly included in the reciprocal space sum.
+
+        threads.syncThreads();
+        const int groupSize = max(1, numberOfAtoms/(10*numThreads));
+        while (true) {
+            int start = gmx_atomic_fetch_add(reinterpret_cast<gmx_atomic_t*>(atomicCounter), groupSize);
+            if (start >= numberOfAtoms)
+                break;
+            int end = min(start+groupSize, numberOfAtoms);
+            for (int i = start; i < end; i++) {
+               fvec4 posI((float) atomCoordinates[i][0], (float) atomCoordinates[i][1], (float) atomCoordinates[i][2], 0.0f);
+                float scaledChargeI = (float) (ONE_4PI_EPS0*posq[4*i+3]);
+                for (set<int>::const_iterator iter = exclusions[i].begin(); iter != exclusions[i].end(); ++iter) {
+                    if (*iter > i) {
+                        int j = *iter;
+                        fvec4 deltaR;
+                        fvec4 posJ((float) atomCoordinates[j][0], (float) atomCoordinates[j][1], (float) atomCoordinates[j][2], 0.0f);
+                        float r2;
+                        getDeltaR(posJ, posI, deltaR, r2, false, boxSize, invBoxSize);
+                        float r = sqrtf(r2);
+                        float alphaR = alphaEwald*r;
+                        float erfAlphaR = erf(alphaR);
+                        if (erfAlphaR > 1e-6f) {
+                            float inverseR = 1/r;
+                            float chargeProdOverR = scaledChargeI*posq[4*j+3]*inverseR;
+                            float dEdR = chargeProdOverR*inverseR*inverseR;
+                            dEdR = dEdR * (erfAlphaR-TWO_OVER_SQRT_PI*alphaR*(float)exp(-alphaR*alphaR));
+                            fvec4 result = deltaR*dEdR;
+                            (fvec4(forces+4*i)-result).store(forces+4*i);
+                            (fvec4(forces+4*j)+result).store(forces+4*j);
+                            if (includeEnergy)
+                                threadEnergy[threadIndex] -= chargeProdOverR*erfAlphaR;
+                        }
+                        else if (includeEnergy)
+                           threadEnergy[threadIndex] -= alphaEwald*TWO_OVER_SQRT_PI*scaledChargeI*posq[4*j+3];
+                    }
+                }
+            }
+        }
+    }
+    else if (cutoff) {
+        // Compute the interactions from the neighbor list.
+
+        while (true) {
+            int nextBlock = gmx_atomic_fetch_add(reinterpret_cast<gmx_atomic_t*>(atomicCounter), 1);
+            if (nextBlock >= neighborList->getNumBlocks())
+                break;
+            calculateBlockIxn(nextBlock, forces, energyPtr, boxSize, invBoxSize);
+        }
+    }
+    else {
+        // Loop over all atom pairs
+
+        while (true) {
+            int i = gmx_atomic_fetch_add(reinterpret_cast<gmx_atomic_t*>(atomicCounter), 1);
+            if (i >= numberOfAtoms)
+                break;
+            for (int j = i+1; j < numberOfAtoms; j++)
+                if (exclusions[j].find(i) == exclusions[j].end())
+                    calculateOneIxn(i, j, forces, energyPtr, boxSize, invBoxSize);
+        }
+    }
+}
+
+void CpuDPMENonbondedForce::calculateOneIxn(int ii, int jj, float* forces, double* totalEnergy, const fvec4& boxSize, const fvec4& invBoxSize) {
+    // get deltaR, R2, and R between 2 atoms
+
+    fvec4 deltaR;
+    fvec4 posI(posq+4*ii);
+    fvec4 posJ(posq+4*jj);
+    float r2;
+    getDeltaR(posJ, posI, deltaR, r2, periodic, boxSize, invBoxSize);
+    if (cutoff && r2 >= cutoffDistance*cutoffDistance)
+        return;
+    float r = sqrtf(r2);
+    float inverseR = 1/r;
+    float switchValue = 1, switchDeriv = 0;
+    if (useSwitch && r > switchingDistance) {
+        float t = (r-switchingDistance)/(cutoffDistance-switchingDistance);
+        switchValue = 1+t*t*t*(-10+t*(15-t*6));
+        switchDeriv = t*t*(-30+t*(60-t*30))/(cutoffDistance-switchingDistance);
+    }
+    float sig       = atomParameters[ii].first + atomParameters[jj].first;
+    float sig2      = inverseR*sig;
+          sig2     *= sig2;
+    float sig6      = sig2*sig2*sig2;
+
+    float eps       = atomParameters[ii].second*atomParameters[jj].second;
+    float dEdR      = switchValue*eps*(12.0f*sig6 - 6.0f)*sig6;
+    float chargeProd = ONE_4PI_EPS0*posq[4*ii+3]*posq[4*jj+3];
+    if (cutoff)
+        dEdR += (float) (chargeProd*(inverseR-2.0f*krf*r2));
+    else
+        dEdR += (float) (chargeProd*inverseR);
+    dEdR *= inverseR*inverseR;
+    float energy = eps*(sig6-1.0f)*sig6;
+    if (useSwitch) {
+        dEdR -= energy*switchDeriv*inverseR;
+        energy *= switchValue;
+    }
+
+    // accumulate energies
+
+    if (totalEnergy) {
+        if (cutoff)
+            energy += (float) (chargeProd*(inverseR+krf*r2-crf));
+        else
+            energy += (float) (chargeProd*inverseR);
+        *totalEnergy += energy;
+    }
+
+    // accumulate forces
+
+    fvec4 result = deltaR*dEdR;
+    (fvec4(forces+4*ii)+result).store(forces+4*ii);
+    (fvec4(forces+4*jj)-result).store(forces+4*jj);
+  }
+
+void CpuDPMENonbondedForce::getDeltaR(const fvec4& posI, const fvec4& posJ, fvec4& deltaR, float& r2, bool periodic, const fvec4& boxSize, const fvec4& invBoxSize) const {
+    deltaR = posJ-posI;
+    if (periodic) {
+        if (triclinic) {
+            deltaR -= periodicBoxVec4[2]*floorf(deltaR[2]*recipBoxSize[2]+0.5f);
+            deltaR -= periodicBoxVec4[1]*floorf(deltaR[1]*recipBoxSize[1]+0.5f);
+            deltaR -= periodicBoxVec4[0]*floorf(deltaR[0]*recipBoxSize[0]+0.5f);
+        }
+        else {
+            fvec4 base = round(deltaR*invBoxSize)*boxSize;
+            deltaR = deltaR-base;
+        }
+    }
+    r2 = dot3(deltaR, deltaR);
+}
+
+float CpuDPMENonbondedForce::erfcApprox(float x) {
+    float x1 = x*erfcDXInv;
+    int index = min((int) floor(x1), NUM_TABLE_POINTS);
+    float coeff2 = x1-index;
+    float coeff1 = 1.0f-coeff2;
+    return coeff1*erfcTable[index] + coeff2*erfcTable[index+1];
+}
+

--- a/platforms/cpu/src/CpuDPMENonbondedForceVec4.cpp
+++ b/platforms/cpu/src/CpuDPMENonbondedForceVec4.cpp
@@ -1,0 +1,422 @@
+
+/* Portions copyright (c) 2006-2015 Stanford University and Simbios.
+ * Contributors: Pande Group
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject
+ * to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS, CONTRIBUTORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "SimTKOpenMMUtilities.h"
+#include "CpuDPMENonbondedForceVec4.h"
+#include <algorithm>
+
+using namespace std;
+using namespace OpenMM;
+
+/**
+ * Factory method to create a CpuDPMENonbondedForceVec4.
+ */
+CpuDPMENonbondedForce* createCpuDPMENonbondedForceVec4() {
+    return new CpuDPMENonbondedForceVec4();
+}
+
+/**---------------------------------------------------------------------------------------
+
+   CpuDPMENonbondedForceVec4 constructor
+
+   --------------------------------------------------------------------------------------- */
+
+CpuDPMENonbondedForceVec4::CpuDPMENonbondedForceVec4() {
+}
+
+enum PeriodicType {NoPeriodic, PeriodicPerAtom, PeriodicPerInteraction, PeriodicTriclinic};
+
+void CpuDPMENonbondedForceVec4::calculateBlockIxn(int blockIndex, float* forces, double* totalEnergy, const fvec4& boxSize, const fvec4& invBoxSize) {
+    // Determine whether we need to apply periodic boundary conditions.
+    
+    PeriodicType periodicType;
+    fvec4 blockCenter;
+    if (!periodic) {
+        periodicType = NoPeriodic;
+        blockCenter = 0.0f;
+    }
+    else {
+        const int* blockAtom = &neighborList->getSortedAtoms()[4*blockIndex];
+        float minx, maxx, miny, maxy, minz, maxz;
+        minx = maxx = posq[4*blockAtom[0]];
+        miny = maxy = posq[4*blockAtom[0]+1];
+        minz = maxz = posq[4*blockAtom[0]+2];
+        for (int i = 1; i < 4; i++) {
+            minx = min(minx, posq[4*blockAtom[i]]);
+            maxx = max(maxx, posq[4*blockAtom[i]]);
+            miny = min(miny, posq[4*blockAtom[i]+1]);
+            maxy = max(maxy, posq[4*blockAtom[i]+1]);
+            minz = min(minz, posq[4*blockAtom[i]+2]);
+            maxz = max(maxz, posq[4*blockAtom[i]+2]);
+        }
+        blockCenter = fvec4(0.5f*(minx+maxx), 0.5f*(miny+maxy), 0.5f*(minz+maxz), 0.0f);
+        if (!(minx < cutoffDistance || miny < cutoffDistance || minz < cutoffDistance ||
+                maxx > boxSize[0]-cutoffDistance || maxy > boxSize[1]-cutoffDistance || maxz > boxSize[2]-cutoffDistance))
+            periodicType = NoPeriodic;
+        else if (triclinic)
+            periodicType = PeriodicTriclinic;
+        else if (0.5f*(boxSize[0]-(maxx-minx)) >= cutoffDistance &&
+                 0.5f*(boxSize[1]-(maxy-miny)) >= cutoffDistance &&
+                 0.5f*(boxSize[2]-(maxz-minz)) >= cutoffDistance)
+            periodicType = PeriodicPerAtom;
+        else
+            periodicType = PeriodicPerInteraction;
+    }
+    
+    // Call the appropriate version depending on what calculation is required for periodic boundary conditions.
+    
+    if (periodicType == NoPeriodic)
+        calculateBlockIxnImpl<NoPeriodic>(blockIndex, forces, totalEnergy, boxSize, invBoxSize, blockCenter);
+    else if (periodicType == PeriodicPerAtom)
+        calculateBlockIxnImpl<PeriodicPerAtom>(blockIndex, forces, totalEnergy, boxSize, invBoxSize, blockCenter);
+    else if (periodicType == PeriodicPerInteraction)
+        calculateBlockIxnImpl<PeriodicPerInteraction>(blockIndex, forces, totalEnergy, boxSize, invBoxSize, blockCenter);
+    else if (periodicType == PeriodicTriclinic)
+        calculateBlockIxnImpl<PeriodicTriclinic>(blockIndex, forces, totalEnergy, boxSize, invBoxSize, blockCenter);
+}
+
+template <int PERIODIC_TYPE>
+void CpuDPMENonbondedForceVec4::calculateBlockIxnImpl(int blockIndex, float* forces, double* totalEnergy, const fvec4& boxSize, const fvec4& invBoxSize, const fvec4& blockCenter) {
+    // Load the positions and parameters of the atoms in the block.
+    
+    const int* blockAtom = &neighborList->getSortedAtoms()[4*blockIndex];
+    fvec4 blockAtomPosq[4];
+    fvec4 blockAtomForceX(0.0f), blockAtomForceY(0.0f), blockAtomForceZ(0.0f);
+    for (int i = 0; i < 4; i++) {
+        blockAtomPosq[i] = fvec4(posq+4*blockAtom[i]);
+        if (PERIODIC_TYPE == PeriodicPerAtom)
+            blockAtomPosq[i] -= floor((blockAtomPosq[i]-blockCenter)*invBoxSize+0.5f)*boxSize;
+    }
+    fvec4 blockAtomX = fvec4(blockAtomPosq[0][0], blockAtomPosq[1][0], blockAtomPosq[2][0], blockAtomPosq[3][0]);
+    fvec4 blockAtomY = fvec4(blockAtomPosq[0][1], blockAtomPosq[1][1], blockAtomPosq[2][1], blockAtomPosq[3][1]);
+    fvec4 blockAtomZ = fvec4(blockAtomPosq[0][2], blockAtomPosq[1][2], blockAtomPosq[2][2], blockAtomPosq[3][2]);
+    fvec4 blockAtomCharge = fvec4(ONE_4PI_EPS0)*fvec4(blockAtomPosq[0][3], blockAtomPosq[1][3], blockAtomPosq[2][3], blockAtomPosq[3][3]);
+    fvec4 blockAtomSigma(atomParameters[blockAtom[0]].first, atomParameters[blockAtom[1]].first, atomParameters[blockAtom[2]].first, atomParameters[blockAtom[3]].first);
+    fvec4 blockAtomEpsilon(atomParameters[blockAtom[0]].second, atomParameters[blockAtom[1]].second, atomParameters[blockAtom[2]].second, atomParameters[blockAtom[3]].second);
+    const bool needPeriodic = (PERIODIC_TYPE == PeriodicPerInteraction || PERIODIC_TYPE == PeriodicTriclinic);
+    const float invSwitchingInterval = 1/(cutoffDistance-switchingDistance);
+    
+    // Loop over neighbors for this block.
+    
+    const vector<int>& neighbors = neighborList->getBlockNeighbors(blockIndex);
+    const vector<char>& exclusions = neighborList->getBlockExclusions(blockIndex);
+    for (int i = 0; i < (int) neighbors.size(); i++) {
+        // Load the next neighbor.
+        
+        int atom = neighbors[i];
+        
+        // Compute the distances to the block atoms.
+        
+        fvec4 dx, dy, dz, r2;
+        fvec4 atomPos(posq+4*atom);
+        if (PERIODIC_TYPE == PeriodicPerAtom)
+            atomPos -= floor((atomPos-blockCenter)*invBoxSize+0.5f)*boxSize;
+        getDeltaR<PERIODIC_TYPE>(atomPos, blockAtomX, blockAtomY, blockAtomZ, dx, dy, dz, r2, needPeriodic, boxSize, invBoxSize);
+        ivec4 include;
+        char excl = exclusions[i];
+        if (excl == 0)
+            include = -1;
+        else
+            include = ivec4(excl&1 ? 0 : -1, excl&2 ? 0 : -1, excl&4 ? 0 : -1, excl&8 ? 0 : -1);
+        include = include & (r2 < cutoffDistance*cutoffDistance);
+        if (!any(include))
+            continue; // No interactions to compute.
+        
+        // Compute the interactions.
+        
+        fvec4 inverseR = rsqrt(r2);
+        fvec4 energy, dEdR;
+        float atomEpsilon = atomParameters[atom].second;
+        if (atomEpsilon != 0.0f) {
+            fvec4 sig = blockAtomSigma+atomParameters[atom].first;
+            fvec4 sig2 = inverseR*sig;
+            sig2 *= sig2;
+            fvec4 sig6 = sig2*sig2*sig2;
+            fvec4 epsSig6 = blockAtomEpsilon*atomEpsilon*sig6;
+            dEdR = epsSig6*(12.0f*sig6 - 6.0f);
+            energy = epsSig6*(sig6-1.0f);
+            if (useSwitch) {
+                fvec4 r = r2*inverseR;
+                fvec4 t = blend(0.0f, (r-switchingDistance)*invSwitchingInterval, r>switchingDistance);
+                fvec4 switchValue = 1+t*t*t*(-10.0f+t*(15.0f-t*6.0f));
+                fvec4 switchDeriv = t*t*(-30.0f+t*(60.0f-t*30.0f))*invSwitchingInterval;
+                dEdR = switchValue*dEdR - energy*switchDeriv*r;
+                energy *= switchValue;
+            }
+        }
+        else {
+            energy = 0.0f;
+            dEdR = 0.0f;
+        }
+        fvec4 chargeProd = blockAtomCharge*posq[4*atom+3];
+        if (cutoff)
+            dEdR += chargeProd*(inverseR-2.0f*krf*r2);
+        else
+            dEdR += chargeProd*inverseR;
+        dEdR *= inverseR*inverseR;
+
+        // Accumulate energies.
+
+        fvec4 one(1.0f);
+        if (totalEnergy) {
+            if (cutoff)
+                energy += chargeProd*(inverseR+krf*r2-crf);
+            else
+                energy += chargeProd*inverseR;
+            energy = blend(0.0f, energy, include);
+            *totalEnergy += dot4(energy, one);
+        }
+
+        // Accumulate forces.
+
+        dEdR = blend(0.0f, dEdR, include);
+        fvec4 fx = dx*dEdR;
+        fvec4 fy = dy*dEdR;
+        fvec4 fz = dz*dEdR;
+        blockAtomForceX += fx;
+        blockAtomForceY += fy;
+        blockAtomForceZ += fz;
+        float* atomForce = forces+4*atom;
+        atomForce[0] -= dot4(fx, one);
+        atomForce[1] -= dot4(fy, one);
+        atomForce[2] -= dot4(fz, one);
+    }
+    
+    // Record the forces on the block atoms.
+
+    fvec4 f[4] = {blockAtomForceX, blockAtomForceY, blockAtomForceZ, 0.0f};
+    transpose(f[0], f[1], f[2], f[3]);
+    for (int j = 0; j < 4; j++)
+        (fvec4(forces+4*blockAtom[j])+f[j]).store(forces+4*blockAtom[j]);
+  }
+
+void CpuDPMENonbondedForceVec4::calculateBlockEwaldIxn(int blockIndex, float* forces, double* totalEnergy, const fvec4& boxSize, const fvec4& invBoxSize) {
+    // Determine whether we need to apply periodic boundary conditions.
+    
+    PeriodicType periodicType;
+    fvec4 blockCenter;
+    if (!periodic) {
+        periodicType = NoPeriodic;
+        blockCenter = 0.0f;
+    }
+    else {
+        const int* blockAtom = &neighborList->getSortedAtoms()[4*blockIndex];
+        float minx, maxx, miny, maxy, minz, maxz;
+        minx = maxx = posq[4*blockAtom[0]];
+        miny = maxy = posq[4*blockAtom[0]+1];
+        minz = maxz = posq[4*blockAtom[0]+2];
+        for (int i = 1; i < 4; i++) {
+            minx = min(minx, posq[4*blockAtom[i]]);
+            maxx = max(maxx, posq[4*blockAtom[i]]);
+            miny = min(miny, posq[4*blockAtom[i]+1]);
+            maxy = max(maxy, posq[4*blockAtom[i]+1]);
+            minz = min(minz, posq[4*blockAtom[i]+2]);
+            maxz = max(maxz, posq[4*blockAtom[i]+2]);
+        }
+        blockCenter = fvec4(0.5f*(minx+maxx), 0.5f*(miny+maxy), 0.5f*(minz+maxz), 0.0f);
+        if (!(minx < cutoffDistance || miny < cutoffDistance || minz < cutoffDistance ||
+                maxx > boxSize[0]-cutoffDistance || maxy > boxSize[1]-cutoffDistance || maxz > boxSize[2]-cutoffDistance))
+            periodicType = NoPeriodic;
+        else if (triclinic)
+            periodicType = PeriodicTriclinic;
+        else if (0.5f*(boxSize[0]-(maxx-minx)) >= cutoffDistance &&
+                 0.5f*(boxSize[1]-(maxy-miny)) >= cutoffDistance &&
+                 0.5f*(boxSize[2]-(maxz-minz)) >= cutoffDistance)
+            periodicType = PeriodicPerAtom;
+        else
+            periodicType = PeriodicPerInteraction;
+    }
+    
+    // Call the appropriate version depending on what calculation is required for periodic boundary conditions.
+    
+    if (periodicType == NoPeriodic)
+        calculateBlockEwaldIxnImpl<NoPeriodic>(blockIndex, forces, totalEnergy, boxSize, invBoxSize, blockCenter);
+    else if (periodicType == PeriodicPerAtom)
+        calculateBlockEwaldIxnImpl<PeriodicPerAtom>(blockIndex, forces, totalEnergy, boxSize, invBoxSize, blockCenter);
+    else if (periodicType == PeriodicPerInteraction)
+        calculateBlockEwaldIxnImpl<PeriodicPerInteraction>(blockIndex, forces, totalEnergy, boxSize, invBoxSize, blockCenter);
+    else if (periodicType == PeriodicTriclinic)
+        calculateBlockEwaldIxnImpl<PeriodicTriclinic>(blockIndex, forces, totalEnergy, boxSize, invBoxSize, blockCenter);
+}
+
+template <int PERIODIC_TYPE>
+void CpuDPMENonbondedForceVec4::calculateBlockEwaldIxnImpl(int blockIndex, float* forces, double* totalEnergy, const fvec4& boxSize, const fvec4& invBoxSize, const fvec4& blockCenter) {
+    // Load the positions and parameters of the atoms in the block.
+    
+    const int* blockAtom = &neighborList->getSortedAtoms()[4*blockIndex];
+    fvec4 blockAtomPosq[4];
+    fvec4 blockAtomForceX(0.0f), blockAtomForceY(0.0f), blockAtomForceZ(0.0f);
+    for (int i = 0; i < 4; i++) {
+        blockAtomPosq[i] = fvec4(posq+4*blockAtom[i]);
+        if (PERIODIC_TYPE == PeriodicPerAtom)
+            blockAtomPosq[i] -= floor((blockAtomPosq[i]-blockCenter)*invBoxSize+0.5f)*boxSize;
+    }
+    fvec4 blockAtomX = fvec4(blockAtomPosq[0][0], blockAtomPosq[1][0], blockAtomPosq[2][0], blockAtomPosq[3][0]);
+    fvec4 blockAtomY = fvec4(blockAtomPosq[0][1], blockAtomPosq[1][1], blockAtomPosq[2][1], blockAtomPosq[3][1]);
+    fvec4 blockAtomZ = fvec4(blockAtomPosq[0][2], blockAtomPosq[1][2], blockAtomPosq[2][2], blockAtomPosq[3][2]);
+    fvec4 blockAtomCharge = fvec4(ONE_4PI_EPS0)*fvec4(blockAtomPosq[0][3], blockAtomPosq[1][3], blockAtomPosq[2][3], blockAtomPosq[3][3]);
+    fvec4 blockAtomSigma(atomParameters[blockAtom[0]].first, atomParameters[blockAtom[1]].first, atomParameters[blockAtom[2]].first, atomParameters[blockAtom[3]].first);
+    fvec4 blockAtomEpsilon(atomParameters[blockAtom[0]].second, atomParameters[blockAtom[1]].second, atomParameters[blockAtom[2]].second, atomParameters[blockAtom[3]].second);
+    const bool needPeriodic = (PERIODIC_TYPE == PeriodicPerInteraction || PERIODIC_TYPE == PeriodicTriclinic);
+    const float invSwitchingInterval = 1/(cutoffDistance-switchingDistance);
+    
+    // Loop over neighbors for this block.
+    
+    const vector<int>& neighbors = neighborList->getBlockNeighbors(blockIndex);
+    const vector<char>& exclusions = neighborList->getBlockExclusions(blockIndex);
+    for (int i = 0; i < (int) neighbors.size(); i++) {
+        // Load the next neighbor.
+        
+        int atom = neighbors[i];
+        
+        // Compute the distances to the block atoms.
+        
+        fvec4 dx, dy, dz, r2;
+        fvec4 atomPos(posq+4*atom);
+        if (PERIODIC_TYPE == PeriodicPerAtom)
+            atomPos -= floor((atomPos-blockCenter)*invBoxSize+0.5f)*boxSize;
+        getDeltaR<PERIODIC_TYPE>(atomPos, blockAtomX, blockAtomY, blockAtomZ, dx, dy, dz, r2, needPeriodic, boxSize, invBoxSize);
+        ivec4 include;
+        char excl = exclusions[i];
+        if (excl == 0)
+            include = -1;
+        else
+            include = ivec4(excl&1 ? 0 : -1, excl&2 ? 0 : -1, excl&4 ? 0 : -1, excl&8 ? 0 : -1);
+        include = include & (r2 < cutoffDistance*cutoffDistance);
+        if (!any(include))
+            continue; // No interactions to compute.
+        
+        // Compute the interactions.
+        
+        fvec4 inverseR = rsqrt(r2);
+        fvec4 r = r2*inverseR;
+        fvec4 energy, dEdR;
+        float atomEpsilon = atomParameters[atom].second;
+        if (atomEpsilon != 0.0f) {
+            fvec4 sig = blockAtomSigma+atomParameters[atom].first;
+            fvec4 sig2 = inverseR*sig;
+            sig2 *= sig2;
+            fvec4 sig6 = sig2*sig2*sig2;
+            fvec4 epsSig6 = blockAtomEpsilon*atomEpsilon*sig6;
+            dEdR = epsSig6*(12.0f*sig6 - 6.0f);
+            energy = epsSig6*(sig6-1.0f);
+            if (useSwitch) {
+                fvec4 t = blend(0.0f, (r-switchingDistance)*invSwitchingInterval, r>switchingDistance);
+                fvec4 switchValue = 1+t*t*t*(-10.0f+t*(15.0f-t*6.0f));
+                fvec4 switchDeriv = t*t*(-30.0f+t*(60.0f-t*30.0f))*invSwitchingInterval;
+                dEdR = switchValue*dEdR - energy*switchDeriv*r;
+                energy *= switchValue;
+            }
+        }
+        else {
+            energy = 0.0f;
+            dEdR = 0.0f;
+        }
+        fvec4 chargeProd = blockAtomCharge*posq[4*atom+3];
+        dEdR += chargeProd*inverseR*ewaldScaleFunction(r);
+        dEdR *= inverseR*inverseR;        
+
+        // Accumulate energies.
+
+        fvec4 one(1.0f);
+        if (totalEnergy) {
+            energy += chargeProd*inverseR*erfcApprox(alphaEwald*r);
+            energy = blend(0.0f, energy, include);
+            *totalEnergy += dot4(energy, one);
+        }
+
+        // Accumulate forces.
+
+        dEdR = blend(0.0f, dEdR, include);
+        fvec4 fx = dx*dEdR;
+        fvec4 fy = dy*dEdR;
+        fvec4 fz = dz*dEdR;
+        blockAtomForceX += fx;
+        blockAtomForceY += fy;
+        blockAtomForceZ += fz;
+        float* atomForce = forces+4*atom;
+        atomForce[0] -= dot4(fx, one);
+        atomForce[1] -= dot4(fy, one);
+        atomForce[2] -= dot4(fz, one);
+    }
+    
+    // Record the forces on the block atoms.
+    
+    fvec4 f[4] = {blockAtomForceX, blockAtomForceY, blockAtomForceZ, 0.0f};
+    transpose(f[0], f[1], f[2], f[3]);
+    for (int j = 0; j < 4; j++)
+        (fvec4(forces+4*blockAtom[j])+f[j]).store(forces+4*blockAtom[j]);
+}
+
+template <int PERIODIC_TYPE>
+void CpuDPMENonbondedForceVec4::getDeltaR(const fvec4& posI, const fvec4& x, const fvec4& y, const fvec4& z, fvec4& dx, fvec4& dy, fvec4& dz, fvec4& r2, bool periodic, const fvec4& boxSize, const fvec4& invBoxSize) const {
+    dx = x-posI[0];
+    dy = y-posI[1];
+    dz = z-posI[2];
+    if (PERIODIC_TYPE == PeriodicTriclinic) {
+        fvec4 scale3 = floor(dz*recipBoxSize[2]+0.5f);
+        dx -= scale3*periodicBoxVectors[2][0];
+        dy -= scale3*periodicBoxVectors[2][1];
+        dz -= scale3*periodicBoxVectors[2][2];
+        fvec4 scale2 = floor(dy*recipBoxSize[1]+0.5f);
+        dx -= scale2*periodicBoxVectors[1][0];
+        dy -= scale2*periodicBoxVectors[1][1];
+        fvec4 scale1 = floor(dx*recipBoxSize[0]+0.5f);
+        dx -= scale1*periodicBoxVectors[0][0];
+    }
+    else if (PERIODIC_TYPE == PeriodicPerInteraction) {
+        dx -= round(dx*invBoxSize[0])*boxSize[0];
+        dy -= round(dy*invBoxSize[1])*boxSize[1];
+        dz -= round(dz*invBoxSize[2])*boxSize[2];
+    }
+    r2 = dx*dx + dy*dy + dz*dz;
+}
+
+fvec4 CpuDPMENonbondedForceVec4::erfcApprox(const fvec4& x) {
+    fvec4 x1 = x*erfcDXInv;
+    ivec4 index = min(floor(x1), NUM_TABLE_POINTS);
+    fvec4 coeff2 = x1-index;
+    fvec4 coeff1 = 1.0f-coeff2;
+    fvec4 t1(&erfcTable[index[0]]);
+    fvec4 t2(&erfcTable[index[1]]);
+    fvec4 t3(&erfcTable[index[2]]);
+    fvec4 t4(&erfcTable[index[3]]);
+    transpose(t1, t2, t3, t4);
+    return coeff1*t1 + coeff2*t2;
+}
+
+fvec4 CpuDPMENonbondedForceVec4::ewaldScaleFunction(const fvec4& x) {
+    // Compute the tabulated Ewald scale factor: erfc(alpha*r) + 2*alpha*r*exp(-alpha*alpha*r*r)/sqrt(PI)
+
+    fvec4 x1 = x*ewaldDXInv;
+    ivec4 index = min(floor(x1), NUM_TABLE_POINTS);
+    fvec4 coeff2 = x1-index;
+    fvec4 coeff1 = 1.0f-coeff2;
+    fvec4 t1(&ewaldScaleTable[index[0]]);
+    fvec4 t2(&ewaldScaleTable[index[1]]);
+    fvec4 t3(&ewaldScaleTable[index[2]]);
+    fvec4 t4(&ewaldScaleTable[index[3]]);
+    transpose(t1, t2, t3, t4);
+    return coeff1*t1 + coeff2*t2;
+}

--- a/platforms/cpu/src/CpuPlatform.cpp
+++ b/platforms/cpu/src/CpuPlatform.cpp
@@ -67,6 +67,7 @@ CpuPlatform::CpuPlatform() {
     registerKernelFactory(CalcPeriodicTorsionForceKernel::Name(), factory);
     registerKernelFactory(CalcRBTorsionForceKernel::Name(), factory);
     registerKernelFactory(CalcNonbondedForceKernel::Name(), factory);
+    registerKernelFactory(CalcDPMENonbondedForceKernel::Name(), factory);
     registerKernelFactory(CalcCustomNonbondedForceKernel::Name(), factory);
     registerKernelFactory(CalcCustomManyParticleForceKernel::Name(), factory);
     registerKernelFactory(CalcGBSAOBCForceKernel::Name(), factory);

--- a/platforms/cpu/tests/TestCpuDPMENonbondedForce.cpp
+++ b/platforms/cpu/tests/TestCpuDPMENonbondedForce.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2013-2016 Stanford University and the Authors.      *
+ * Portions copyright (c) 2015 Stanford University and the Authors.           *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -29,39 +29,8 @@
  * USE OR OTHER DEALINGS IN THE SOFTWARE.                                     *
  * -------------------------------------------------------------------------- */
 
-#include "CpuKernelFactory.h"
-#include "CpuKernels.h"
-#include "CpuPlatform.h"
-#include "openmm/internal/ContextImpl.h"
-#include "openmm/OpenMMException.h"
+#include "CpuTests.h"
+#include "TestDPMENonbondedForce.h"
 
-using namespace OpenMM;
-
-KernelImpl* CpuKernelFactory::createKernelImpl(std::string name, const Platform& platform, ContextImpl& context) const {
-    CpuPlatform::PlatformData& data = CpuPlatform::getPlatformData(context);
-    if (name == CalcForcesAndEnergyKernel::Name())
-        return new CpuCalcForcesAndEnergyKernel(name, platform, data, context);
-    if (name == CalcHarmonicAngleForceKernel::Name())
-        return new CpuCalcHarmonicAngleForceKernel(name, platform, data);
-    if (name == CalcPeriodicTorsionForceKernel::Name())
-        return new CpuCalcPeriodicTorsionForceKernel(name, platform, data);
-    if (name == CalcRBTorsionForceKernel::Name())
-        return new CpuCalcRBTorsionForceKernel(name, platform, data);
-    if (name == CalcNonbondedForceKernel::Name())
-        return new CpuCalcNonbondedForceKernel(name, platform, data);
-    if (name == CalcDPMENonbondedForceKernel::Name())
-        return new CpuCalcDPMENonbondedForceKernel(name, platform, data);
-    if (name == CalcCustomNonbondedForceKernel::Name())
-        return new CpuCalcCustomNonbondedForceKernel(name, platform, data);
-    if (name == CalcCustomManyParticleForceKernel::Name())
-        return new CpuCalcCustomManyParticleForceKernel(name, platform, data);
-    if (name == CalcGBSAOBCForceKernel::Name())
-        return new CpuCalcGBSAOBCForceKernel(name, platform, data);
-    if (name == CalcCustomGBForceKernel::Name())
-        return new CpuCalcCustomGBForceKernel(name, platform, data);
-    if (name == CalcGayBerneForceKernel::Name())
-        return new CpuCalcGayBerneForceKernel(name, platform, data);
-    if (name == IntegrateLangevinStepKernel::Name())
-        return new CpuIntegrateLangevinStepKernel(name, platform, data);
-    throw OpenMMException((std::string("Tried to create kernel with illegal kernel name '") + name + "'").c_str());
+void runPlatformTests() {
 }

--- a/platforms/reference/include/ReferenceDPMECoulomb14.h
+++ b/platforms/reference/include/ReferenceDPMECoulomb14.h
@@ -1,0 +1,73 @@
+
+/* Portions copyright (c) 2006-2016 Stanford University and Simbios.
+ * Contributors: Pande Group
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject
+ * to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS, CONTRIBUTORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef __ReferenceDPMECoulomb14_H__
+#define __ReferenceDPMECoulomb14_H__
+
+#include "ReferenceBondIxn.h"
+#include "openmm/internal/windowsExport.h"
+
+namespace OpenMM {
+
+class OPENMM_EXPORT ReferenceDPMECoulomb14 : public ReferenceBondIxn {
+
+   public:
+
+      /**---------------------------------------------------------------------------------------
+      
+         Constructor
+      
+         --------------------------------------------------------------------------------------- */
+
+       ReferenceDPMECoulomb14();
+
+      /**---------------------------------------------------------------------------------------
+      
+         Destructor
+      
+         --------------------------------------------------------------------------------------- */
+
+       ~ReferenceDPMECoulomb14();
+
+      /**---------------------------------------------------------------------------------------
+      
+         Calculate Ryckaert-Bellemans bond ixn
+      
+         @param atomIndices      atom indices of 4 atoms in bond
+         @param atomCoordinates  atom coordinates
+         @param parameters       six RB parameters
+         @param forces           force array (forces added to current values)
+         @param totalEnergy      if not null, the energy will be added to this
+            
+         --------------------------------------------------------------------------------------- */
+      
+      void calculateBondIxn(int* atomIndices, std::vector<OpenMM::RealVec>& atomCoordinates,
+                            RealOpenMM* parameters, std::vector<OpenMM::RealVec>& forces,
+                            RealOpenMM* totalEnergy, double* energyParamDerivs);
+
+};
+
+} // namespace OpenMM
+
+#endif // __ReferenceDPMECoulomb14_H__

--- a/platforms/reference/include/ReferenceDPMECoulombIxn.h
+++ b/platforms/reference/include/ReferenceDPMECoulombIxn.h
@@ -1,0 +1,174 @@
+
+/* Portions copyright (c) 2006-2013 Stanford University and Simbios.
+ * Contributors: Pande Group
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject
+ * to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS, CONTRIBUTORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef __ReferenceDPMECoulombIxn_H__
+#define __ReferenceDPMECoulombIxn_H__
+
+#include "ReferencePairIxn.h"
+#include "ReferenceNeighborList.h"
+
+namespace OpenMM {
+
+class ReferenceDPMECoulombIxn {
+
+   private:
+       
+      bool cutoff;
+      bool useSwitch;
+      bool periodic;
+      bool ewald;
+      bool pme_setup, dpme_setup;
+      const OpenMM::NeighborList* neighborList;
+      OpenMM::RealVec periodicBoxVectors[3];
+      RealOpenMM cutoffDistance, dpmeShift;
+      RealOpenMM krf, crf;
+      RealOpenMM alphaEwald, alphaDispersionEwald;
+      int numRx, numRy, numRz;
+      int meshDim[3], dispersionMeshDim[3];
+
+      // parameter indices
+
+      static const int SigIndex = 0;
+      static const int EpsIndex = 1;
+      static const int   QIndex = 2;
+
+
+   public:
+
+      /**---------------------------------------------------------------------------------------
+      
+         Constructor
+      
+         --------------------------------------------------------------------------------------- */
+
+       ReferenceDPMECoulombIxn();
+
+      /**---------------------------------------------------------------------------------------
+      
+         Destructor
+      
+         --------------------------------------------------------------------------------------- */
+
+       ~ReferenceDPMECoulombIxn();
+
+      /**---------------------------------------------------------------------------------------
+      
+         Set the force to use a cutoff.
+      
+         @param distance            the cutoff distance
+         @param neighbors           the neighbor list to use
+         @param solventDielectric   the dielectric constant of the bulk solvent
+      
+         --------------------------------------------------------------------------------------- */
+      
+      void setUseCutoff(RealOpenMM distance, const OpenMM::NeighborList& neighbors, RealOpenMM solventDielectric);
+
+      
+      /**---------------------------------------------------------------------------------------
+      
+         Set the force to use periodic boundary conditions.  This requires that a cutoff has
+         already been set, and the smallest side of the periodic box is at least twice the cutoff
+         distance.
+      
+         @param vectors    the vectors defining the periodic box
+      
+         --------------------------------------------------------------------------------------- */
+      
+      void setPeriodic(OpenMM::RealVec* vectors);
+       
+     
+      /**---------------------------------------------------------------------------------------
+
+         Set the force to use Particle-Mesh Ewald (PME) summation for dispersion.
+
+         @param dalpha             the dispersion Ewald separation parameter
+         @param dispersionGridSize the dimensions of the disperson mesh
+
+         --------------------------------------------------------------------------------------- */
+
+      void setupDispersionPME(RealOpenMM dalpha, int dispersionMeshSize[3]);
+
+
+      /**---------------------------------------------------------------------------------------
+      
+         Set the force to use Particle-Mesh Ewald (PME) summation.
+      
+         @param alpha    the Ewald separation parameter
+         @param gridSize the dimensions of the mesh
+      
+         --------------------------------------------------------------------------------------- */
+      
+      void setupPME(RealOpenMM alpha, int meshSize[3]);
+      
+      /**---------------------------------------------------------------------------------------
+      
+         Calculate DPME Coulomb pair ixn
+      
+         @param numberOfAtoms    number of atoms
+         @param atomCoordinates  atom coordinates
+         @param atomParameters   atom parameters (charges, c6, c12, ...)     atomParameters[atomIndex][paramterIndex]
+         @param exclusions       atom exclusion indices
+                                 exclusions[atomIndex] contains the list of exclusions for that atom
+         @param fixedParameters  non atom parameters (not currently used)
+         @param forces           force array (forces added)
+         @param energyByAtom     atom energy
+         @param totalEnergy      total energy
+         @param includeDirect      true if direct space interactions should be included
+         @param includeReciprocal  true if reciprocal space interactions should be included
+      
+         --------------------------------------------------------------------------------------- */
+          
+      void calculatePairIxn(int numberOfAtoms, std::vector<OpenMM::RealVec>& atomCoordinates,
+                            RealOpenMM** atomParameters, std::vector<std::set<int> >& exclusions,
+                            RealOpenMM* fixedParameters, std::vector<OpenMM::RealVec>& forces,
+                            RealOpenMM* energyByAtom, RealOpenMM* totalEnergy, bool includeDirect, bool includeReciprocal) const;
+
+private:
+      /**---------------------------------------------------------------------------------------
+      
+         Calculate Ewald ixn
+      
+         @param numberOfAtoms    number of atoms
+         @param atomCoordinates  atom coordinates
+         @param atomParameters   atom parameters (charges, c6, c12, ...)     atomParameters[atomIndex][paramterIndex]
+         @param exclusions       atom exclusion indices
+                                 exclusions[atomIndex] contains the list of exclusions for that atom
+         @param fixedParameters  non atom parameters (not currently used)
+         @param forces           force array (forces added)
+         @param energyByAtom     atom energy
+         @param totalEnergy      total energy
+         @param includeDirect      true if direct space interactions should be included
+         @param includeReciprocal  true if reciprocal space interactions should be included
+            
+         --------------------------------------------------------------------------------------- */
+          
+      void calculatePMEIxn(int numberOfAtoms, std::vector<OpenMM::RealVec>& atomCoordinates,
+                            RealOpenMM** atomParameters, std::vector<std::set<int> >& exclusions,
+                            RealOpenMM* fixedParameters, std::vector<OpenMM::RealVec>& forces,
+                            RealOpenMM* energyByAtom, RealOpenMM* totalEnergy, bool includeDirect, bool includeReciprocal) const;
+};
+
+} // namespace OpenMM
+
+#endif // __ReferenceDPMECoulombIxn_H__

--- a/platforms/reference/include/ReferenceKernels.h
+++ b/platforms/reference/include/ReferenceKernels.h
@@ -616,6 +616,67 @@ private:
     NeighborList* neighborList;
 };
 
+
+/**
+ * This kernel is invoked by DPMENonbondedForce to calculate the forces acting on the system.
+ */
+class ReferenceCalcDPMENonbondedForceKernel : public CalcDPMENonbondedForceKernel {
+public:
+    ReferenceCalcDPMENonbondedForceKernel(std::string name, const Platform& platform) : CalcDPMENonbondedForceKernel(name, platform) {
+    }
+    ~ReferenceCalcDPMENonbondedForceKernel();
+    /**
+     * Initialize the kernel.
+     * 
+     * @param system     the System this kernel will be applied to
+     * @param force      the DPMENonbondedForce this kernel will be used for
+     */
+    void initialize(const System& system, const DPMENonbondedForce& force);
+    /**
+     * Execute the kernel to calculate the forces and/or energy.
+     *
+     * @param context        the context in which to execute this kernel
+     * @param includeForces  true if forces should be calculated
+     * @param includeEnergy  true if the energy should be calculated
+     * @param includeReciprocal  true if reciprocal space interactions should be included
+     * @return the potential energy due to the force
+     */
+    double execute(ContextImpl& context, bool includeForces, bool includeEnergy, bool includeDirect, bool includeReciprocal);
+    /**
+     * Copy changed parameters over to a context.
+     *
+     * @param context    the context to copy parameters to
+     * @param force      the DPMENonbondedForce to copy the parameters from
+     */
+    void copyParametersToContext(ContextImpl& context, const DPMENonbondedForce& force);
+    /**
+     * Get the parameters being used for PME.
+     * 
+     * @param alpha   the separation parameter
+     * @param nx      the number of grid points along the X axis
+     * @param ny      the number of grid points along the Y axis
+     * @param nz      the number of grid points along the Z axis
+     */
+    void getPMEParameters(double& alpha, int& nx, int& ny, int& nz) const;
+    /**
+     * Get the parameters being used for dispersion PME.
+     *
+     * @param dalpha   the dispersion separation parameter
+     * @param dnx      the number of dispersion grid points along the X axis
+     * @param dny      the number of dispersion grid points along the Y axis
+     * @param dnz      the number of dispersion grid points along the Z axis
+     */
+    void getDispersionPMEParameters(double& dalpha, int& dnx, int& dny, int& dnz) const;
+private:
+    int numParticles, num14;
+    int **bonded14IndexArray;
+    RealOpenMM **particleParamArray, **bonded14ParamArray;
+    RealOpenMM nonbondedCutoff, rfDielectric, ewaldDispersionAlpha, ewaldAlpha, dispersionCoefficient;
+    int kmax[3], dispersionGridSize[3], gridSize[3];
+    std::vector<std::set<int> > exclusions;
+    NeighborList* neighborList;
+};
+
 /**
  * This kernel is invoked by CustomNonbondedForce to calculate the forces acting on the system.
  */

--- a/platforms/reference/include/ReferencePME.h
+++ b/platforms/reference/include/ReferencePME.h
@@ -86,6 +86,25 @@ pme_exec(pme_t       pme,
          const OpenMM::RealVec  periodicBoxVectors[3],
          RealOpenMM *    energy);
 
+/*
+ * Evaluate reciprocal space Dispersion PME energy and forces.
+ *
+ * Args:
+ *
+ * pme         Opaque pme_t object, must have been initialized with pme_init()
+ * x           Pointer to coordinate data array (nm)
+ * f           Pointer to force data array (will be written as kJ/mol/nm)
+ * charge      Array of C6 coefficients ((kJ/mol)^1/2 nm^3)
+ * box         Simulation cell dimensions (nm)
+ * energy      Total energy (will be written in units of kJ/mol)
+ */
+int OPENMM_EXPORT
+pme_exec_dpme(pme_t       pme,
+         const std::vector<OpenMM::RealVec>& atomCoordinates,
+         std::vector<OpenMM::RealVec>& forces,
+         const std::vector<RealOpenMM>& c6s,
+         const OpenMM::RealVec  periodicBoxVectors[3],
+         RealOpenMM *    energy);
 
 
 /* Release all memory in pme structure */

--- a/platforms/reference/src/ReferenceKernelFactory.cpp
+++ b/platforms/reference/src/ReferenceKernelFactory.cpp
@@ -48,6 +48,8 @@ KernelImpl* ReferenceKernelFactory::createKernelImpl(std::string name, const Pla
         return new ReferenceVirtualSitesKernel(name, platform);
     if (name == CalcNonbondedForceKernel::Name())
         return new ReferenceCalcNonbondedForceKernel(name, platform);
+    if (name == CalcDPMENonbondedForceKernel::Name())
+        return new ReferenceCalcDPMENonbondedForceKernel(name, platform);
     if (name == CalcCustomNonbondedForceKernel::Name())
         return new ReferenceCalcCustomNonbondedForceKernel(name, platform);
     if (name == CalcHarmonicBondForceKernel::Name())

--- a/platforms/reference/src/ReferencePlatform.cpp
+++ b/platforms/reference/src/ReferencePlatform.cpp
@@ -57,6 +57,7 @@ ReferencePlatform::ReferencePlatform() {
     registerKernelFactory(CalcCMAPTorsionForceKernel::Name(), factory);
     registerKernelFactory(CalcCustomTorsionForceKernel::Name(), factory);
     registerKernelFactory(CalcNonbondedForceKernel::Name(), factory);
+    registerKernelFactory(CalcDPMENonbondedForceKernel::Name(), factory);
     registerKernelFactory(CalcCustomNonbondedForceKernel::Name(), factory);
     registerKernelFactory(CalcGBSAOBCForceKernel::Name(), factory);
     registerKernelFactory(CalcCustomGBForceKernel::Name(), factory);

--- a/platforms/reference/src/SimTKReference/ReferenceDPMECoulomb14.cpp
+++ b/platforms/reference/src/SimTKReference/ReferenceDPMECoulomb14.cpp
@@ -1,0 +1,138 @@
+
+/* Portions copyright (c) 2006-2016 Stanford University and Simbios.
+ * Contributors: Pande Group
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject
+ * to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS, CONTRIBUTORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <string.h>
+#include <sstream>
+
+#include "SimTKOpenMMUtilities.h"
+#include "ReferenceDPMECoulomb14.h"
+#include "ReferenceForce.h"
+
+using std::vector;
+using namespace OpenMM;
+
+/**---------------------------------------------------------------------------------------
+
+   ReferenceDPMECoulomb14 constructor
+
+   --------------------------------------------------------------------------------------- */
+
+ReferenceDPMECoulomb14::ReferenceDPMECoulomb14() {
+
+   // ---------------------------------------------------------------------------------------
+
+   // static const char* methodName = "\nReferenceDPMECoulomb14::ReferenceDPMECoulomb14";
+
+   // ---------------------------------------------------------------------------------------
+
+}
+
+/**---------------------------------------------------------------------------------------
+
+   ReferenceDPMECoulomb14 destructor
+
+   --------------------------------------------------------------------------------------- */
+
+ReferenceDPMECoulomb14::~ReferenceDPMECoulomb14() {
+
+   // ---------------------------------------------------------------------------------------
+
+   // static const char* methodName = "\nReferenceDPMECoulomb14::~ReferenceDPMECoulomb14";
+
+   // ---------------------------------------------------------------------------------------
+
+}
+
+/**---------------------------------------------------------------------------------------
+
+   Calculate DPME 1-4 ixn
+
+   @param atomIndices      atom indices of 4 atoms in bond
+   @param atomCoordinates  atom coordinates
+   @param parameters       three parameters:
+                                        parameters[0]= (c12/c6)**1/6  (sigma)
+                                        parameters[1]= c6*c6/c12      (4*epsilon)
+                                        parameters[2]= epsfac*q1*q2
+   @param forces           force array (forces added to current values)
+   @param totalEnergy      if not null, the energy will be added to this
+
+   --------------------------------------------------------------------------------------- */
+
+void ReferenceDPMECoulomb14::calculateBondIxn(int* atomIndices, vector<RealVec>& atomCoordinates,
+                                     RealOpenMM* parameters, vector<RealVec>& forces,
+                                     RealOpenMM* totalEnergy, double* energyParamDerivs) {
+
+   static const std::string methodName = "\nReferenceDPMECoulomb14::calculateBondIxn";
+
+   // constants -- reduce Visual Studio warnings regarding conversions between float & double
+
+   static const RealOpenMM zero        =  0.0;
+   static const RealOpenMM one         =  1.0;
+   static const RealOpenMM two         =  2.0;
+   static const RealOpenMM three       =  3.0;
+   static const RealOpenMM six         =  6.0;
+   static const RealOpenMM twelve      = 12.0;
+   static const RealOpenMM oneM        = -1.0;
+
+   static const int threeI             = 3;
+
+   // number of parameters
+
+   static const int numberOfParameters = 3;
+
+   static const int LastAtomIndex      = 2;
+
+   RealOpenMM deltaR[2][ReferenceForce::LastDeltaRIndex];
+
+   // ---------------------------------------------------------------------------------------
+
+   // get deltaR, R2, and R between 2 atoms
+
+   int atomAIndex = atomIndices[0];
+   int atomBIndex = atomIndices[1];
+   ReferenceForce::getDeltaR(atomCoordinates[atomBIndex], atomCoordinates[atomAIndex], deltaR[0]);  
+
+   RealOpenMM r2        = deltaR[0][ReferenceForce::R2Index];
+   RealOpenMM inverseR  = one/(deltaR[0][ReferenceForce::RIndex]);
+   RealOpenMM sig2      = inverseR*parameters[0];
+              sig2     *= sig2;
+   RealOpenMM sig6      = sig2*sig2*sig2;
+
+   RealOpenMM dEdR      = parameters[1]*(twelve*sig6 - six)*sig6;
+              dEdR     += (RealOpenMM) (ONE_4PI_EPS0*parameters[2]*inverseR);
+              dEdR     *= inverseR*inverseR;
+
+   // accumulate forces
+
+   for (int ii = 0; ii < 3; ii++) {
+      RealOpenMM force        = dEdR*deltaR[0][ii];
+      forces[atomAIndex][ii] += force;
+      forces[atomBIndex][ii] -= force;
+   }
+
+   // accumulate energies
+
+   if (totalEnergy != NULL)
+       *totalEnergy += parameters[1]*(sig6 - one)*sig6 + (ONE_4PI_EPS0*parameters[2]*inverseR);
+}

--- a/platforms/reference/src/SimTKReference/ReferenceDPMECoulombIxn.cpp
+++ b/platforms/reference/src/SimTKReference/ReferenceDPMECoulombIxn.cpp
@@ -1,0 +1,427 @@
+
+/* Portions copyright (c) 2006-2013 Stanford University and Simbios.
+ * Contributors: Pande Group
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject
+ * to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS, CONTRIBUTORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <string.h>
+#include <sstream>
+#include <complex>
+#include <algorithm>
+#include <iostream>
+
+#include "SimTKOpenMMUtilities.h"
+#include "ReferenceDPMECoulombIxn.h"
+#include "ReferenceForce.h"
+#include "ReferencePME.h"
+#include "openmm/OpenMMException.h"
+#include "openmm/Units.h"
+
+// In case we're using some primitive version of Visual Studio this will
+// make sure that erf() and erfc() are defined.
+#include "openmm/internal/MSVC_erfc.h"
+
+using std::set;
+using std::vector;
+using namespace OpenMM;
+
+/**---------------------------------------------------------------------------------------
+
+   ReferenceDPMECoulombIxn constructor
+
+   --------------------------------------------------------------------------------------- */
+
+ReferenceDPMECoulombIxn::ReferenceDPMECoulombIxn() : cutoff(false), periodic(false), pme_setup(false), dpme_setup(false) {
+}
+
+/**---------------------------------------------------------------------------------------
+
+   ReferenceDPMECoulombIxn destructor
+
+   --------------------------------------------------------------------------------------- */
+
+ReferenceDPMECoulombIxn::~ReferenceDPMECoulombIxn() {
+}
+
+/**---------------------------------------------------------------------------------------
+
+     Set the force to use a cutoff.
+
+     @param distance            the cutoff distance
+     @param neighbors           the neighbor list to use
+     @param solventDielectric   the dielectric constant of the bulk solvent
+
+     --------------------------------------------------------------------------------------- */
+
+void ReferenceDPMECoulombIxn::setUseCutoff(RealOpenMM distance, const OpenMM::NeighborList& neighbors, RealOpenMM solventDielectric) {
+
+    cutoff = true;
+    cutoffDistance = distance;
+    neighborList = &neighbors;
+    krf = pow(cutoffDistance, -3.0)*(solventDielectric-1.0)/(2.0*solventDielectric+1.0);
+    crf = (1.0/cutoffDistance)*(3.0*solventDielectric)/(2.0*solventDielectric+1.0);
+}
+
+
+/**---------------------------------------------------------------------------------------
+
+     Set the force to use periodic boundary conditions.  This requires that a cutoff has
+     also been set, and the smallest side of the periodic box is at least twice the cutoff
+     distance.
+
+     @param vectors    the vectors defining the periodic box
+
+     --------------------------------------------------------------------------------------- */
+
+void ReferenceDPMECoulombIxn::setPeriodic(OpenMM::RealVec* vectors) {
+
+    assert(cutoff);
+    assert(vectors[0][0] >= 2.0*cutoffDistance);
+    assert(vectors[1][1] >= 2.0*cutoffDistance);
+    assert(vectors[2][2] >= 2.0*cutoffDistance);
+    periodic = true;
+    periodicBoxVectors[0] = vectors[0];
+    periodicBoxVectors[1] = vectors[1];
+    periodicBoxVectors[2] = vectors[2];
+}
+
+
+/**---------------------------------------------------------------------------------------
+
+     Set the force to use Particle-Mesh Ewald (PME) summation.
+
+     @param alpha  the Ewald separation parameter
+     @param gridSize the dimensions of the mesh
+
+     --------------------------------------------------------------------------------------- */
+
+void ReferenceDPMECoulombIxn::setupPME(RealOpenMM alpha, int meshSize[3]) {
+    alphaEwald = alpha;
+    meshDim[0] = meshSize[0];
+    meshDim[1] = meshSize[1];
+    meshDim[2] = meshSize[2];
+    pme_setup = true;
+}
+
+/**---------------------------------------------------------------------------------------
+
+     Set the force to use Particle-Mesh Ewald (PME) summation for dispersion.
+
+     @param alpha  the Ewald dispersion separation parameter
+     @param gridSize the dimensions of the dispersion mesh
+
+     --------------------------------------------------------------------------------------- */
+
+void ReferenceDPMECoulombIxn::setupDispersionPME(RealOpenMM dalpha, int dispersionMeshSize[3]) {
+    alphaDispersionEwald = dalpha;
+    dispersionMeshDim[0] = dispersionMeshSize[0];
+    dispersionMeshDim[1] = dispersionMeshSize[1];
+    dispersionMeshDim[2] = dispersionMeshSize[2];
+    dpme_setup = true;
+}
+
+/**---------------------------------------------------------------------------------------
+
+   Calculate PME ixn
+
+   @param numberOfAtoms    number of atoms
+   @param atomCoordinates  atom coordinates
+   @param atomParameters   atom parameters                             atomParameters[atomIndex][paramterIndex]
+   @param exclusions       atom exclusion indices
+                           exclusions[atomIndex] contains the list of exclusions for that atom
+   @param fixedParameters  non atom parameters (not currently used)
+   @param forces           force array (forces added)
+   @param energyByAtom     atom energy
+   @param totalEnergy      total energy
+   @param includeDirect      true if direct space interactions should be included
+   @param includeReciprocal  true if reciprocal space interactions should be included
+
+   --------------------------------------------------------------------------------------- */
+
+void ReferenceDPMECoulombIxn::calculatePMEIxn(int numberOfAtoms, vector<RealVec>& atomCoordinates,
+                                              RealOpenMM** atomParameters, vector<set<int> >& exclusions,
+                                              RealOpenMM* fixedParameters, vector<RealVec>& forces,
+                                              RealOpenMM* energyByAtom, RealOpenMM* totalEnergy, bool includeDirect, bool includeReciprocal) const {
+    typedef std::complex<RealOpenMM> d_complex;
+
+    static const RealOpenMM one         =  1.0;
+    static const RealOpenMM six         =  6.0;
+    static const RealOpenMM twelve      = 12.0;
+
+    RealOpenMM SQRT_PI                  = sqrt(PI_M);
+
+    RealOpenMM totalSelfEwaldEnergy     = 0.0;
+    RealOpenMM realSpaceEwaldEnergy     = 0.0;
+    RealOpenMM recipEnergy              = 0.0;
+    RealOpenMM vdwEnergy                = 0.0;
+
+    // **************************************************************************************
+    // SELF ENERGY
+    // **************************************************************************************
+
+    if(!pme_setup)
+        throw OpenMMException("setupPME must be called before computing energies or forces.");
+    if(!dpme_setup)
+        throw OpenMMException("setupDispersionPME must be called before computing energies or forces.");
+    if (includeReciprocal) {
+
+        for (int atomID = 0; atomID < numberOfAtoms; atomID++) {
+            // Electrostatic term
+            RealOpenMM selfEwaldEnergy       = (RealOpenMM) (ONE_4PI_EPS0*atomParameters[atomID][QIndex]*atomParameters[atomID][QIndex] * alphaEwald/SQRT_PI);
+            // Dispersion term
+            selfEwaldEnergy -= pow(alphaDispersionEwald, 6.0) * 64.0*pow(atomParameters[atomID][SigIndex], 6.0) * pow(atomParameters[atomID][EpsIndex], 2.0) / 12.0;
+
+            totalSelfEwaldEnergy            -= selfEwaldEnergy;
+            if (energyByAtom) {
+                energyByAtom[atomID]        -= selfEwaldEnergy;
+            }
+        }
+    }
+
+    if (totalEnergy) {
+        *totalEnergy += totalSelfEwaldEnergy;
+    }
+
+    // **************************************************************************************
+    // RECIPROCAL SPACE EWALD ENERGY AND FORCES
+    // **************************************************************************************
+    // PME
+
+    if (includeReciprocal) {
+        pme_t          pmedata; /* abstract handle for PME data */
+
+        pme_init(&pmedata,alphaEwald,numberOfAtoms,meshDim,5,1);
+        vector<RealOpenMM> charges(numberOfAtoms);
+        for (int i = 0; i < numberOfAtoms; i++)
+            charges[i] = atomParameters[i][QIndex];
+        pme_exec(pmedata,atomCoordinates,forces,charges,periodicBoxVectors,&recipEnergy);
+        pme_destroy(pmedata);
+        if (totalEnergy)
+            *totalEnergy += recipEnergy;
+
+        if (energyByAtom)
+            for (int n = 0; n < numberOfAtoms; n++)
+                energyByAtom[n] += recipEnergy;
+
+        // Dispersion reciprocal space terms
+        pme_init(&pmedata,alphaDispersionEwald,numberOfAtoms,dispersionMeshDim,5,1);
+        std::vector<RealVec> dpmeforces;
+
+        for (int i = 0; i < numberOfAtoms; i++){
+            charges[i] = 8.0*pow(atomParameters[i][SigIndex], 3.0) * atomParameters[i][EpsIndex];
+            dpmeforces.push_back(RealVec());
+        }
+        pme_exec_dpme(pmedata,atomCoordinates,dpmeforces,charges,periodicBoxVectors,&recipEnergy);
+        for (int i = 0; i < numberOfAtoms; i++){
+            forces[i][0] -= 2.0*dpmeforces[i][0];
+            forces[i][1] -= 2.0*dpmeforces[i][1];
+            forces[i][2] -= 2.0*dpmeforces[i][2];
+        }
+
+        pme_destroy(pmedata);
+
+        if (totalEnergy)
+            *totalEnergy += recipEnergy;
+
+        if (energyByAtom)
+            for (int n = 0; n < numberOfAtoms; n++)
+                energyByAtom[n] += recipEnergy;
+
+
+    }
+
+
+
+    // **************************************************************************************
+    // SHORT-RANGE ENERGY AND FORCES
+    // **************************************************************************************
+
+    if (!includeDirect)
+        return;
+    RealOpenMM totalVdwEnergy            = 0.0f;
+    RealOpenMM totalRealSpaceEwaldEnergy = 0.0f;
+
+    for (int i = 0; i < (int) neighborList->size(); i++) {
+        OpenMM::AtomPair pair = (*neighborList)[i];
+        int ii = pair.first;
+        int jj = pair.second;
+
+        RealOpenMM deltaR[2][ReferenceForce::LastDeltaRIndex];
+        ReferenceForce::getDeltaRPeriodic(atomCoordinates[jj], atomCoordinates[ii], periodicBoxVectors, deltaR[0]);
+        RealOpenMM r         = deltaR[0][ReferenceForce::RIndex];
+        RealOpenMM inverseR  = one/(deltaR[0][ReferenceForce::RIndex]);
+        RealOpenMM alphaR    = alphaEwald * r;
+        RealOpenMM dalphaR   = alphaDispersionEwald * r;
+        RealOpenMM dar2 = dalphaR*dalphaR;
+        RealOpenMM dar4 = dar2*dar2;
+        RealOpenMM dar6 = dar4*dar2;
+        RealOpenMM inverseR2 = inverseR*inverseR;
+
+
+
+        RealOpenMM dEdR      = (RealOpenMM) (ONE_4PI_EPS0 * atomParameters[ii][QIndex] * atomParameters[jj][QIndex] * inverseR * inverseR * inverseR);
+        dEdR      = (RealOpenMM) (dEdR * (erfc(alphaR) + 2 * alphaR * exp (- alphaR * alphaR) / SQRT_PI));
+
+        RealOpenMM sig       = atomParameters[ii][SigIndex] +  atomParameters[jj][SigIndex];
+        RealOpenMM sig2      = inverseR*sig;
+        sig2     *= sig2;
+        RealOpenMM sig6      = sig2*sig2*sig2;
+        RealOpenMM eps       = atomParameters[ii][EpsIndex]*atomParameters[jj][EpsIndex];
+        RealOpenMM c6i = 8.0*pow(atomParameters[ii][SigIndex], 3.0) * atomParameters[ii][EpsIndex];
+        RealOpenMM c6j = 8.0*pow(atomParameters[jj][SigIndex], 3.0) * atomParameters[jj][EpsIndex];
+        // For the energies and forces, we first add the regular Lorentz−Berthelot terms.  The C12 term is treated as usual
+        // but we then subtract out (remembering that the C6 term is negative) the multiplicative C6 term that has been
+        // computed in real space.  Finally, we add a potential shift term to account for the difference between the LB
+        // and multiplicative functional forms at the cutoff.
+        dEdR     += eps*(twelve*sig6 - six)*sig6*inverseR*inverseR;
+        vdwEnergy = eps*(sig6-one)*sig6;
+        RealOpenMM emult = c6i*c6j*inverseR2*inverseR2*inverseR2*(1.0 - EXP(-dar2) * (1.0 + dar2 + 0.5*dar4));
+        dEdR += 6.0*c6i*c6j*inverseR2*inverseR2*inverseR2*inverseR2*(1.0 - EXP(-dar2) * (1.0 + dar2 + 0.5*dar4 + dar6/6.0));
+        // The additive part of the potential shift
+        RealOpenMM inverseCut2 = 1.0/(cutoffDistance*cutoffDistance);
+        RealOpenMM inverseCut6 = inverseCut2*inverseCut2*inverseCut2;
+        sig2 = atomParameters[ii][SigIndex] +  atomParameters[jj][SigIndex];
+        sig2 *= sig2;
+        sig6 = sig2*sig2*sig2;
+        RealOpenMM potentialshift = eps*sig6*inverseCut6;
+        dalphaR   = alphaDispersionEwald * cutoffDistance;
+        dar2 = dalphaR*dalphaR;
+        dar4 = dar2*dar2;
+        // The multiplicative part of the potential shift
+        potentialshift -= c6i*c6j*inverseCut6*(1.0 - EXP(-dar2) * (1.0 + dar2 + 0.5*dar4));
+        vdwEnergy += emult + potentialshift;
+
+        // accumulate forces
+
+        for (int kk = 0; kk < 3; kk++) {
+            RealOpenMM force  = dEdR*deltaR[0][kk];
+            forces[ii][kk]   += force;
+            forces[jj][kk]   -= force;
+        }
+
+        // accumulate energies
+
+        realSpaceEwaldEnergy        = (RealOpenMM) (ONE_4PI_EPS0*atomParameters[ii][QIndex]*atomParameters[jj][QIndex]*inverseR*erfc(alphaR));
+
+        totalVdwEnergy             += vdwEnergy;
+        totalRealSpaceEwaldEnergy  += realSpaceEwaldEnergy;
+
+        if (energyByAtom) {
+            energyByAtom[ii] += realSpaceEwaldEnergy + vdwEnergy;
+            energyByAtom[jj] += realSpaceEwaldEnergy + vdwEnergy;
+        }
+
+    }
+
+    if (totalEnergy)
+        *totalEnergy += totalRealSpaceEwaldEnergy + totalVdwEnergy;
+
+    // Now subtract off the exclusions, since they were implicitly included in the reciprocal space sum.
+
+    RealOpenMM totalExclusionEnergy = 0.0f;
+    const double TWO_OVER_SQRT_PI = 2/sqrt(PI_M);
+    for (int i = 0; i < numberOfAtoms; i++)
+        for (set<int>::const_iterator iter = exclusions[i].begin(); iter != exclusions[i].end(); ++iter) {
+            if (*iter > i) {
+                int ii = i;
+                int jj = *iter;
+
+                RealOpenMM deltaR[2][ReferenceForce::LastDeltaRIndex];
+                ReferenceForce::getDeltaR(atomCoordinates[jj], atomCoordinates[ii], deltaR[0]);
+                RealOpenMM r         = deltaR[0][ReferenceForce::RIndex];
+                RealOpenMM inverseR  = one/(deltaR[0][ReferenceForce::RIndex]);
+                RealOpenMM alphaR    = alphaEwald * r;
+                if (erf(alphaR) > 1e-6) {
+                    RealOpenMM dEdR      = (RealOpenMM) (ONE_4PI_EPS0 * atomParameters[ii][QIndex] * atomParameters[jj][QIndex] * inverseR * inverseR * inverseR);
+                               dEdR      = (RealOpenMM) (dEdR * (erf(alphaR) - 2 * alphaR * exp (- alphaR * alphaR) / SQRT_PI));
+
+                    // accumulate forces
+
+                    for (int kk = 0; kk < 3; kk++) {
+                        RealOpenMM force  = dEdR*deltaR[0][kk];
+                        forces[ii][kk]   -= force;
+                        forces[jj][kk]   += force;
+                    }
+
+                    // accumulate energies
+
+                    realSpaceEwaldEnergy = (RealOpenMM) (ONE_4PI_EPS0*atomParameters[ii][QIndex]*atomParameters[jj][QIndex]*inverseR*erf(alphaR));
+                }
+                else {
+                    realSpaceEwaldEnergy = (RealOpenMM) (alphaEwald*TWO_OVER_SQRT_PI*ONE_4PI_EPS0*atomParameters[ii][QIndex]*atomParameters[jj][QIndex]);
+                }
+
+                // Dispersion terms.  Here we just back out the reciprocal space terms, and don't add any extra real space terms.
+                RealOpenMM dalphaR   = alphaDispersionEwald * r;
+                RealOpenMM inverseR2 = inverseR*inverseR;
+                RealOpenMM dar2 = dalphaR*dalphaR;
+                RealOpenMM dar4 = dar2*dar2;
+                RealOpenMM dar6 = dar4*dar2;
+                RealOpenMM c6i = 8.0*pow(atomParameters[ii][SigIndex], 3.0) * atomParameters[ii][EpsIndex];
+                RealOpenMM c6j = 8.0*pow(atomParameters[jj][SigIndex], 3.0) * atomParameters[jj][EpsIndex];
+                realSpaceEwaldEnergy += c6i*c6j*inverseR2*inverseR2*inverseR2*(1.0 - EXP(-dar2) * (1.0 + dar2 + 0.5*dar4));
+                RealOpenMM dEdR = 6.0*c6i*c6j*inverseR2*inverseR2*inverseR2*inverseR2*(1.0 - EXP(-dar2) * (1.0 + dar2 + 0.5*dar4 + dar6/6.0));
+                for (int kk = 0; kk < 3; kk++) {
+                    RealOpenMM force  = dEdR*deltaR[0][kk];
+                    forces[ii][kk]   -= force;
+                    forces[jj][kk]   += force;
+                }
+
+                totalExclusionEnergy += realSpaceEwaldEnergy;
+                if (energyByAtom) {
+                    energyByAtom[ii] -= realSpaceEwaldEnergy;
+                    energyByAtom[jj] -= realSpaceEwaldEnergy;
+                }
+            }
+        }
+    if (totalEnergy)
+        *totalEnergy -= totalExclusionEnergy;
+}
+
+
+/**---------------------------------------------------------------------------------------
+
+   Calculate DPME Coulomb pair ixn
+
+   @param numberOfAtoms    number of atoms
+   @param atomCoordinates  atom coordinates
+   @param atomParameters   atom parameters                             atomParameters[atomIndex][paramterIndex]
+   @param exclusions       atom exclusion indices
+                           exclusions[atomIndex] contains the list of exclusions for that atom
+   @param fixedParameters  non atom parameters (not currently used)
+   @param forces           force array (forces added)
+   @param energyByAtom     atom energy
+   @param totalEnergy      total energy
+   @param includeDirect      true if direct space interactions should be included
+   @param includeReciprocal  true if reciprocal space interactions should be included
+
+   --------------------------------------------------------------------------------------- */
+
+void ReferenceDPMECoulombIxn::calculatePairIxn(int numberOfAtoms, vector<RealVec>& atomCoordinates,
+                                               RealOpenMM** atomParameters, vector<set<int> >& exclusions,
+                                               RealOpenMM* fixedParameters, vector<RealVec>& forces,
+                                               RealOpenMM* energyByAtom, RealOpenMM* totalEnergy, bool includeDirect, bool includeReciprocal) const {
+
+    calculatePMEIxn(numberOfAtoms, atomCoordinates, atomParameters, exclusions, fixedParameters, forces, energyByAtom,
+                      totalEnergy, includeDirect, includeReciprocal);
+    return;
+}
+

--- a/platforms/reference/tests/TestReferenceDPMENonbondedForce.cpp
+++ b/platforms/reference/tests/TestReferenceDPMENonbondedForce.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2013-2016 Stanford University and the Authors.      *
+ * Portions copyright (c) 2015 Stanford University and the Authors.           *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -29,39 +29,8 @@
  * USE OR OTHER DEALINGS IN THE SOFTWARE.                                     *
  * -------------------------------------------------------------------------- */
 
-#include "CpuKernelFactory.h"
-#include "CpuKernels.h"
-#include "CpuPlatform.h"
-#include "openmm/internal/ContextImpl.h"
-#include "openmm/OpenMMException.h"
+#include "ReferenceTests.h"
+#include "TestDPMENonbondedForce.h"
 
-using namespace OpenMM;
-
-KernelImpl* CpuKernelFactory::createKernelImpl(std::string name, const Platform& platform, ContextImpl& context) const {
-    CpuPlatform::PlatformData& data = CpuPlatform::getPlatformData(context);
-    if (name == CalcForcesAndEnergyKernel::Name())
-        return new CpuCalcForcesAndEnergyKernel(name, platform, data, context);
-    if (name == CalcHarmonicAngleForceKernel::Name())
-        return new CpuCalcHarmonicAngleForceKernel(name, platform, data);
-    if (name == CalcPeriodicTorsionForceKernel::Name())
-        return new CpuCalcPeriodicTorsionForceKernel(name, platform, data);
-    if (name == CalcRBTorsionForceKernel::Name())
-        return new CpuCalcRBTorsionForceKernel(name, platform, data);
-    if (name == CalcNonbondedForceKernel::Name())
-        return new CpuCalcNonbondedForceKernel(name, platform, data);
-    if (name == CalcDPMENonbondedForceKernel::Name())
-        return new CpuCalcDPMENonbondedForceKernel(name, platform, data);
-    if (name == CalcCustomNonbondedForceKernel::Name())
-        return new CpuCalcCustomNonbondedForceKernel(name, platform, data);
-    if (name == CalcCustomManyParticleForceKernel::Name())
-        return new CpuCalcCustomManyParticleForceKernel(name, platform, data);
-    if (name == CalcGBSAOBCForceKernel::Name())
-        return new CpuCalcGBSAOBCForceKernel(name, platform, data);
-    if (name == CalcCustomGBForceKernel::Name())
-        return new CpuCalcCustomGBForceKernel(name, platform, data);
-    if (name == CalcGayBerneForceKernel::Name())
-        return new CpuCalcGayBerneForceKernel(name, platform, data);
-    if (name == IntegrateLangevinStepKernel::Name())
-        return new CpuIntegrateLangevinStepKernel(name, platform, data);
-    throw OpenMMException((std::string("Tried to create kernel with illegal kernel name '") + name + "'").c_str());
+void runPlatformTests() {
 }

--- a/tests/TestDPMENonBondedForce.h
+++ b/tests/TestDPMENonBondedForce.h
@@ -1,0 +1,807 @@
+/* -------------------------------------------------------------------------- *
+ *                                   OpenMM                                   *
+ * -------------------------------------------------------------------------- *
+ * This is part of the OpenMM molecular simulation toolkit originating from   *
+ * Simbios, the NIH National Center for Physics-Based Simulation of           *
+ * Biological Structures at Stanford, funded under the NIH Roadmap for        *
+ * Medical Research, grant U54 GM072970. See https://simtk.org.               *
+ *                                                                            *
+ * Portions copyright (c) 2008-2015 Stanford University and the Authors.      *
+ * Authors: Peter Eastman                                                     *
+ * Contributors:                                                              *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included in *
+ * all copies or substantial portions of the Software.                        *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS, CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,    *
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR      *
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE  *
+ * USE OR OTHER DEALINGS IN THE SOFTWARE.                                     *
+ * -------------------------------------------------------------------------- */
+
+#include "openmm/internal/AssertionUtilities.h"
+#include "openmm/Context.h"
+#include "ReferencePlatform.h"
+#include "openmm/HarmonicBondForce.h"
+#include "openmm/DPMENonbondedForce.h"
+#include "openmm/System.h"
+#include "openmm/VerletIntegrator.h"
+#include "openmm/Units.h"
+#include "SimTKOpenMMRealType.h"
+#include "sfmt/SFMT.h"
+#include <iostream>
+#include <iomanip>
+
+#include <vector>
+
+using namespace OpenMM;
+using namespace std;
+
+const double TOL = 1e-5;
+
+void testExclusionsAnd14() {
+    System system;
+    DPMENonbondedForce* nonbonded = new DPMENonbondedForce();
+    for (int i = 0; i < 5; ++i) {
+        system.addParticle(1.0);
+        nonbonded->addParticle(0, 1.5, 0);
+    }
+    vector<pair<int, int> > bonds;
+    bonds.push_back(pair<int, int>(0, 1));
+    bonds.push_back(pair<int, int>(1, 2));
+    bonds.push_back(pair<int, int>(2, 3));
+    bonds.push_back(pair<int, int>(3, 4));
+    nonbonded->createExceptionsFromBonds(bonds, 0.0, 0.0);
+    int first14, second14;
+    for (int i = 0; i < nonbonded->getNumExceptions(); i++) {
+        int particle1, particle2;
+        double chargeProd, sigma, epsilon;
+        nonbonded->getExceptionParameters(i, particle1, particle2, chargeProd, sigma, epsilon);
+        if ((particle1 == 0 && particle2 == 3) || (particle1 == 3 && particle2 == 0))
+            first14 = i;
+        if ((particle1 == 1 && particle2 == 4) || (particle1 == 4 && particle2 == 1))
+            second14 = i;
+    }
+    system.addForce(nonbonded);
+    VerletIntegrator integrator(0.01);
+    Context context(system, integrator, platform);
+    for (int i = 1; i < 5; ++i) {
+
+        // Test LJ forces
+
+        vector<Vec3> positions(5);
+        const double r = 1.0;
+        for (int j = 0; j < 5; ++j) {
+            nonbonded->setParticleParameters(j, 0, 1.5, 0);
+            positions[j] = Vec3(0, j, 0);
+        }
+        nonbonded->setParticleParameters(0, 0, 1.5, 1);
+        nonbonded->setParticleParameters(i, 0, 1.5, 1);
+        nonbonded->setExceptionParameters(first14, 0, 3, 0, 1.5, i == 3 ? 0.5 : 0.0);
+        nonbonded->setExceptionParameters(second14, 1, 4, 0, 1.5, 0.0);
+        positions[i] = Vec3(r, 0, 0);
+        context.reinitialize();
+        context.setPositions(positions);
+        State state = context.getState(State::Forces | State::Energy);
+        const vector<Vec3>& forces = state.getForces();
+        double x = 1.5/r;
+        double eps = 1.0;
+        double force = 4.0*eps*(12*std::pow(x, 12.0)-6*std::pow(x, 6.0))/r;
+        double energy = 4.0*eps*(std::pow(x, 12.0)-std::pow(x, 6.0));
+        if (i == 3) {
+            force *= 0.5;
+            energy *= 0.5;
+        }
+        if (i < 3) {
+            force = 0;
+            energy = 0;
+        }
+        ASSERT_EQUAL_VEC(Vec3(-force, 0, 0), forces[0], TOL);
+        ASSERT_EQUAL_VEC(Vec3(force, 0, 0), forces[i], TOL);
+        ASSERT_EQUAL_TOL(energy, state.getPotentialEnergy(), TOL);
+
+        // Test Coulomb forces
+
+        nonbonded->setParticleParameters(0, 2, 1.5, 0);
+        nonbonded->setParticleParameters(i, 2, 1.5, 0);
+        nonbonded->setExceptionParameters(first14, 0, 3, i == 3 ? 4/1.2 : 0, 1.5, 0);
+        nonbonded->setExceptionParameters(second14, 1, 4, 0, 1.5, 0);
+        context.reinitialize();
+        context.setPositions(positions);
+        state = context.getState(State::Forces | State::Energy);
+        const vector<Vec3>& forces2 = state.getForces();
+        force = ONE_4PI_EPS0*4/(r*r);
+        energy = ONE_4PI_EPS0*4/r;
+        if (i == 3) {
+            force /= 1.2;
+            energy /= 1.2;
+        }
+        if (i < 3) {
+            force = 0;
+            energy = 0;
+        }
+        ASSERT_EQUAL_VEC(Vec3(-force, 0, 0), forces2[0], TOL);
+        ASSERT_EQUAL_VEC(Vec3(force, 0, 0), forces2[i], TOL);
+        ASSERT_EQUAL_TOL(energy, state.getPotentialEnergy(), TOL);
+    }
+}
+
+
+void make_waterbox(int natoms, double boxEdgeLength, DPMENonbondedForce *forceField,  vector<Vec3> &positions, vector<double>& eps, vector<double>& sig,
+                   vector<pair<int, int> >& bonds, System &system, bool do_electrostatics) {
+    const int RESSIZE = 3;
+    const double masses[RESSIZE]    = {     8.0,    1.0,    1.0 };
+    const double charges[RESSIZE]   = {  -0.834,  0.417,  0.417 };
+    // Values from the CHARMM force field, in AKMA units
+    const double epsilons[RESSIZE]  = { -0.1521, -0.046, -0.046 };
+    const double halfrmins[RESSIZE] = {  1.7682, 0.2245, 0.2245 };
+    positions.clear();
+    if(natoms == 6){
+        const double coords[6][3] = {
+            {  2.000000, 2.000000, 2.000000},
+            {  2.500000, 2.000000, 3.000000},
+            {  1.500000, 2.000000, 3.000000},
+            {  0.000000, 0.000000, 0.000000},
+            {  0.500000, 0.000000, 1.000000},
+            { -0.500000, 0.000000, 1.000000}
+        };
+        for(int atom = 0; atom < natoms; ++atom)
+            positions.push_back(Vec3(coords[atom][0], coords[atom][1], coords[atom][2])*OpenMM::NmPerAngstrom);
+    }else if(natoms == 375){
+        const double coords[375][3] = {
+            { -6.227577, -6.257691, -6.242372 },
+            { -5.323856, -6.038433, -6.004096 },
+            { -6.756728, -5.564157, -5.841659 },
+            { -3.045385, -6.233543, -6.190951 },
+            { -3.526738, -5.554781, -5.712262 },
+            { -3.599325, -6.431115, -6.949685 },
+            {  0.021426, -6.231744, -6.149739 },
+            { -0.875209, -5.976613, -6.378901 },
+            {  0.535110, -6.037842, -6.937199 },
+            {  3.100433, -6.203101, -6.272233 },
+            {  3.874100, -6.357529, -5.725284 },
+            {  2.378191, -6.111572, -5.646492 },
+            {  6.186877, -6.143892, -6.207648 },
+            {  6.463778, -6.660529, -5.447403 },
+            {  6.262846, -6.748390, -6.949519 },
+            { -6.215886, -3.157497, -6.242725 },
+            { -6.237827, -3.077604, -5.286327 },
+            { -6.028329, -2.268904, -6.553829 },
+            { -3.143522, -3.072478, -6.164691 },
+            { -3.384628, -3.637034, -6.902733 },
+            { -2.183705, -3.058977, -6.176044 },
+            { -0.001261, -3.162923, -6.234377 },
+            { -0.032904, -2.309579, -6.672970 },
+            {  0.052913, -2.950816, -5.299691 },
+            {  3.087208, -3.110696, -6.143281 },
+            {  2.657287, -2.555869, -6.798183 },
+            {  3.804920, -3.533514, -6.620435 },
+            {  6.169768, -3.141467, -6.167741 },
+            {  7.044757, -3.328081, -6.515780 },
+            {  5.953438, -2.272871, -6.514589 },
+            { -6.207742, -0.041917, -6.155951 },
+            { -5.438834,  0.329527, -6.594553 },
+            { -6.956596,  0.335819, -6.622957 },
+            { -3.102424, -0.064365, -6.193126 },
+            { -3.759220,  0.421493, -6.697232 },
+            { -2.461457,  0.600160, -5.930203 },
+            {  0.057084, -0.011721, -6.176128 },
+            { -0.107739,  0.025184, -7.121132 },
+            { -0.798344,  0.160864, -5.776104 },
+            {  3.038705,  0.009068, -6.198274 },
+            {  3.541849,  0.080397, -7.012718 },
+            {  3.690240, -0.224328, -5.533000 },
+            {  6.176831,  0.057180, -6.193629 },
+            {  5.789021, -0.734630, -6.573369 },
+            {  7.097056, -0.172982, -6.046071 },
+            { -6.202562,  3.152015, -6.250632 },
+            { -6.598511,  3.181133, -5.376596 },
+            { -5.879135,  2.252396, -6.338049 },
+            { -3.097153,  3.045646, -6.175594 },
+            { -3.888514,  3.580848, -6.269758 },
+            { -2.415842,  3.541069, -6.635956 },
+            {  0.004020,  3.065952, -6.260601 },
+            { -0.714153,  3.647384, -6.000359 },
+            {  0.650339,  3.152212, -5.556049 },
+            {  3.148082,  3.065474, -6.236447 },
+            {  3.111314,  3.313051, -5.309670 },
+            {  2.384648,  3.494128, -6.630129 },
+            {  6.195396,  3.144020, -6.257042 },
+            {  6.825505,  3.254686, -5.541307 },
+            {  5.765894,  2.305751, -6.071584 },
+            { -6.224762,  6.269436, -6.199499 },
+            { -6.227138,  5.744470, -7.003219 },
+            { -5.898129,  5.671700, -5.523050 },
+            { -3.049795,  6.244848, -6.205918 },
+            { -3.087748,  5.286175, -6.173255 },
+            { -3.968304,  6.520275, -6.251129 },
+            { -0.053210,  6.218043, -6.169688 },
+            {  0.825799,  6.589399, -6.064810 },
+            {  0.018791,  5.642523, -6.934642 },
+            {  3.109156,  6.250395, -6.157883 },
+            {  3.646142,  5.470269, -6.314764 },
+            {  2.467680,  6.248139, -6.872071 },
+            {  6.221542,  6.201019, -6.270430 },
+            {  5.372468,  6.425629, -5.882893 },
+            {  6.803922,  6.076521, -5.517505 },
+            { -6.192636, -6.150665, -3.134919 },
+            { -6.377934, -7.011364, -3.517572 },
+            { -6.257279, -6.290045, -2.187314 },
+            { -3.109530, -6.270465, -3.117828 },
+            { -2.298394, -5.772194, -2.993950 },
+            { -3.809490, -5.627637, -2.982220 },
+            { -0.038820, -6.182503, -3.150607 },
+            { -0.071984, -7.054630, -2.750788 },
+            {  0.688173, -5.741421, -2.705086 },
+            {  3.102774, -6.145922, -3.077989 },
+            {  2.352681, -6.724399, -3.233832 },
+            {  3.862449, -6.652292, -3.374712 },
+            {  6.221089, -6.201529, -3.167266 },
+            {  6.825244, -6.363707, -2.439079 },
+            {  5.358331, -6.130338, -2.752367 },
+            { -6.262103, -3.132226, -3.123586 },
+            { -6.166340, -2.275929, -2.700331 },
+            { -5.366218, -3.471706, -3.184445 },
+            { -3.111137, -3.051004, -3.142406 },
+            { -3.311768, -3.968529, -3.341042 },
+            { -2.770611, -3.068346, -2.245019 },
+            {  0.005724, -3.130303, -3.163012 },
+            {  0.482202, -2.374690, -2.811473 },
+            { -0.573062, -3.403472, -2.447507 },
+            {  3.095078, -3.099676, -3.168462 },
+            {  2.417453, -3.190640, -2.494584 },
+            {  3.919837, -3.073655, -2.677893 },
+            {  6.196105, -3.040136, -3.088337 },
+            {  5.640465, -3.619831, -3.614436 },
+            {  6.939673, -3.589544, -2.829842 },
+            { -6.182065, -0.003400, -3.042390 },
+            { -6.005810, -0.591008, -3.780776 },
+            { -6.797182,  0.644978, -3.392815 },
+            { -3.055877, -0.038021, -3.078205 },
+            { -2.957574,  0.804401, -3.527898 },
+            { -4.001938, -0.200904, -3.077218 },
+            { -0.034735,  0.036962, -3.061441 },
+            { -0.339387, -0.376429, -3.872525 },
+            {  0.890739, -0.210258, -2.998671 },
+            {  3.137299, -0.056306, -3.103061 },
+            {  3.449365,  0.817518, -3.349247 },
+            {  2.217754,  0.076224, -2.861330 },
+            {  6.202733, -0.057422, -3.135143 },
+            {  6.891866,  0.607339, -3.204067 },
+            {  5.583070,  0.304112, -2.497277 },
+            { -6.235328,  3.091028, -3.161196 },
+            { -5.620224,  3.796590, -2.948140 },
+            { -6.337344,  2.604974, -2.339669 },
+            { -3.100761,  3.085670, -3.040001 },
+            { -3.841514,  3.471502, -3.513266 },
+            { -2.405567,  3.015122, -3.698249 },
+            {  0.017686,  3.040997, -3.114710 },
+            { -0.562190,  3.593571, -3.643829 },
+            {  0.281457,  3.602138, -2.381834 },
+            {  3.040493,  3.118625, -3.091261 },
+            {  3.497428,  2.301545, -2.878768 },
+            {  3.706278,  3.661985, -3.519106 },
+            {  6.153747,  3.141770, -3.110452 },
+            {  6.524448,  2.527782, -3.748544 },
+            {  6.728033,  3.068367, -2.344704 },
+            { -6.228412,  6.153262, -3.134991 },
+            { -5.497842,  6.211200, -2.514933 },
+            { -6.569498,  7.048988, -3.188810 },
+            { -3.114261,  6.247531, -3.052990 },
+            { -3.763440,  5.838093, -3.629608 },
+            { -2.269351,  5.925773, -3.375729 },
+            {  0.033856,  6.255675, -3.075505 },
+            {  0.340270,  5.631131, -3.737032 },
+            { -0.877663,  6.003468, -2.910926 },
+            {  3.072932,  6.151993, -3.082847 },
+            {  3.294846,  6.929869, -2.565910 },
+            {  3.393954,  6.350465, -3.965522 },
+            {  6.229389,  6.147520, -3.121044 },
+            {  5.797138,  6.388219, -2.298375 },
+            {  6.254689,  6.963103, -3.626757 },
+            { -6.218080, -6.208893, -0.064724 },
+            { -5.793234, -6.874918,  0.480691 },
+            { -6.438098, -5.502241,  0.546665 },
+            { -3.161793, -6.216735, -0.028339 },
+            { -2.502753, -6.872853,  0.209857 },
+            { -2.775567, -5.379832,  0.239959 },
+            { -0.002532, -6.140991, -0.003478 },
+            {  0.689039, -6.720671, -0.330985 },
+            { -0.648843, -6.734293,  0.386184 },
+            {  3.039844, -6.205646, -0.017228 },
+            {  3.777609, -6.569800, -0.511855 },
+            {  3.436401, -5.858902,  0.785313 },
+            {  6.257004, -6.165220, -0.008551 },
+            {  5.368434, -6.091008, -0.364215 },
+            {  6.245060, -6.979374,  0.499948 },
+            { -6.246883, -3.055033, -0.019337 },
+            { -6.350454, -3.640127,  0.734652 },
+            { -5.423699, -3.332793, -0.427723 },
+            { -3.094331, -3.063472,  0.051555 },
+            { -2.443051, -3.620051, -0.381590 },
+            { -3.906094, -3.218919, -0.436745 },
+            {  0.059986, -3.108175,  0.026527 },
+            { -0.319331, -2.356822, -0.435152 },
+            { -0.632825, -3.772569,  0.014099 },
+            {  3.056825, -3.094971, -0.045775 },
+            {  3.286789, -3.903484,  0.417890 },
+            {  3.657675, -2.435504,  0.308690 },
+            {  6.204418, -3.046271, -0.032672 },
+            {  5.666837, -3.316225,  0.715455 },
+            {  6.781360, -3.795765, -0.196864 },
+            { -6.187331,  0.042326, -0.046499 },
+            { -6.739113, -0.736038, -0.152558 },
+            { -5.980298,  0.064208,  0.890635 },
+            { -3.111868, -0.045870, -0.046351 },
+            { -3.369378, -0.088582,  0.877460 },
+            { -2.701406,  0.816674, -0.141741 },
+            { -0.028600, -0.027927, -0.052228 },
+            { -0.450128,  0.284536,  0.751664 },
+            {  0.904097,  0.158746,  0.077351 },
+            {  3.043640,  0.022778, -0.015695 },
+            {  3.263633, -0.820206,  0.387469 },
+            {  3.890123,  0.458652, -0.138341 },
+            {  6.198501,  0.054145, -0.036443 },
+            {  5.524424, -0.562672,  0.258040 },
+            {  7.017693, -0.296767,  0.320414 },
+            { -6.142883,  3.087172,  0.001701 },
+            { -6.832739,  2.822585,  0.614608 },
+            { -6.592184,  3.640199, -0.641611 },
+            { -3.054590,  3.097169, -0.043753 },
+            { -3.795838,  2.503772,  0.097642 },
+            { -3.184109,  3.800316,  0.596849 },
+            {  0.025258,  3.140300,  0.048161 },
+            { -0.898451,  3.040556, -0.193447 },
+            {  0.497539,  2.578923, -0.571006 },
+            {  3.142639,  3.155831,  0.004528 },
+            {  3.281734,  2.283294,  0.379885 },
+            {  2.300622,  3.089671, -0.451752 },
+            {  6.271003,  3.089878, -0.000229 },
+            {  5.555786,  2.545332, -0.337120 },
+            {  5.835504,  3.874496,  0.340762 },
+            { -6.186874,  6.153181, -0.032864 },
+            { -6.458269,  6.211097,  0.886130 },
+            { -6.268404,  7.050370, -0.364476 },
+            { -3.063571,  6.194209, -0.050917 },
+            { -2.845329,  6.642761,  0.769286 },
+            { -3.992058,  5.967481,  0.038907 },
+            { -0.005511,  6.203833,  0.065479 },
+            { -0.675428,  5.996461, -0.590089 },
+            {  0.762902,  6.461025, -0.449259 },
+            {  3.107182,  6.260055, -0.038149 },
+            {  3.570052,  6.091314,  0.785768 },
+            {  2.575104,  5.473755, -0.180227 },
+            {  6.264803,  6.186329,  0.022994 },
+            {  5.538470,  5.646253, -0.296882 },
+            {  5.951245,  7.089071, -0.068103 },
+            { -6.267283, -6.211735,  3.078419 },
+            { -5.985306, -6.384271,  3.979686 },
+            { -5.465039, -5.947785,  2.622023 },
+            { -3.107839, -6.241119,  3.047498 },
+            { -2.699991, -6.510712,  3.873658 },
+            { -3.434740, -5.354930,  3.218863 },
+            { -0.033434, -6.169301,  3.060705 },
+            {  0.838698, -6.005633,  3.426984 },
+            { -0.308002, -6.999962,  3.455898 },
+            {  3.150365, -6.250863,  3.115724 },
+            {  2.771880, -5.609654,  3.721663 },
+            {  2.687846, -6.101322,  2.287910 },
+            {  6.204347, -6.213550,  3.168674 },
+            {  5.750267, -6.738865,  2.505789 },
+            {  6.699059, -5.564375,  2.663310 },
+            { -6.172325, -3.107328,  3.047333 },
+            { -6.828965, -2.449862,  3.288422 },
+            { -6.128632, -3.692984,  3.806714 },
+            { -3.080296, -3.042262,  3.111628 },
+            { -3.599745, -3.563632,  3.727994 },
+            { -2.972174, -3.611996,  2.346596 },
+            {  0.018427, -3.040709,  3.111508 },
+            { -0.861291, -3.412145,  3.209954 },
+            {  0.568794, -3.788138,  2.866545 },
+            {  3.076991, -3.074154,  3.156063 },
+            {  3.816301, -3.685968,  3.130285 },
+            {  2.808084, -2.983447,  2.238990 },
+            {  6.202874, -3.044570,  3.132656 },
+            {  5.483336, -3.645941,  2.927282 },
+            {  6.989368, -3.493060,  2.813525 },
+            { -6.185279, -0.059803,  3.120451 },
+            { -6.419455,  0.669043,  3.699681 },
+            { -6.332522,  0.280211,  2.234860 },
+            { -3.050408,  0.039017,  3.105488 },
+            { -3.468427, -0.425632,  3.834133 },
+            { -3.577897, -0.193686,  2.337916 },
+            {  0.036504, -0.020609,  3.153990 },
+            {  0.239664, -0.086591,  2.218077 },
+            { -0.819081,  0.413707,  3.184104 },
+            {  3.091492,  0.008311,  3.039147 },
+            {  2.481020, -0.295977,  3.714642 },
+            {  3.913193,  0.164051,  3.510436 },
+            {  6.191365, -0.063471,  3.111335 },
+            {  6.055864,  0.479518,  2.331358 },
+            {  6.599523,  0.527950,  3.747880 },
+            { -6.205614,  3.054919,  3.058779 },
+            { -6.876203,  3.731733,  3.176233 },
+            { -5.553000,  3.242989,  3.737223 },
+            { -3.118412,  3.069232,  3.157498 },
+            { -3.646030,  3.741133,  2.719629 },
+            { -2.320885,  3.006400,  2.626871 },
+            {  0.024980,  3.055432,  3.065769 },
+            { -0.877220,  3.144581,  3.381441 },
+            {  0.480709,  3.822007,  3.421065 },
+            {  3.070975,  3.105245,  3.160550 },
+            {  3.950017,  3.440960,  2.970440 },
+            {  2.769856,  2.734952,  2.327620 },
+            {  6.198446,  3.079479,  3.164063 },
+            {  7.022878,  3.306229,  2.727648 },
+            {  5.520109,  3.278660,  2.514642 },
+            { -6.193602,  6.242270,  3.157025 },
+            { -5.567869,  5.886374,  2.521920 },
+            { -7.052009,  5.960994,  2.832091 },
+            { -3.103387,  6.145098,  3.080057 },
+            { -2.343780,  6.698458,  3.275890 },
+            { -3.861615,  6.691317,  3.299822 },
+            { -0.045554,  6.242642,  3.134180 },
+            {  0.637737,  6.548568,  2.533277 },
+            {  0.085332,  5.292898,  3.183344 },
+            {  3.128530,  6.249892,  3.145938 },
+            {  3.572612,  5.823157,  2.409562 },
+            {  2.233691,  5.903232,  3.120423 },
+            {  6.255670,  6.195132,  3.061028 },
+            {  5.552429,  5.596136,  3.322210 },
+            {  6.082243,  6.999450,  3.555555 },
+            { -6.208072, -6.163006,  6.157412 },
+            { -6.293854, -5.991009,  7.097954 },
+            { -6.096342, -7.114505,  6.096361 },
+            { -3.093215, -6.194828,  6.270532 },
+            { -2.561298, -5.900834,  5.527435 },
+            { -3.805554, -6.699586,  5.871339 },
+            {  0.028309, -6.255582,  6.240192 },
+            { -0.704628, -5.700497,  6.516318 },
+            {  0.255286, -5.935581,  5.364040 },
+            {  3.112376, -6.185324,  6.145057 },
+            {  3.768593, -6.549569,  6.743611 },
+            {  2.294122, -6.201701,  6.646808 },
+            {  6.221282, -6.173949,  6.151454 },
+            {  6.616602, -6.986255,  6.476173 },
+            {  5.563911, -5.945569,  6.812716 },
+            { -6.214945, -3.105559,  6.141418 },
+            { -6.767312, -2.662372,  6.789520 },
+            { -5.513791, -3.508545,  6.658668 },
+            { -3.134984, -3.050634,  6.183218 },
+            { -2.194062, -3.145360,  6.348303 },
+            { -3.509793, -3.897382,  6.436395 },
+            {  0.019709, -3.066046,  6.156136 },
+            { -0.062167, -2.811154,  7.078030 },
+            { -0.250671, -3.986954,  6.136538 },
+            {  3.047052, -3.093053,  6.174132 },
+            {  3.846770, -3.511425,  5.847060 },
+            {  3.252831, -2.858011,  7.081861 },
+            {  6.264526, -3.131008,  6.192287 },
+            {  6.014957, -2.208761,  6.098811 },
+            {  5.479151, -3.558207,  6.541928 },
+            { -6.202784,  0.012060,  6.271161 },
+            { -5.794767, -0.706266,  5.782190 },
+            { -6.679360,  0.514844,  5.606597 },
+            { -3.132137,  0.011406,  6.148615 },
+            { -3.531033, -0.354855,  6.941266 },
+            { -2.218018,  0.173816,  6.392684 },
+            { -0.048817, -0.044068,  6.207411 },
+            {  0.264785,  0.472342,  5.461397 },
+            {  0.510082,  0.227141,  6.939285 },
+            {  3.104615, -0.056762,  6.239817 },
+            {  2.334121,  0.441331,  5.957323 },
+            {  3.851786,  0.459650,  5.928986 },
+            {  6.191962, -0.011674,  6.269664 },
+            {  7.056171,  0.162434,  5.889678 },
+            {  5.589740,  0.022864,  5.522872 },
+            { -6.227582,  3.048278,  6.177333 },
+            { -5.456950,  3.575652,  5.954701 },
+            { -6.623561,  3.504488,  6.923412 },
+            { -3.095950,  3.167462,  6.219110 },
+            { -3.718176,  2.753599,  5.616521 },
+            { -2.605272,  2.434738,  6.598467 },
+            { -0.028196,  3.102085,  6.266027 },
+            {  0.892169,  3.276065,  6.055742 },
+            { -0.444613,  2.949998,  5.414541 },
+            {  3.122055,  3.044925,  6.230400 },
+            {  2.318548,  3.530579,  6.430594 },
+            {  3.590528,  3.602778,  5.605184 },
+            {  6.235943,  3.056340,  6.242112 },
+            {  5.925321,  3.913199,  6.543556 },
+            {  6.022471,  3.038970,  5.306329 },
+            { -6.152078,  6.212531,  6.242895 },
+            { -6.277517,  6.463813,  5.324917 },
+            { -7.001466,  5.855602,  6.512529 },
+            { -3.075211,  6.151648,  6.229296 },
+            { -3.984620,  6.273567,  5.947033 },
+            { -2.668015,  7.012240,  6.106276 },
+            {  0.047399,  6.200405,  6.251791 },
+            { -0.389422,  5.502373,  5.758333 },
+            { -0.362937,  7.009521,  5.937917 },
+            {  3.121019,  6.156392,  6.245211 },
+            {  3.669300,  6.880502,  5.934383 },
+            {  2.256232,  6.330001,  5.866310 },
+            {  6.204797,  6.271399,  6.195395 },
+            {  5.469074,  5.654753,  6.199970 },
+            {  6.973096,  5.730251,  6.391449 }
+        };
+        for(int atom = 0; atom < natoms; ++atom)
+            positions.push_back(Vec3(coords[atom][0], coords[atom][1], coords[atom][2])*OpenMM::NmPerAngstrom);
+    }else{
+        throw exception();
+    }
+
+    system.setDefaultPeriodicBoxVectors(Vec3(boxEdgeLength, 0, 0),
+                                        Vec3(0, boxEdgeLength, 0),
+                                        Vec3(0, 0, boxEdgeLength));
+
+    sig.clear();
+    eps.clear();
+    bonds.clear();
+    for(int atom = 0; atom < natoms; ++atom){
+        system.addParticle(masses[atom%RESSIZE]);
+        double sigma = 2.0*pow(2.0, -1.0/6.0)*halfrmins[atom%RESSIZE]*OpenMM::NmPerAngstrom;
+        double epsilon = fabs(epsilons[atom%RESSIZE])*OpenMM::KJPerKcal;
+        sig.push_back(0.5*sigma);
+        eps.push_back(2.0*sqrt(epsilon));
+        if(atom%RESSIZE == 0){
+            bonds.push_back(pair<int, int>(atom, atom+1));
+            bonds.push_back(pair<int, int>(atom, atom+2));
+        }
+        double charge = do_electrostatics ? charges[atom] : 0;
+        forceField->addParticle(charge, sigma, epsilon);
+    }
+}
+
+void print_forces(const vector<Vec3>& forces){
+    // Print the forces in AKMA units, to compare against other codes.
+    std::cout << "Forces:" << std::endl;
+    for(int n = 0; n < forces.size(); ++ n){
+        std::cout << setw(3)<< n+1
+                  << setw(16) << setprecision(10) << -forces[n][0]*OpenMM::NmPerAngstrom*OpenMM::KcalPerKJ
+                  << setw(16) << setprecision(10) << -forces[n][1]*OpenMM::NmPerAngstrom*OpenMM::KcalPerKJ
+                  << setw(16) << setprecision(10) << -forces[n][2]*OpenMM::NmPerAngstrom*OpenMM::KcalPerKJ << std::endl;
+    }
+}
+
+void test_water125_dpme_vs_long_cutoff_with_exclusions() {
+    const double cutoff = 8.0*OpenMM::NmPerAngstrom;
+    const double alpha = 0.45*OpenMM::AngstromsPerNm;
+    const double dalpha = 0.45*OpenMM::AngstromsPerNm;
+    const int grid = 32;
+    DPMENonbondedForce* forceField = new DPMENonbondedForce();
+
+    vector<Vec3> positions;
+    vector<double> epsvals;
+    vector<double> sigvals;
+    vector<pair<int, int> > bonds;
+    System system;
+
+    const int NATOMS = 375;
+    double boxEdgeLength = 16.01*OpenMM::NmPerAngstrom;
+
+    make_waterbox(NATOMS, boxEdgeLength, forceField,  positions, epsvals, sigvals, bonds, system, false);
+
+    forceField->createExceptionsFromBonds(bonds, 1.0, 1.0);
+    forceField->setPMEParameters(alpha, grid, grid, grid);
+    forceField->setDispersionPMEParameters(dalpha, grid, grid, grid);
+    forceField->setCutoffDistance(cutoff);
+    forceField->setReactionFieldDielectric(1.0);
+    system.addForce(forceField);
+
+    VerletIntegrator integrator(0.01);
+    Context context(system, integrator, platform);
+    context.setPositions(positions);
+
+    State state = context.getState(State::Forces | State::Energy);
+    double energy = state.getPotentialEnergy();
+//    std::cout << "Energy " << energy*OpenMM::KcalPerKJ << std::endl;
+    const vector<Vec3>& forces = state.getForces();
+//    print_forces(forces);
+
+
+    // Find the exclusion information
+    vector<set<int> > exclusions(NATOMS);
+    for (int i = 0; i < forceField->getNumExceptions(); i++) {
+        int particle1, particle2;
+        double chargeProd, sigma, epsilon;
+        forceField->getExceptionParameters(i, particle1, particle2, chargeProd, sigma, epsilon);
+        exclusions[particle1].insert(particle2);
+        exclusions[particle2].insert(particle1);
+    }
+
+    const double longcutoff = 30.0*OpenMM::NmPerAngstrom;
+    const double longcutoff2 = longcutoff*longcutoff;
+    const double cutoff2 = cutoff*cutoff;
+    const double cutoff6inv = 1.0 / (cutoff2*cutoff2*cutoff2);
+    const int nboxes = ceil(longcutoff/boxEdgeLength);
+
+    double refenergy = 0.0;
+    // Loop over home box first...
+    for(int i = 0; i < NATOMS; ++ i){
+        for(int j = i+1; j < NATOMS; ++j){
+            Vec3 dR = positions[i] - positions[j];
+            double R2 = dR[0]*dR[0] + dR[1]*dR[1] + dR[2]*dR[2];
+            double sig2 = (sigvals[i] + sigvals[j])*(sigvals[i] + sigvals[j]) / R2;
+            double sig6 = sig2*sig2*sig2;
+            double eps = epsvals[i]*epsvals[j];
+            refenergy += 2.0*eps*(sig6-1.0)*sig6;
+            if(R2 < cutoff2){
+                // Add a shift term for direct space parts withing t
+                refenergy += 2.0*eps*(pow(sigvals[i]+sigvals[j], 6) - 64.0*pow(sigvals[i]*sigvals[j], 3))*cutoff6inv;
+            }
+        }
+    }
+
+    // ... back out exclusions
+    for (int ii = 0; ii < NATOMS; ii++){
+        for (set<int>::const_iterator iter = exclusions[ii].begin(); iter != exclusions[ii].end(); ++iter) {
+            if (*iter > ii) {
+                int i = ii;
+                int j = *iter;
+                Vec3 dR = positions[i] - positions[j];
+                double R2 = dR[0]*dR[0] + dR[1]*dR[1] + dR[2]*dR[2];
+                double sig2 = (sigvals[i] + sigvals[j])*(sigvals[i] + sigvals[j]) / R2;
+                double sig6 = sig2*sig2*sig2;
+                double eps = epsvals[i]*epsvals[j];
+                refenergy -= 2.0*eps*(sig6-1.0)*sig6;
+                if(R2 < cutoff2){
+                    // Add a shift term for direct space parts withing t
+                    refenergy -= 2.0*eps*(pow(sigvals[i]+sigvals[j], 6) - 64.0*pow(sigvals[i]*sigvals[j], 3))*cutoff6inv;
+                }
+            }
+        }
+    }
+
+    // ... and now add in the image box terms
+    for(int bx = -nboxes; bx <= nboxes; ++bx){
+        for(int by = -nboxes; by <= nboxes; ++by){
+            for(int bz = -nboxes; bz <= nboxes; ++bz){
+                if(bx==0 && by==0 && bz==0) continue;
+                Vec3 offset(bx*boxEdgeLength, by*boxEdgeLength, bz*boxEdgeLength);
+                for(int i = 0; i < NATOMS; ++ i){
+                    for(int j = 0; j < NATOMS; ++j){
+                        Vec3 dR = positions[i] - positions[j] + offset;
+                        double R2 = dR[0]*dR[0] + dR[1]*dR[1] + dR[2]*dR[2];
+                        if(R2 > longcutoff2) continue;
+                        double sig2 = (sigvals[i] + sigvals[j])*(sigvals[i] + sigvals[j]) / R2;
+                        double sig6 = sig2*sig2*sig2;
+                        double eps = epsvals[i]*epsvals[j];
+                        refenergy += eps*(sig6-1.0)*sig6;
+                        if(R2 < cutoff2){
+                            // Add a shift term for direct space parts withing teh
+                            refenergy += eps*(pow(sigvals[i]+sigvals[j], 6) - 64.0*pow(sigvals[i]*sigvals[j], 3))*cutoff6inv;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    refenergy *= 0.5;
+
+    // For this test the reference energy is -394.662 kJ/mol, while the difference between DPME and 30A cutoffs
+    // is just 0.064 kJ/mol.  The difference is due to the fact that arithmetic mean combination rules are used
+    // up to the cutoff, while the reciprocal space uses the geometric mean.  See DOI: 10.1021/acs.jctc.5b00726
+    ASSERT_EQUAL_TOL(refenergy, energy, 2E-4);
+}
+
+
+void test_water125_dpme_vs_long_cutoff_no_exclusions() {
+    const double cutoff = 8.0*OpenMM::NmPerAngstrom;
+    const double alpha = 0.45*OpenMM::AngstromsPerNm;
+    const double dalpha = 0.45*OpenMM::AngstromsPerNm;
+    const int grid = 32;
+    DPMENonbondedForce* forceField = new DPMENonbondedForce();
+
+    vector<Vec3> positions;
+    vector<double> epsvals;
+    vector<double> sigvals;
+    vector<pair<int, int> > bonds;
+    System system;
+
+    const int NATOMS = 375;
+    double boxEdgeLength = 16.01*OpenMM::NmPerAngstrom;
+
+    make_waterbox(NATOMS, boxEdgeLength, forceField,  positions, epsvals, sigvals, bonds, system, false);
+
+    forceField->setPMEParameters(alpha, grid, grid, grid);
+    forceField->setDispersionPMEParameters(dalpha, grid, grid, grid);
+    forceField->setCutoffDistance(cutoff);
+    forceField->setReactionFieldDielectric(1.0);
+    system.addForce(forceField);
+
+    VerletIntegrator integrator(0.01);
+    Context context(system, integrator, platform);
+    context.setPositions(positions);
+
+    State state = context.getState(State::Forces | State::Energy);
+    double energy = state.getPotentialEnergy();
+//    std::cout << "Energy " << energy*OpenMM::KcalPerKJ << std::endl;
+    const vector<Vec3>& forces = state.getForces();
+//    print_forces(forces);
+
+
+    const double longcutoff = 30.0*OpenMM::NmPerAngstrom;
+    const double longcutoff2 = longcutoff*longcutoff;
+    const double cutoff2 = cutoff*cutoff;
+    const double cutoff6inv = 1.0 / (cutoff2*cutoff2*cutoff2);
+    const int nboxes = ceil(longcutoff/boxEdgeLength);
+
+    double refenergy = 0.0;
+    // Loop over home box first...
+    for(int i = 0; i < NATOMS; ++ i){
+        for(int j = i+1; j < NATOMS; ++j){
+            Vec3 dR = positions[i] - positions[j];
+            double R2 = dR[0]*dR[0] + dR[1]*dR[1] + dR[2]*dR[2];
+            double sig2 = (sigvals[i] + sigvals[j])*(sigvals[i] + sigvals[j]) / R2;
+            double sig6 = sig2*sig2*sig2;
+            double eps = epsvals[i]*epsvals[j];
+            refenergy += 2.0*eps*(sig6-1.0)*sig6;
+            if(R2 < cutoff2){
+                // Add a shift term for direct space parts withing t
+                refenergy += 2.0*eps*(pow(sigvals[i]+sigvals[j], 6) - 64.0*pow(sigvals[i]*sigvals[j], 3))*cutoff6inv;
+            }
+        }
+    }
+
+    // ... and now add in the image box terms
+    for(int bx = -nboxes; bx <= nboxes; ++bx){
+        for(int by = -nboxes; by <= nboxes; ++by){
+            for(int bz = -nboxes; bz <= nboxes; ++bz){
+                if(bx==0 && by==0 && bz==0) continue;
+                Vec3 offset(bx*boxEdgeLength, by*boxEdgeLength, bz*boxEdgeLength);
+                for(int i = 0; i < NATOMS; ++ i){
+                    for(int j = 0; j < NATOMS; ++j){
+                        Vec3 dR = positions[i] - positions[j] + offset;
+                        double R2 = dR[0]*dR[0] + dR[1]*dR[1] + dR[2]*dR[2];
+                        if(R2 > longcutoff2) continue;
+                        double sig2 = (sigvals[i] + sigvals[j])*(sigvals[i] + sigvals[j]) / R2;
+                        double sig6 = sig2*sig2*sig2;
+                        double eps = epsvals[i]*epsvals[j];
+                        refenergy += eps*(sig6-1.0)*sig6;
+                        if(R2 < cutoff2){
+                            // Add a shift term for direct space parts withing teh
+                            refenergy += eps*(pow(sigvals[i]+sigvals[j], 6) - 64.0*pow(sigvals[i]*sigvals[j], 3))*cutoff6inv;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    refenergy *= 0.5;
+
+    // For this test the reference energy is 545537 kJ/mol, while the difference between DPME and 30A cutoffs
+    // is just 1.624 kJ/mol.  The difference is due to the fact that arithmetic mean combination rules are used
+    // up to the cutoff, while the reciprocal space uses the geometric mean.  See DOI: 10.1021/acs.jctc.5b00726
+    ASSERT_EQUAL_TOL(refenergy, energy, 5E-6);
+}
+
+void runPlatformTests();
+
+int main(int argc, char* argv[]) {
+    try {
+        initializeTests(argc, argv);
+
+        // Tests of energy; long cutoff LJ vs. DPME with short cutoffs.
+        test_water125_dpme_vs_long_cutoff_with_exclusions();
+        test_water125_dpme_vs_long_cutoff_no_exclusions();
+
+        runPlatformTests();
+    }
+    catch(const exception& e) {
+        cout << "exception: " << e.what() << endl;
+        return 1;
+    }
+    cout << "Done" << endl;
+    return 0;
+}


### PR DESCRIPTION
Description
=========

This partly addresses the issues raised in #933, but is hardwired for the Lennard-Jones potential (I'll address the arbitrary power version in a plugin, later).  The method uses Lorentz–Berthelot combination rules in real space, but the geometric mean in reciprocal space, as developed in [this paper](http://dx.doi.org/10.1021/acs.jctc.5b00726).

Status
=====

This is far from ready, but I wanted to submit a PR early, to get feedback from anybody that would prefer a different approach to implementing this.

- [ ] Ready to go!

TODO
=====

- [x] Reference implementation, with exclusions.
- [x] Test against large cutoffs.
- [ ] Test case for forces.
- [ ] Properly handle special 1-4 interactions.
- [ ] Convert the CPU platform code, which is just ripped of from NonbondedForce right now.