### PR TITLE
Fixed error with exclusions for Drude particles

### DIFF
--- a/wrappers/python/simtk/openmm/app/forcefield.py
+++ b/wrappers/python/simtk/openmm/app/forcefield.py
@@ -1271,6 +1271,9 @@ def _findBondsForExclusions(data, sys):
                 bondIndices.append((child1, child2))
         for child2 in data.excludeAtomWith[atom2]:
             bondIndices.append((atom1, child2))
+    for atom in data.atoms:
+        for child in data.excludeAtomWith[atom.index]:
+            bondIndices.append((child, atom.index))
     return bondIndices
 
 def _countResidueAtoms(elements):


### PR DESCRIPTION
If you attached a Drude particle to an isolated atom, not bonded to anything else, ForceField would fail to add a nonbonded exclusion between the atom and its Drude particle.