### PR TITLE
Fix handling of scientific notation for field 7 in torsions in certain GROMACS topologies

### DIFF
--- a/wrappers/python/simtk/openmm/app/gromacstopfile.py
+++ b/wrappers/python/simtk/openmm/app/gromacstopfile.py
@@ -772,7 +772,7 @@ class GromacsTopFile(object):
                                 if periodic is None:
                                     periodic = mm.PeriodicTorsionForce()
                                     sys.addForce(periodic)
-                                periodic.addTorsion(baseAtomIndex+atoms[0], baseAtomIndex+atoms[1], baseAtomIndex+atoms[2], baseAtomIndex+atoms[3], int(params[7]), float(params[5])*degToRad, k)
+                                periodic.addTorsion(baseAtomIndex+atoms[0], baseAtomIndex+atoms[1], baseAtomIndex+atoms[2], baseAtomIndex+atoms[3], int(float(params[7])), float(params[5])*degToRad, k)
                         elif dihedralType == '2':
                             # Harmonic torsion
                             k = float(params[6])


### PR DESCRIPTION
Certain GROMACS topologies (see https://github.com/choderalab/yank/issues/623) fail to process correctly when the final term in a torsion uses scientific notation, as it is handled as an integer. Specifically, terms like this are problematic:

```
      1       2       3       4     1    1.80000080e+02    1.51670000e+01    2.00000000e+00
```
and produce an error `ValueError: invalid literal for int() with base 10: '2.00000000e+00'` due to the fact that int('2.00000000e+00') raises a value error. Seems like the simplest fix is to process as a float (which works correctly) and if, indeed, this is supposed to be an int (can someone confirm?) then cast to an int after reading.