### PR TITLE
Avoid adding hydrogens at same location

### DIFF
--- a/wrappers/python/simtk/openmm/app/modeller.py
+++ b/wrappers/python/simtk/openmm/app/modeller.py
@@ -870,7 +870,7 @@ class Modeller(object):
             # and causes hydrogens to spread out evenly.
 
             system = System()
-            nonbonded = CustomNonbondedForce('100/((r/0.1)^4+1)')
+            nonbonded = CustomNonbondedForce('100/(r/0.1)^4')
             nonbonded.setNonbondedMethod(CustomNonbondedForce.CutoffNonPeriodic);
             nonbonded.setCutoffDistance(1*nanometer)
             bonds = HarmonicBondForce()


### PR DESCRIPTION
If you call `addHydrogens()` but don't specify a forcefield, it generates a simple one designed to space out the added hydrogens evenly.  It was using a soft core repulsive force that went to 0 at r=0.  That meant it would occasionally add two hydrogens at the same location.  I've switched it to a hard core force that doesn't have that problem.