### PR TITLE
Fixed bug merging steps in CustomIntegrator

### DIFF
--- a/platforms/cuda/src/CudaKernels.cpp
+++ b/platforms/cuda/src/CudaKernels.cpp
@@ -7098,7 +7098,7 @@ void CudaIntegrateCustomStepKernel::prepareForComputation(ContextImpl& context, 
         // Identify steps that can be merged into a single kernel.
         
         for (int step = 1; step < numSteps; step++) {
-            if ((needsForces[step] || needsEnergy[step]) && (invalidatesForces[step-1] || forceGroupFlags[step] != forceGroupFlags[step-1]))
+            if (invalidatesForces[step-1] || forceGroupFlags[step] != forceGroupFlags[step-1])
                 continue;
             if (stepType[step-1] == CustomIntegrator::ComputePerDof && stepType[step] == CustomIntegrator::ComputePerDof)
                 merged[step] = true;

--- a/platforms/opencl/src/OpenCLKernels.cpp
+++ b/platforms/opencl/src/OpenCLKernels.cpp
@@ -7387,7 +7387,7 @@ void OpenCLIntegrateCustomStepKernel::prepareForComputation(ContextImpl& context
         // Identify steps that can be merged into a single kernel.
         
         for (int step = 1; step < numSteps; step++) {
-            if ((needsForces[step] || needsEnergy[step]) && (invalidatesForces[step-1] || forceGroupFlags[step] != forceGroupFlags[step-1]))
+            if (invalidatesForces[step-1] || forceGroupFlags[step] != forceGroupFlags[step-1])
                 continue;
             if (stepType[step-1] == CustomIntegrator::ComputePerDof && stepType[step] == CustomIntegrator::ComputePerDof)
                 merged[step] = true;


### PR DESCRIPTION
See https://simtk.org/plugins/phpBB/viewtopicPhpbb.php?f=161&t=7284&p=19138.

The error was in selecting steps to merge into a single GPU kernel.  It happened when you had three per-DOF computations in a row with the following properties:

Step 1: Invalidates forces (such as by modifying x)
Step 2: Neither uses nor invalidates forces
Step 3: Uses forces

Merging steps 1 and 2 is valid, and merging steps 2 and 3 is also valid, but merging all three steps is not.  It needs to recompute forces somewhere between step 1 and step 3.

The fix is perhaps a bit overly conservative.  I made it so if a step invalidates forces, it will *never* merge that with the following step.  In some cases that will prevent it from merging steps even though it would be ok to do so.  But it's really easy to make mistakes in this logic, and the effect on performance is probably negligible, so I decided it's better to be overly cautious.