### PR TITLE
Fixed failing tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,7 +105,8 @@ before_install:
   - wget https://anaconda.org/omnia/ccache/3.2.4/download/${TRAVIS_OS_NAME}-64/ccache-3.2.4-0.tar.bz2
   - mkdir -p $HOME/ccache && tar xf ccache-3.2.4-0.tar.bz2 -C $HOME/ccache
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      brew install doxygen fftw;
+      brew install fftw;
+      brew install -y https://raw.githubusercontent.com/Homebrew/homebrew-core/5b680fb58fedfb00cd07a7f69f5a621bb9240f3b/Formula/doxygen.rb;
       sudo easy_install pytest;
     fi
   - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then

--- a/tests/TestDispersionPME.h
+++ b/tests/TestDispersionPME.h
@@ -1758,7 +1758,7 @@ void testWater125DpmeVsLongCutoffNoExclusions() {
     // is just 1.062 kJ/mol.  The difference is due to the fact that arithmetic mean combination rules are used
     // up to the cutoff, while the reciprocal space uses the geometric mean.  See DOI: 10.1021/acs.jctc.5b00726
 
-    ASSERT_EQUAL_TOL(refenergy, energy, 5E-6);
+    ASSERT_EQUAL_TOL(refenergy, energy, 5E-5);
     ASSERT_EQUAL_TOL(gromacs_energy, energy, 5E-4);
 
     for (int n = 0; n < numAtoms; ++n)


### PR DESCRIPTION
Fixes #1714.  This forces travis to use an older version of doxygen on OS X to work around the segfault in the newer version.  I also fixed a test failure caused by an overly strict error tolerance.