### PR TITLE
Defined entry point so other packages can add force field directories

### DIFF
--- a/wrappers/python/simtk/openmm/app/forcefield.py
+++ b/wrappers/python/simtk/openmm/app/forcefield.py
@@ -46,13 +46,16 @@ import simtk.unit as unit
 from . import element as elem
 from simtk.openmm.app import Topology
 from simtk.openmm.app.internal.singleton import Singleton
-from pkg_resources import iter_entry_points
 
 # Directories from which to load built in force fields.
 
 _dataDirectories = [os.path.join(os.path.dirname(__file__), 'data')]
-for entry in iter_entry_points(group='openmm.forcefielddir'):
-    _dataDirectories.append(entry.load()())
+try:
+    from pkg_resources import iter_entry_points
+    for entry in iter_entry_points(group='openmm.forcefielddir'):
+        _dataDirectories.append(entry.load()())
+except:
+    pass # pkg_resources is not installed
 
 def _convertParameterToNumber(param):
     if unit.is_quantity(param):

--- a/wrappers/python/simtk/openmm/app/forcefield.py
+++ b/wrappers/python/simtk/openmm/app/forcefield.py
@@ -46,6 +46,13 @@ import simtk.unit as unit
 from . import element as elem
 from simtk.openmm.app import Topology
 from simtk.openmm.app.internal.singleton import Singleton
+from pkg_resources import iter_entry_points
+
+# Directories from which to load built in force fields.
+
+_dataDirectories = [os.path.join(os.path.dirname(__file__), 'data')]
+for entry in iter_entry_points(group='openmm.forcefielddir'):
+    _dataDirectories.append(entry.load()())
 
 def _convertParameterToNumber(param):
     if unit.is_quantity(param):
@@ -186,11 +193,16 @@ class ForceField(object):
         trees = []
 
         for file in files:
+            tree = None
             try:
                 # this handles either filenames or open file-like objects
                 tree = etree.parse(file)
             except IOError:
-                tree = etree.parse(os.path.join(os.path.dirname(__file__), 'data', file))
+                for dataDir in _dataDirectories:
+                    f = os.path.join(dataDir, file)
+                    if os.path.isfile(f):
+                        tree = etree.parse(f)
+                        break
             except Exception as e:
                 # Fail with an error message about which file could not be read.
                 # TODO: Also handle case where fallback to 'data' directory encounters problems,
@@ -202,6 +214,8 @@ class ForceField(object):
                     filename = str(file)
                 msg += "ForceField.loadFile() encountered an error reading file '%s'\n" % filename
                 raise Exception(msg)
+            if tree is None:
+                raise ValueError('Could not locate file "%s"' % file)
 
             trees.append(tree)
 


### PR DESCRIPTION
The group is called `openmm.forcefielddir`.  The entry point should be a function that returns a string containing the path to a directory.

See https://github.com/choderalab/openmm-forcefields/issues/6.  Also see http://setuptools.readthedocs.io/en/latest/setuptools.html#dynamic-discovery-of-services-and-plugins for information on creating entry points.