### PR TITLE
README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build Status](https://travis-ci.org/pandegroup/openmm.svg?branch=master)](https://travis-ci.org/pandegroup/openmm)
+[![Anaconda Cloud Badge](https://anaconda.org/omnia/openmm/badges/downloads.svg)](https://anaconda.org/omnia/openmm)
+
 ## OpenMM: A High Performance Molecular Dynamics Library
 
 Introduction
@@ -14,8 +17,3 @@ Need Help? Check out the [documentation](http://docs.openmm.org/) and [discussio
 [C++ API Reference](http://docs.openmm.org/6.3.0/api-c++/namespaceOpenMM.html)
 
 [Python API Reference](http://docs.openmm.org/6.3.0/api-python/annotated.html)
-
-Badges
-------
-* Travis CI `linux` and `osx` integration tests: [![Build Status](https://travis-ci.org/pandegroup/openmm.svg?branch=master)](https://travis-ci.org/pandegroup/openmm)
-* Anaconda Cloud `openmm` conda release: [![Anaconda Cloud Badge](https://anaconda.org/omnia/openmm/badges/downloads.svg)](https://anaconda.org/omnia/openmm)

--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ Badges
 * Travis CI `linux` and `osx` integration tests:
   * GitHub master [![Build Status](https://travis-ci.org/pandegroup/openmm.svg?branch=master)](https://travis-ci.org/pandegroup/openmm)
   * `openmm-dev` recipe [![Build Status](https://travis-ci.org/omnia-md/conda-dev-recipes.svg?branch=master)](https://travis-ci.org/omnia-md/conda-dev-recipes)
-* Anaconda Cloud `openmm` conda release: [![Anaconda Cloud Badge](https://anaconda.org/pandegroup/openmm/badges/downloads.svg)](https://anaconda.org/pandegroup/openmm)
+* Anaconda Cloud `openmm` conda release: [![Anaconda Cloud Badge](https://anaconda.org/omnia/openmm/badges/downloads.svg)](https://anaconda.org/omnia/openmm)

--- a/README.md
+++ b/README.md
@@ -20,5 +20,4 @@ Badges
 * Travis CI `linux` and `osx` integration tests:
   * GitHub master [![Build Status](https://travis-ci.org/pandegroup/openmm.svg?branch=master)](https://travis-ci.org/pandegroup/openmm)
   * `openmm-dev` recipe [![Build Status](https://travis-ci.org/omnia-md/conda-dev-recipes.svg?branch=master)](https://travis-ci.org/omnia-md/conda-dev-recipes)
-* Anaconda Cloud `openmm` conda release: [![Binstar `openmm` conda release](https://anaconda.org/omnia/openmm/badges/version.svg)](https://anaconda.org/omnia/openmm)
-* Anaconda Cloud `openmm-dev` conda package: [![Binstar `openmm-dev` conda package](https://anaconda.org/omnia/openmm-dev/badges/version.svg)](https://anaconda.org/omnia/openmm-dev)
+* Anaconda Cloud `openmm` conda release: [![Anaconda Cloud Badge](https://anaconda.org/pandegroup/openmm/badges/downloads.svg)](https://anaconda.org/pandegroup/openmm)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,5 @@ Need Help? Check out the [documentation](http://docs.openmm.org/) and [discussio
 
 Badges
 ------
-* Travis CI `linux` and `osx` integration tests:
-  * GitHub master [![Build Status](https://travis-ci.org/pandegroup/openmm.svg?branch=master)](https://travis-ci.org/pandegroup/openmm)
-  * `openmm-dev` recipe [![Build Status](https://travis-ci.org/omnia-md/conda-dev-recipes.svg?branch=master)](https://travis-ci.org/omnia-md/conda-dev-recipes)
+* Travis CI `linux` and `osx` integration tests: [![Build Status](https://travis-ci.org/pandegroup/openmm.svg?branch=master)](https://travis-ci.org/pandegroup/openmm)
 * Anaconda Cloud `openmm` conda release: [![Anaconda Cloud Badge](https://anaconda.org/omnia/openmm/badges/downloads.svg)](https://anaconda.org/omnia/openmm)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,3 @@ Getting Help
 ------------
 
 Need Help? Check out the [documentation](http://docs.openmm.org/) and [discussion forums](https://simtk.org/forums/viewforum.php?f=161).
-
-[C++ API Reference](http://docs.openmm.org/6.3.0/api-c++/namespaceOpenMM.html)
-
-[Python API Reference](http://docs.openmm.org/6.3.0/api-python/annotated.html)


### PR DESCRIPTION
* Remove outdated `openmm-dev` anaconda and travis badges
* Replace `openmm` anaconda badge (previously read 0.0.0) with one that lists total number of downloads
* Move badges to top
* Eliminate outdated links to OpenMM 6.3 Python and C++ references while maintaining links to overall documentation 

Here is a [preview](https://github.com/jchodera/openmm/blob/6516827afc01b885abb45dec847b1d5f8bd974ca/README.md)