### PR TITLE
Fix overflow in dcdfile

### DIFF
--- a/wrappers/python/simtk/openmm/app/dcdfile.py
+++ b/wrappers/python/simtk/openmm/app/dcdfile.py
@@ -122,7 +122,7 @@ class DCDFile(object):
         file.seek(8, os.SEEK_SET)
         file.write(struct.pack('<i', self._modelCount))
         file.seek(20, os.SEEK_SET)
-        file.write(struct.pack('<i', self._firstStep+self._modelCount*self._interval))
+        file.write(struct.pack('<i', (self._firstStep+self._modelCount*self._interval) % (2**32-1)))
 
         # Write the data.
 


### PR DESCRIPTION
For simulations with more than 2**32-1 steps that use a DCDReporter (using a 2fs timestep, this is around 2.2 microseconds), line 125 of dcdfile.py breaks because of an overflow.

```
 File "simtk/openmm/app/dcdreporter.py", line 92, in report
   self._dcd.writeModel(state.getPositions(), mm.Vec3(a[0].value_in_unit(nanometer), b[1].value_in_unit(nanometer), c[2].value_in_unit(nanometer))*nanometer)
 File "/simtk/openmm/app/dcdfile.py", line 125, in writeModel
   file.write(struct.pack('<i', self._firstStep+self._modelCount*self._interval))
struct.error: 'i' format requires -2147483648 <= number <= 2147483647
```

In a shell, you can reproduce this with something like

```
In [17]: import struct

In [18]: struct.pack('<i', 2**32)     
---------------------------------------------------------------------------
error                                     Traceback (most recent call last)
<ipython-input-18-06a6912b051f> in <module>()
----> 1 struct.pack('<i', 2**32)

error: 'i' format requires -2147483648 <= number <= 2147483647
```

It seems to be that the least invasive way to fix this is just to wrap around.