### PR TITLE
Fixed bug in switching functions with CustomNonbondedForce

### DIFF
--- a/platforms/cuda/src/CudaKernels.cpp
+++ b/platforms/cuda/src/CudaKernels.cpp
@@ -2271,7 +2271,7 @@ void CudaCalcCustomNonbondedForceKernel::initialize(const System& system, const 
     Lepton::ParsedExpression energyExpression = Lepton::Parser::parse(force.getEnergyFunction(), functions).optimize();
     Lepton::ParsedExpression forceExpression = energyExpression.differentiate("r").optimize();
     map<string, Lepton::ParsedExpression> forceExpressions;
-    forceExpressions["tempEnergy += "] = energyExpression;
+    forceExpressions["real customEnergy = "] = energyExpression;
     forceExpressions["tempForce -= "] = forceExpression;
 
     // Create the kernels.

--- a/platforms/cuda/src/kernels/customNonbonded.cu
+++ b/platforms/cuda/src/kernels/customNonbonded.cu
@@ -14,8 +14,10 @@ if (!isExcluded) {
 #endif
     COMPUTE_FORCE
 #if USE_SWITCH
-    tempForce = tempForce*switchValue - tempEnergy*switchDeriv;
-    tempEnergy *= switchValue;
+    tempForce = tempForce*switchValue - customEnergy*switchDeriv;
+    tempEnergy += customEnergy*switchValue;
+#else
+    tempEnergy += customEnergy;
 #endif
     dEdR += tempForce*invR;
 }

--- a/platforms/opencl/src/OpenCLKernels.cpp
+++ b/platforms/opencl/src/OpenCLKernels.cpp
@@ -2331,7 +2331,7 @@ void OpenCLCalcCustomNonbondedForceKernel::initialize(const System& system, cons
     Lepton::ParsedExpression energyExpression = Lepton::Parser::parse(force.getEnergyFunction(), functions).optimize();
     Lepton::ParsedExpression forceExpression = energyExpression.differentiate("r").optimize();
     map<string, Lepton::ParsedExpression> forceExpressions;
-    forceExpressions["tempEnergy += "] = energyExpression;
+    forceExpressions["real customEnergy = "] = energyExpression;
     forceExpressions["tempForce -= "] = forceExpression;
 
     // Create the kernels.

--- a/platforms/opencl/src/kernels/customNonbonded.cl
+++ b/platforms/opencl/src/kernels/customNonbonded.cl
@@ -14,8 +14,10 @@ if (!isExcluded) {
 #endif
     COMPUTE_FORCE
 #if USE_SWITCH
-    tempForce = tempForce*switchValue - tempEnergy*switchDeriv;
-    tempEnergy *= switchValue;
+    tempForce = tempForce*switchValue - customEnergy*switchDeriv;
+    tempEnergy += customEnergy*switchValue;
+#else
+    tempEnergy += customEnergy;
 #endif
     dEdR += tempForce*invR;
 }


### PR DESCRIPTION
This was a somewhat obscure bug that caused forces and energies to be wrong under a very specialized set of conditions.  To encounter the error, 1) your system needed to included multiple nonbonded forces, 2) at least one of them needed to be a CustomNonbondedForce that enabled the switching function, and 3) you had to be using the CUDA or OpenCL platform.  But even then it wouldn't always happen.  It also depended on the assignment of force groups and the order in which the forces were added to the system.  See https://simtk.org/plugins/phpBB/viewtopicPhpbb.php?f=161&t=7140&p=0&start=0&view= for more information.