### PR TITLE
Fixed bug computing energies without forces

### DIFF
--- a/platforms/cuda/src/kernels/nonbonded.cu
+++ b/platforms/cuda/src/kernels/nonbonded.cu
@@ -278,9 +278,9 @@ extern "C" __global__ void computeNonbonded(
                 localData[tbx+tj].fz += dEdR2.z;
 #endif 
 #endif // end USE_SYMMETRIC
+#endif
 #ifdef ENABLE_SHUFFLE
                 SHUFFLE_WARP_DATA
-#endif
 #endif
 #ifdef USE_EXCLUSIONS
                 excl >>= 1;
@@ -484,9 +484,9 @@ extern "C" __global__ void computeNonbonded(
                     localData[tbx+tj].fz += dEdR2.z;
 #endif 
 #endif // end USE_SYMMETRIC
+#endif
 #ifdef ENABLE_SHUFFLE
                     SHUFFLE_WARP_DATA
-#endif
 #endif
                     tj = (tj + 1) & (TILE_SIZE - 1);
                 }
@@ -555,9 +555,9 @@ extern "C" __global__ void computeNonbonded(
                     localData[tbx+tj].fz += dEdR2.z;
 #endif 
 #endif // end USE_SYMMETRIC
+#endif
 #ifdef ENABLE_SHUFFLE
                     SHUFFLE_WARP_DATA
-#endif
 #endif
                     tj = (tj + 1) & (TILE_SIZE - 1);
                 }


### PR DESCRIPTION
Fixes #1625.

This was really hard to track down!  The error occurs when `ContextImpl::calcForcesAndEnergy()` gets called with `includeEnergy` true but `includeForces` false.  That doesn't happen when you call `getState()`, since even if you don't ask for forces, it still needs them to correct the kinetic energy.  And it doesn't happen within standard integrators, because they don't use energy.  The only place it happens is in a CustomIntegrator that requests energy but not forces.  That happened in #1625 because it specifies the forces as `f0` (only group 0), but the energy as `energy` (all groups).