### PR TITLE
Fix typo in bibtex entry

### DIFF
--- a/docs-source/usersguide/references.bib
+++ b/docs-source/usersguide/references.bib
@@ -526,7 +526,7 @@
    number = {ja},
    pages = {null},
    year = {2017},
-   type = {Journal Article}
+   type = {Journal Article},
    doi = {10.1021/acs.jpcb.7b02320},
 }
 


### PR DESCRIPTION
Missing comma causes docs not to compile.

Fixes omnia-md/conda-dev-recipes#84