### PR TITLE
Allow docs to build in Sphinx 1.3.1 and 1.5.1

### DIFF
--- a/docs-source/developerguide/conf.py
+++ b/docs-source/developerguide/conf.py
@@ -185,14 +185,14 @@ latex_elements = {
     \\usepackage{caption}
     \\setcounter{tocdepth}{3}
     \\captionsetup[figure]{labelformat=empty}
-    % Backwards behavior for sphinx < 1.5
+    % Backwards compatibility for sphinx < 1.5
     \\let\\DUspan\\null % force DUspan to be defined
     \\renewcommand{\DUspan}[2]{%
         \\IfEqCase{#1}{%
             {code}{\\small{}\\texttt{#2}\\normalsize{}}
         }[\\PackageError{DUspan}{Unrecognized option passed to DUspan: #1}{}]%
     }%
-    % Sphinx > 1.5 behavior (github.com/sphinx-doc/sphinx/issues/2231)
+    % Sphinx > 1.5 compatibility (github.com/sphinx-doc/sphinx/issues/2231)
     \\newcommand{\\DUrolecode}[1]{%
         \\small{}\\texttt{#1}\\normalsize{}%
     }%""",

--- a/docs-source/developerguide/conf.py
+++ b/docs-source/developerguide/conf.py
@@ -185,10 +185,16 @@ latex_elements = {
     \\usepackage{caption}
     \\setcounter{tocdepth}{3}
     \\captionsetup[figure]{labelformat=empty}
+    % Backwards behavior for sphinx < 1.5
+    \\let\\DUspan\\null % force DUspan to be defined
     \\renewcommand{\DUspan}[2]{%
         \\IfEqCase{#1}{%
-            {code}{\\small{}\\texttt{#2}\\normalsize{}}%
+            {code}{\\small{}\\texttt{#2}\\normalsize{}}
         }[\\PackageError{DUspan}{Unrecognized option passed to DUspan: #1}{}]%
+    }%
+    % Sphinx > 1.5 behavior (github.com/sphinx-doc/sphinx/issues/2231)
+    \\newcommand{\\DUrolecode}[1]{%
+        \\small{}\\texttt{#1}\\normalsize{}%
     }%""",
 }
 

--- a/docs-source/usersguide/conf.py
+++ b/docs-source/usersguide/conf.py
@@ -185,10 +185,16 @@ latex_elements = {
     \\usepackage{caption}
     \\setcounter{tocdepth}{3}
     \\captionsetup[figure]{labelformat=empty}
+    % Backwards behavior for sphinx < 1.5
+    \\let\\DUspan\\null % force DUspan to be defined
     \\renewcommand{\DUspan}[2]{%
         \\IfEqCase{#1}{%
-            {code}{\\small{}\\texttt{#2}\\normalsize{}}%
+            {code}{\\small{}\\texttt{#2}\\normalsize{}}
         }[\\PackageError{DUspan}{Unrecognized option passed to DUspan: #1}{}]%
+    }%
+    % Sphinx > 1.5 behavior (github.com/sphinx-doc/sphinx/issues/2231)
+    \\newcommand{\\DUrolecode}[1]{%
+        \\small{}\\texttt{#1}\\normalsize{}%
     }%""",
 
 # Omit the index.

--- a/docs-source/usersguide/conf.py
+++ b/docs-source/usersguide/conf.py
@@ -185,14 +185,14 @@ latex_elements = {
     \\usepackage{caption}
     \\setcounter{tocdepth}{3}
     \\captionsetup[figure]{labelformat=empty}
-    % Backwards behavior for sphinx < 1.5
+    % Backwards compatibility for sphinx < 1.5
     \\let\\DUspan\\null % force DUspan to be defined
     \\renewcommand{\DUspan}[2]{%
         \\IfEqCase{#1}{%
             {code}{\\small{}\\texttt{#2}\\normalsize{}}
         }[\\PackageError{DUspan}{Unrecognized option passed to DUspan: #1}{}]%
     }%
-    % Sphinx > 1.5 behavior (github.com/sphinx-doc/sphinx/issues/2231)
+    % Sphinx > 1.5 compatibility (github.com/sphinx-doc/sphinx/issues/2231)
     \\newcommand{\\DUrolecode}[1]{%
         \\small{}\\texttt{#1}\\normalsize{}%
     }%""",


### PR DESCRIPTION
Sphinx's `DUspan` function was improved and renamed to `DUrole` between 1.3.1 and 1.5.1. Since OpenMM's docs extend the custom text role to support `code`, this caused the docs to not compile on both versions. 

This PR allows the old rewrite to `DUspan` (will continue to break for anything other than `code`) while also allowing the new `DUrole` (with proper extension to allow `code`). Both versions yield the same typesetting output for this function. 

Related issues:
omnia-md/conda-recipes#723
omnia-md/conda-dev-recipes#81