### PR TITLE
Fix for errors on Pascal GPUs

### DIFF
--- a/platforms/opencl/src/kernels/findInteractingBlocks.cl
+++ b/platforms/opencl/src/kernels/findInteractingBlocks.cl
@@ -99,7 +99,7 @@ __kernel void findBlocksWithInteractions(real4 periodicBoxSize, real4 invPeriodi
     __local real3 posBuffer[GROUP_SIZE];
     __local volatile int workgroupTileIndex[GROUP_SIZE/32];
     __local bool includeBlockFlags[GROUP_SIZE];
-    __local short2 atomCountBuffer[GROUP_SIZE];
+    __local volatile short2 atomCountBuffer[GROUP_SIZE];
     __local int* buffer = workgroupBuffer+BUFFER_SIZE*(warpStart/32);
     __local int* exclusionsForX = warpExclusions+MAX_EXCLUSIONS*(warpStart/32);
     __local volatile int* tileStartIndex = workgroupTileIndex+(warpStart/32);


### PR DESCRIPTION
Fixes #1651.  This only works if you have driver 375.20 or later.  It does *not* work with driver 367.48, which is the one bundled with CUDA 8.0.