### PR TITLE
User-defined atom types for the ForceField class

### DIFF
--- a/wrappers/python/simtk/openmm/app/forcefield.py
+++ b/wrappers/python/simtk/openmm/app/forcefield.py
@@ -962,7 +962,7 @@ class ForceField(object):
 
     def createSystem(self, topology, nonbondedMethod=NoCutoff, nonbondedCutoff=1.0*unit.nanometer,
                      constraints=None, rigidWater=True, removeCMMotion=True, hydrogenMass=None, residueTemplates=dict(),
-                     ignoreExternalBonds=False, **args):
+                     ignoreExternalBonds=False, atomTypes=None, atomCharges=None, **args):
         """Construct an OpenMM System representing a Topology with this force field.
 
         Parameters
@@ -998,6 +998,15 @@ class ForceField(object):
             not terminated properly.  This option can create ambiguities where multiple
             templates match the same residue.  If that happens, use the residueTemplates
             argument to specify which one to use.
+        atomTypes : dict
+            A dictionary of atom type strings (e.g. 'ca') where the key is the index of an
+            atom in the input geometry. This allows atom types to be assigned by an external 
+            program rather than relying on template matching. Further, it can allow simulations
+            to be made on the fly with residues that do not have templates.
+        atomCharges : dict
+            A dictionary of point charge values where the key is the index of an atom in the
+            input geometry. This is necessary when a residue does not have a template and thus does
+            not have charges.
         args
             Arbitrary additional keyword arguments may also be specified.
             This allows extra parameters to be specified that are specific to
@@ -1031,52 +1040,64 @@ class ForceField(object):
             data.atomBonds[bond.atom1].append(i)
             data.atomBonds[bond.atom2].append(i)
 
-        # Find the template matching each residue and assign atom types.
+        # Check that if atomTypes or atomCharges are passed in, both are passed in or neither is passed in
+        if (bool(atomTypes) ^ bool(atomCharges)):
+            raise Exception('Need to provide both atomTypes and atomCharges')
 
-        unmatchedResidues = []
-        for chain in topology.chains():
-            for res in chain.residues():
-                if res in residueTemplates:
-                    tname = residueTemplates[res]
-                    template = self._templates[tname]
-                    matches = _matchResidue(res, template, bondedToAtom, ignoreExternalBonds)
+        if atomTypes is None:
+
+            # Find the template matching each residue and assign atom types.
+
+            unmatchedResidues = []
+            for chain in topology.chains():
+                for res in chain.residues():
+                    if res in residueTemplates:
+                        tname = residueTemplates[res]
+                        template = self._templates[tname]
+                        matches = _matchResidue(res, template, bondedToAtom, ignoreExternalBonds)
+                        if matches is None:
+                            raise Exception('User-supplied template %s does not match the residue %d (%s)' % (tname, res.index+1, res.name))
+                    else:
+                        # Attempt to match one of the existing templates.
+                        [template, matches] = self._getResidueTemplateMatches(res, bondedToAtom, ignoreExternalBonds=ignoreExternalBonds)
                     if matches is None:
-                        raise Exception('User-supplied template %s does not match the residue %d (%s)' % (tname, res.index+1, res.name))
-                else:
-                    # Attempt to match one of the existing templates.
-                    [template, matches] = self._getResidueTemplateMatches(res, bondedToAtom, ignoreExternalBonds=ignoreExternalBonds)
+                        unmatchedResidues.append(res)
+                    else:
+                        data.recordMatchedAtomParameters(res, template, matches)
+
+            # Try to apply patches to find matches for any unmatched residues.
+
+            if len(unmatchedResidues) > 0:
+                unmatchedResidues = _applyPatchesToMatchResidues(self, data, unmatchedResidues, bondedToAtom, ignoreExternalBonds)
+
+            # If we still haven't found a match for a residue, attempt to use residue template generators to create
+            # new templates (and potentially atom types/parameters).
+
+            for res in unmatchedResidues:
+                # A template might have been generated on an earlier iteration of this loop.
+                [template, matches] = self._getResidueTemplateMatches(res, bondedToAtom, ignoreExternalBonds=ignoreExternalBonds)
                 if matches is None:
-                    unmatchedResidues.append(res)
+                    # Try all generators.
+                    for generator in self._templateGenerators:
+                        if generator(self, res):
+                            # This generator has registered a new residue template that should match.
+                            [template, matches] = self._getResidueTemplateMatches(res, bondedToAtom, ignoreExternalBonds=ignoreExternalBonds)
+                            if matches is None:
+                                # Something went wrong because the generated template does not match the residue signature.
+                                raise Exception('The residue handler %s indicated it had correctly parameterized residue %s, but the generated template did not match the residue signature.' % (generator.__class__.__name__, str(res)))
+                            else:
+                                # We successfully generated a residue template.  Break out of the for loop.
+                                break
+                if matches is None:
+                    raise ValueError('No template found for residue %d (%s).  %s' % (res.index+1, res.name, _findMatchErrors(self, res)))
                 else:
                     data.recordMatchedAtomParameters(res, template, matches)
 
-        # Try to apply patches to find matches for any unmatched residues.
-
-        if len(unmatchedResidues) > 0:
-            unmatchedResidues = _applyPatchesToMatchResidues(self, data, unmatchedResidues, bondedToAtom, ignoreExternalBonds)
-
-        # If we still haven't found a match for a residue, attempt to use residue template generators to create
-        # new templates (and potentially atom types/parameters).
-
-        for res in unmatchedResidues:
-            # A template might have been generated on an earlier iteration of this loop.
-            [template, matches] = self._getResidueTemplateMatches(res, bondedToAtom, ignoreExternalBonds=ignoreExternalBonds)
-            if matches is None:
-                # Try all generators.
-                for generator in self._templateGenerators:
-                    if generator(self, res):
-                        # This generator has registered a new residue template that should match.
-                        [template, matches] = self._getResidueTemplateMatches(res, bondedToAtom, ignoreExternalBonds=ignoreExternalBonds)
-                        if matches is None:
-                            # Something went wrong because the generated template does not match the residue signature.
-                            raise Exception('The residue handler %s indicated it had correctly parameterized residue %s, but the generated template did not match the residue signature.' % (generator.__class__.__name__, str(res)))
-                        else:
-                            # We successfully generated a residue template.  Break out of the for loop.
-                            break
-            if matches is None:
-                raise ValueError('No template found for residue %d (%s).  %s' % (res.index+1, res.name, _findMatchErrors(self, res)))
-            else:
-                data.recordMatchedAtomParameters(res, template, matches)
+        else:
+            # Assign user provided atom types and charges to atoms
+            for atom in topology.atoms():
+                data.atomType[atom] = atomTypes[atom.index]
+                data.atomParameters[atom] = {'charge':atomCharges[atom.index]}
 
         # Create the System and add atoms
 

--- a/wrappers/python/simtk/openmm/app/modeller.py
+++ b/wrappers/python/simtk/openmm/app/modeller.py
@@ -255,7 +255,7 @@ class Modeller(object):
         self.topology = newTopology
         self.positions = newPositions
 
-    def addSolvent(self, forcefield, model='tip3p', boxSize=None, boxVectors=None, padding=None, numAdded=None, positiveIon='Na+', negativeIon='Cl-', ionicStrength=0*molar, neutralize=True):
+    def addSolvent(self, forcefield, model='tip3p', boxSize=None, boxVectors=None, padding=None, numAdded=None, positiveIon='Na+', negativeIon='Cl-', ionicStrength=0*molar, neutralize=True, atomTypes=None, atomCharges=None):
         """Add solvent (both water and ions) to the model to fill a rectangular box.
 
         The algorithm works as follows:
@@ -301,6 +301,15 @@ class Modeller(object):
             Note that only monovalent ions are currently supported.
         neutralize : bool=True
             whether to add ions to neutralize the system
+        atomTypes : dict
+            A dictionary of atom type strings (e.g. 'ca') where the key is the index of an
+            atom in the input geometry. This allows atom types to be assigned by an external 
+            program rather than relying on template matching. Further, it can allow simulations
+            to be made on the fly with residues that do not have templates.
+        atomCharges : dict
+            A dictionary of point charge values where the key is the index of an atom in the
+            input geometry. This is necessary when a residue does not have a template and thus does
+            not have charges.
         """
         if len([x for x in (boxSize, boxVectors, padding, numAdded) if x is not None]) > 1:
             raise ValueError('At most one of the following arguments may be specified: boxSize, boxVectors, padding, numAdded')
@@ -371,8 +380,13 @@ class Modeller(object):
         negativeElement = negIonElements[negativeIon]
 
         # Have the ForceField build a System for the solute from which we can determine van der Waals radii.
+        if (bool(atomTypes) ^ bool(atomCharges)):
+            raise Exception('If atomTypes or atomCharges are provided, both need to be provided')
+        if atomTypes is None:
+            system = forcefield.createSystem(self.topology)
+        else:
+            system = forcefield.createSystem(self.topology, atomTypes=atomTypes, atomCharges=atomCharges) 
 
-        system = forcefield.createSystem(self.topology)
         nonbonded = None
         for i in range(system.getNumForces()):
             if isinstance(system.getForce(i), NonbondedForce):
@@ -859,7 +873,6 @@ class Modeller(object):
 
         if forcefield is not None:
             # Use the ForceField the user specified.
-
             system = forcefield.createSystem(newTopology, rigidWater=False, nonbondedMethod=CutoffNonPeriodic)
             atoms = list(newTopology.atoms())
             for i in range(system.getNumParticles()):
@@ -1117,7 +1130,7 @@ class Modeller(object):
         if len(missingPositions) > 0:
             # There were particles whose position we couldn't identify before, since they were neither virtual sites nor Drude particles.
             # Try to figure them out based on bonds.  First, use the ForceField to create a list of every bond involving one of them.
-
+    
             system = forcefield.createSystem(newTopology, constraints=AllBonds)
             bonds = []
             for i in range(system.getNumConstraints()):


### PR DESCRIPTION
Added keyword arguments to pass in user-defined atom types and atom charges in the ForceField createSystem method. This allows systems to be made that do not have templates as assigning atom types and atom charges from dictionaries eliminates the necessity of a template. 

This is useful for small molecules where templates would have to be created; with these changes, simulations can be made on the fly. Also added these changes in the Modeller class addSolvent method.

One issue I have ran across is that the Modeller class will create a system during the addition of solvent before adding solvent, but it does not return the system. In the case of passing in atom types and charges, using dictionaries for atom types and charges with the new modeller positions and topology will fail as the new water molecules will not be in the dictionaries. Perhaps the system that is created during the addition of solvent molecules could be returned if the atom types and charges are passed in as arguments. 