### PR TITLE
Automate Windows builds

### DIFF
--- a/devtools/packaging/scripts/windows/Vagrantfile
+++ b/devtools/packaging/scripts/windows/Vagrantfile
@@ -1,0 +1,10 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "gusztavvargadr/windows10ee"
+  config.vm.provision :shell, path: "prepare.ps1"
+
+  config.vm.provider :virtualbox do |vb|
+    vb.customize ["modifyvm", :id, "--memory", "2048"]
+    vb.customize ["modifyvm", :id, "--cpus", "2"]
+    vb.customize ["modifyvm", :id, "--ioapic", "on"]
+  end  
+end

--- a/devtools/packaging/scripts/windows/build.bat
+++ b/devtools/packaging/scripts/windows/build.bat
@@ -1,16 +1,13 @@
-REM "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
-
-cd openmm
 mkdir build
 cd build
 
-set FFTW=C:\Program Files\Miniconda3\pkgs\fftw3f-3.3.4-vc14_2\Library
+set FFTW=C:\Miniconda3\pkgs\fftw3f-3.3.4-vc14_2\Library
 "C:\Program Files\CMake\bin\cmake.exe" .. -G "NMake Makefiles JOM" -DCMAKE_BUILD_TYPE=Release -DOPENMM_GENERATE_API_DOCS=ON -DFFTW_INCLUDES="%FFTW%/include" -DFFTW_LIBRARY="%FFTW%/lib/libfftw3f-3.lib"
 
 jom
 jom PythonInstall
 jom C++ApiDocs
 jom PythonApiDocs
-# jom sphinxpdf
+REM jom sphinxpdf
 jom install
 jom PythonBdist

--- a/devtools/packaging/scripts/windows/build.bat
+++ b/devtools/packaging/scripts/windows/build.bat
@@ -1,0 +1,16 @@
+REM "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
+
+cd openmm
+mkdir build
+cd build
+
+set FFTW=C:\Program Files\Miniconda3\pkgs\fftw3f-3.3.4-vc14_2\Library
+"C:\Program Files\CMake\bin\cmake.exe" .. -G "NMake Makefiles JOM" -DCMAKE_BUILD_TYPE=Release -DOPENMM_GENERATE_API_DOCS=ON -DFFTW_INCLUDES="%FFTW%/include" -DFFTW_LIBRARY="%FFTW%/lib/libfftw3f-3.lib"
+
+jom
+jom PythonInstall
+jom C++ApiDocs
+jom PythonApiDocs
+# jom sphinxpdf
+jom install
+jom PythonBdist

--- a/devtools/packaging/scripts/windows/build.bat
+++ b/devtools/packaging/scripts/windows/build.bat
@@ -2,7 +2,10 @@ mkdir build
 cd build
 
 set FFTW=C:\Miniconda3\pkgs\fftw3f-3.3.4-vc14_2\Library
-"C:\Program Files\CMake\bin\cmake.exe" .. -G "NMake Makefiles JOM" -DCMAKE_BUILD_TYPE=Release -DOPENMM_GENERATE_API_DOCS=ON -DFFTW_INCLUDES="%FFTW%/include" -DFFTW_LIBRARY="%FFTW%/lib/libfftw3f-3.lib"
+set APPSDK=C:\Program Files (x86)\AMD APP SDK\2.9-1
+"C:\Program Files\CMake\bin\cmake.exe" .. -G "NMake Makefiles JOM" -DCMAKE_BUILD_TYPE=Release -DOPENMM_GENERATE_API_DOCS=ON ^
+    -DOPENCL_INCLUDE_DIR="%APPSDK%\include" -DOPENCL_LIBRARY="%APPSDK%\lib\x86_64\OpenCL.lib" ^
+    -DFFTW_INCLUDES="%FFTW%/include" -DFFTW_LIBRARY="%FFTW%/lib/libfftw3f-3.lib"
 
 jom
 jom PythonInstall

--- a/devtools/packaging/scripts/windows/prepare.ps1
+++ b/devtools/packaging/scripts/windows/prepare.ps1
@@ -9,6 +9,11 @@ choco install -y doxygen.portable swig cmake doxygen.install vcbuildtools git jo
 wget https://developer.nvidia.com/compute/cuda/8.0/prod/network_installers/cuda_8.0.44_win10_network-exe -UseBasicParsing -OutFile cuda_8.0.44_win10_network.exe
 .\cuda_8.0.44_win10_network.exe -s compiler_8.0 cudart_8.0 cufft_8.0 cufft_dev_8.0 nvrtc_8.0 nvrtc_dev_8.0 | Out-Null
 
+# Install AMD APP SDK.
+
+wget https://s3.amazonaws.com/omnia-ci/AMD-APP-SDK-v2.9-1.599.381-GA-Full-windows-64.exe -UseBasicParsing -OutFile AMD-APP-SDK-v2.9-1.599.381-GA-Full-windows-64.exe
+.\AMD-APP-SDK-v2.9-1.599.381-GA-Full-windows-64.exe /S /v/qn | Out-Null
+
 # Install Miniconda.
 
 wget https://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86_64.exe -UseBasicParsing -OutFile Miniconda3-latest-Windows-x86_64.exe

--- a/devtools/packaging/scripts/windows/prepare.ps1
+++ b/devtools/packaging/scripts/windows/prepare.ps1
@@ -1,0 +1,20 @@
+cd C:\Users\vagrant
+
+# Install everything we can with choco.
+
+choco install -y doxygen.portable swig cmake doxygen.install vcbuildtools git jom
+
+# Install CUDA.
+
+wget https://developer.nvidia.com/compute/cuda/8.0/prod/network_installers/cuda_8.0.44_win10_network-exe -UseBasicParsing -OutFile cuda_8.0.44_win10_network.exe
+.\cuda_8.0.44_win10_network.exe -s compiler_8.0 cudart_8.0 cufft_8.0 cufft_dev_8.0 nvrtc_8.0 nvrtc_dev_8.0 | Out-Null
+
+# Install Miniconda.
+
+wget https://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86_64.exe -UseBasicParsing -OutFile Miniconda3-latest-Windows-x86_64.exe
+Start-Process -Wait -FilePath Miniconda3-latest-Windows-x86_64.exe -ArgumentList '/S'
+
+# Install software with conda.
+
+& "C:\Program Files\Miniconda3\Scripts\conda.exe" install -y -c omnia fftw3f jinja2 lxml sphinx sphinxcontrib-autodoc_doxygen sphinxcontrib-lunrsearch
+& "C:\Program Files\Miniconda3\Scripts\pip.exe" install sphinxcontrib.bibtex

--- a/devtools/packaging/scripts/windows/prepare.ps1
+++ b/devtools/packaging/scripts/windows/prepare.ps1
@@ -12,9 +12,9 @@ wget https://developer.nvidia.com/compute/cuda/8.0/prod/network_installers/cuda_
 # Install Miniconda.
 
 wget https://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86_64.exe -UseBasicParsing -OutFile Miniconda3-latest-Windows-x86_64.exe
-Start-Process -Wait -FilePath Miniconda3-latest-Windows-x86_64.exe -ArgumentList '/S'
+.\Miniconda3-latest-Windows-x86_64.exe /S /D=C:\Miniconda3 | Out-Null
 
 # Install software with conda.
 
-& "C:\Program Files\Miniconda3\Scripts\conda.exe" install -y -c omnia fftw3f jinja2 lxml sphinx sphinxcontrib-autodoc_doxygen sphinxcontrib-lunrsearch
-& "C:\Program Files\Miniconda3\Scripts\pip.exe" install sphinxcontrib.bibtex
+& "C:\Miniconda3\Scripts\conda.exe" install -y -c omnia fftw3f jinja2 lxml sphinx sphinxcontrib-autodoc_doxygen sphinxcontrib-lunrsearch conda-build
+& "C:\Miniconda3\Scripts\pip.exe" install sphinxcontrib.bibtex


### PR DESCRIPTION
I'm making progress on this.  Slowly.  And very painfully.  And why does nothing ever work?  And did I mention how much I hate Windows?  It's bad for my health.

It's not yet fully automated, but it's a lot closer than before.  I'm using Vagrant to create a VM.  Then I log into it, clone the OpenMM repository inside it, and run the build script to do the build.

I've never managed to get sphinx to build pdfs on Windows.  See https://github.com/pandegroup/openmm/issues/1362#issuecomment-187351460.  And I don't think it's worth worrying about that right now.  So for this release I'll probably just disable building documentation, then copy over a docs directory from one of the other builds.

Can we drop support for Python 3.4 on Windows?  To build for Python 3.5, we use Visual Studio 2015 which I can get with a simple `choco install vcbuildtools`.  But Python 3.4 needs Visual Studio 2010, which is much harder to install.  *Much* harder.

I've discovered that choco is awesome when it works, which unfortunately isn't anywhere close to 100% of the time.  It fails unpredictably and erratically in various ways.  Something will be working perfectly, and then stop working for no apparent reason.  Why does nothing ever work?

Did I mention how much I hate Windows?