### PR TITLE
Created Bond class that can store bond type and order

### DIFF
--- a/wrappers/python/setup.py
+++ b/wrappers/python/setup.py
@@ -229,8 +229,8 @@ def buildKeywordDictionary(major_version_num=MAJOR_VERSION_NUM,
 
 
 def main():
-    if sys.version_info < (2, 6):
-        reportError("OpenMM requires Python 2.6 or better.")
+    if sys.version_info < (2, 7):
+        reportError("OpenMM requires Python 2.7 or better.")
     if platform.system() == 'Darwin':
         macVersion = [int(x) for x in platform.mac_ver()[0].split('.')]
         if tuple(macVersion) < (10, 5):

--- a/wrappers/python/simtk/openmm/app/__init__.py
+++ b/wrappers/python/simtk/openmm/app/__init__.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import
 __docformat__ = "epytext en"
 
 __author__ = "Peter Eastman"
-__copyright__ = "Copyright 2015, Stanford University and Peter Eastman"
+__copyright__ = "Copyright 2016, Stanford University and Peter Eastman"
 __credits__ = []
 __license__ = "MIT"
 __maintainer__ = "Peter Eastman"
@@ -44,3 +44,10 @@ PME = forcefield.PME
 HBonds = forcefield.HBonds
 AllBonds = forcefield.AllBonds
 HAngles = forcefield.HAngles
+
+Single = topology.Single
+Double = topology.Double
+Triple = topology.Triple
+Aromatic = topology.Aromatic
+Amide = topology.Amide
+

--- a/wrappers/python/simtk/openmm/app/internal/singleton.py
+++ b/wrappers/python/simtk/openmm/app/internal/singleton.py
@@ -7,7 +7,7 @@ class Singleton(object):
     _inst = None
     def __new__(cls):
         if cls._inst is None:
-            cls._inst = super(_Singleton, cls).__new__(cls)
+            cls._inst = super(Singleton, cls).__new__(cls)
         return cls._inst
 
     def __reduce__(self):

--- a/wrappers/python/simtk/openmm/app/internal/singleton.py
+++ b/wrappers/python/simtk/openmm/app/internal/singleton.py
@@ -1,0 +1,15 @@
+"""
+Creates a subclass for all classes intended to be a singleton. This
+maintains the correctness of instance is instance even following
+pickling/unpickling
+"""
+class Singleton(object):
+    _inst = None
+    def __new__(cls):
+        if cls._inst is None:
+            cls._inst = super(_Singleton, cls).__new__(cls)
+        return cls._inst
+
+    def __reduce__(self):
+        return repr(self)
+

--- a/wrappers/python/simtk/openmm/app/topology.py
+++ b/wrappers/python/simtk/openmm/app/topology.py
@@ -32,35 +32,37 @@ from __future__ import absolute_import
 __author__ = "Peter Eastman"
 __version__ = "1.0"
 
+from collections import namedtuple
 import os
 import xml.etree.ElementTree as etree
 from simtk.openmm.vec3 import Vec3
+from simtk.openmm.app.internal.singleton import Singleton
 from simtk.unit import nanometers, sqrt, is_quantity
 from copy import deepcopy
 
 # Enumerated values for bond type
 
-class Single(object):
+class Single(Singleton):
     def __repr__(self):
         return 'Single'
 Single = Single()
 
-class Double(object):
+class Double(Singleton):
     def __repr__(self):
         return 'Double'
 Double = Double()
 
-class Triple(object):
+class Triple(Singleton):
     def __repr__(self):
         return 'Triple'
 Triple = Triple()
 
-class Aromatic(object):
+class Aromatic(Singleton):
     def __repr__(self):
         return 'Aromatic'
 Aromatic = Aromatic()
 
-class Amide(object):
+class Amide(Singleton):
     def __repr__(self):
         return 'Amide'
 Amide = Amide()
@@ -437,15 +439,15 @@ class Atom(object):
     def __repr__(self):
         return "<Atom %d (%s) of chain %d residue %d (%s)>" % (self.index, self.name, self.residue.chain.index, self.residue.index, self.residue.name)
 
-class Bond(tuple):
+class Bond(namedtuple('Bond', ['atom1', 'atom2'])):
     """A Bond object represents a bond between two Atoms within a Topology.
-    
+
     This class extends tuple, and may be interpreted as a 2 element tuple of Atom objects.
     It also has fields that can optionally be used to describe the bond order and type of bond."""
 
     def __new__(cls, atom1, atom2, type=None, order=None):
         """Create a new Bond.  You should call addBond() on the Topology instead of calling this directly."""
-        bond = tuple.__new__(cls, (atom1, atom2))
+        bond = super(Bond, cls).__new__(cls, atom1, atom2)
         bond.type = type
         bond.order = order
         return bond

--- a/wrappers/python/simtk/openmm/app/topology.py
+++ b/wrappers/python/simtk/openmm/app/topology.py
@@ -6,7 +6,7 @@ Simbios, the NIH National Center for Physics-Based Simulation of
 Biological Structures at Stanford, funded under the NIH Roadmap for
 Medical Research, grant U54 GM072970. See https://simtk.org.
 
-Portions copyright (c) 2012-2015 Stanford University and the Authors.
+Portions copyright (c) 2012-2016 Stanford University and the Authors.
 Authors: Peter Eastman
 Contributors:
 
@@ -37,6 +37,33 @@ import xml.etree.ElementTree as etree
 from simtk.openmm.vec3 import Vec3
 from simtk.unit import nanometers, sqrt, is_quantity
 from copy import deepcopy
+
+# Enumerated values for bond type
+
+class Single(object):
+    def __repr__(self):
+        return 'Single'
+Single = Single()
+
+class Double(object):
+    def __repr__(self):
+        return 'Double'
+Double = Double()
+
+class Triple(object):
+    def __repr__(self):
+        return 'Triple'
+Triple = Triple()
+
+class Aromatic(object):
+    def __repr__(self):
+        return 'Aromatic'
+Aromatic = Aromatic()
+
+class Amide(object):
+    def __repr__(self):
+        return 'Amide'
+Amide = Amide()
 
 class Topology(object):
     """Topology stores the topological information about a system.
@@ -155,7 +182,7 @@ class Topology(object):
         residue._atoms.append(atom)
         return atom
 
-    def addBond(self, atom1, atom2):
+    def addBond(self, atom1, atom2, type=None, order=None):
         """Create a new bond and add it to the Topology.
 
         Parameters
@@ -164,8 +191,13 @@ class Topology(object):
             The first Atom connected by the bond
         atom2 : Atom
             The second Atom connected by the bond
+        type : object=None
+            The type of bond to add.  Allowed values are None, Single, Double, Triple,
+            Aromatic, or Amide.
+        order : int=None
+            The bond order, or None if it is not specified
         """
-        self._bonds.append((atom1, atom2))
+        self._bonds.append(Bond(atom1, atom2, type, order))
 
     def chains(self):
         """Iterate over all Chains in the Topology."""
@@ -387,7 +419,7 @@ class Residue(object):
         return "<Residue %d (%s) of chain %d>" % (self.index, self.name, self.chain.index)
 
 class Atom(object):
-    """An Atom object represents a residue within a Topology."""
+    """An Atom object represents an atom within a Topology."""
 
     def __init__(self, name, element, index, residue, id):
         """Construct a new Atom.  You should call addAtom() on the Topology instead of calling this directly."""
@@ -404,3 +436,32 @@ class Atom(object):
 
     def __repr__(self):
         return "<Atom %d (%s) of chain %d residue %d (%s)>" % (self.index, self.name, self.residue.chain.index, self.residue.index, self.residue.name)
+
+class Bond(tuple):
+    """A Bond object represents a bond between two Atoms within a Topology.
+    
+    This class extends tuple, and may be interpreted as a 2 element tuple of Atom objects.
+    It also has fields that can optionally be used to describe the bond order and type of bond."""
+
+    def __new__(cls, atom1, atom2, type=None, order=None):
+        """Create a new Bond.  You should call addBond() on the Topology instead of calling this directly."""
+        bond = tuple.__new__(cls, (atom1, atom2))
+        bond.type = type
+        bond.order = order
+        return bond
+
+    def __getnewargs__(self):
+        "Support for pickle protocol 2: http://docs.python.org/2/library/pickle.html#pickling-and-unpickling-normal-class-instances"
+        return self[0], self[1], self.type, self.order
+
+    def __deepcopy__(self, memo):
+        return Bond(self[0], self[1], self.type, self.order)
+
+    def __repr__(self):
+        s = "Bond(%s, %s" % (self[0], self[1])
+        if self.type is not None:
+            s = "%s, type=%s" % (s, self.type)
+        if self.order is not None:
+            s = "%s, order=%d" % (s, self.order)
+        s += ")"
+        return s

--- a/wrappers/python/tests/TestTopology.py
+++ b/wrappers/python/tests/TestTopology.py
@@ -1,3 +1,4 @@
+import pickle
 import sys
 import unittest
 from simtk.openmm.app import *
@@ -25,6 +26,14 @@ class TestTopology(unittest.TestCase):
     def test_getters(self):
         """Test getters for number of atoms, residues, chains."""
         self.check_pdbfile('systems/1T2Y.pdb', 271, 25, 1)
+
+    def test_bondtype_singleton(self):
+        """ Tests that the bond types are really singletons """
+        self.assertIs(Single, pickle.loads(pickle.dumps(Single)))
+        self.assertIs(Double, pickle.loads(pickle.dumps(Double)))
+        self.assertIs(Triple, pickle.loads(pickle.dumps(Triple)))
+        self.assertIs(Aromatic, pickle.loads(pickle.dumps(Aromatic)))
+        self.assertIs(Amide, pickle.loads(pickle.dumps(Amide)))
 
     def test_residue_bonds(self):
         """Test retrieving bonds for a residue produces expected results."""


### PR DESCRIPTION
Fixes #1443 

This builds off of #1668 with a few other features:

1. `Bond` now inherits from `namedtuple` as an example of what I meant (and passing tests will demonstrate that it still behaves the same, hopefully)
1. The bond type classes are now *really* singletons and work with pickling.  This is particularly important to make `Topology` play nicely with multiprocessing and/or mpi4py, if I recall correctly.  It also adds a test for that.

The second point in particular is important, IMO, since it allows you to use the `is` binary operator to compare the `bond.type` to the enumerated options.  This is the natural operator to use (over, for instance, `==`, which wouldn't work correctly upon pickling, either).

The first change here can be scrapped.