### PR TITLE
Added option for CPU PME to be deterministic

### DIFF
--- a/olla/include/openmm/kernels.h
+++ b/olla/include/openmm/kernels.h
@@ -1295,8 +1295,9 @@ public:
      * @param gridz        the z size of the PME grid
      * @param numParticles the number of particles in the system
      * @param alpha        the Ewald blending parameter
+     * @param deterministic whether it should attempt to make the resulting forces deterministic
      */
-    virtual void initialize(int gridx, int gridy, int gridz, int numParticles, double alpha) = 0;
+    virtual void initialize(int gridx, int gridy, int gridz, int numParticles, double alpha, bool deterministic) = 0;
     /**
      * Begin computing the force and energy.
      *
@@ -1368,8 +1369,9 @@ public:
      * @param gridz        the z size of the PME grid
      * @param numParticles the number of particles in the system
      * @param alpha        the Ewald blending parameter
+     * @param deterministic whether it should attempt to make the resulting forces deterministic
      */
-    virtual void initialize(int gridx, int gridy, int gridz, int numParticles, double alpha) = 0;
+    virtual void initialize(int gridx, int gridy, int gridz, int numParticles, double alpha, bool deterministic) = 0;
     /**
      * Begin computing the force and energy.
      *

--- a/platforms/cpu/include/CpuPlatform.h
+++ b/platforms/cpu/include/CpuPlatform.h
@@ -69,6 +69,15 @@ public:
         return key;
     }
     /**
+     * This is the name of the parameter for requesting that force computations be deterministic.  Setting
+     * this to "true" DOES NOT GUARANTEE that the forces will actually be fully deterministic, but it does
+     * try to reduce the variation in them at the cost of a small loss in performance.
+     */
+    static const std::string& CpuDeterministicForces() {
+        static const std::string key = "DeterministicForces";
+        return key;
+    }
+    /**
      * We cannot use the standard mechanism for platform data, because that is already used by the superclass.
      * Instead, we maintain a table of ContextImpls to PlatformDatas.
      */
@@ -80,7 +89,7 @@ private:
 
 class CpuPlatform::PlatformData {
 public:
-    PlatformData(int numParticles, int numThreads);
+    PlatformData(int numParticles, int numThreads, bool deterministicForces);
     ~PlatformData();
     void requestNeighborList(double cutoffDistance, double padding, bool useExclusions, const std::vector<std::set<int> >& exclusionList);
     AlignedArray<float> posq;
@@ -91,7 +100,7 @@ public:
     std::map<std::string, std::string> propertyValues;
     CpuNeighborList* neighborList;
     double cutoff, paddedCutoff;
-    bool anyExclusions;
+    bool anyExclusions, deterministicForces;
     std::vector<std::set<int> > exclusions;
 };
 

--- a/platforms/cpu/src/CpuKernels.cpp
+++ b/platforms/cpu/src/CpuKernels.cpp
@@ -642,7 +642,7 @@ double CpuCalcNonbondedForceKernel::execute(ContextImpl& context, bool includeFo
             useOptimizedPme = getPlatform().supportsKernels(kernelNames);
             if (useOptimizedPme) {
                 optimizedPme = getPlatform().createKernel(CalcPmeReciprocalForceKernel::Name(), context);
-                optimizedPme.getAs<CalcPmeReciprocalForceKernel>().initialize(gridSize[0], gridSize[1], gridSize[2], numParticles, ewaldAlpha);
+                optimizedPme.getAs<CalcPmeReciprocalForceKernel>().initialize(gridSize[0], gridSize[1], gridSize[2], numParticles, ewaldAlpha, data.deterministicForces);
             }
         }
         if (nonbondedMethod == LJPME) {
@@ -653,10 +653,10 @@ double CpuCalcNonbondedForceKernel::execute(ContextImpl& context, bool includeFo
             useOptimizedPme = getPlatform().supportsKernels(kernelNames);
             if (useOptimizedPme) {
                 optimizedPme = getPlatform().createKernel(CalcPmeReciprocalForceKernel::Name(), context);
-                optimizedPme.getAs<CalcPmeReciprocalForceKernel>().initialize(gridSize[0], gridSize[1], gridSize[2], numParticles, ewaldAlpha);
+                optimizedPme.getAs<CalcPmeReciprocalForceKernel>().initialize(gridSize[0], gridSize[1], gridSize[2], numParticles, ewaldAlpha, data.deterministicForces);
                 optimizedDispersionPme = getPlatform().createKernel(CalcDispersionPmeReciprocalForceKernel::Name(), context);
                 optimizedDispersionPme.getAs<CalcDispersionPmeReciprocalForceKernel>().initialize(dispersionGridSize[0], dispersionGridSize[1],
-                                                                                                  dispersionGridSize[2], numParticles, ewaldDispersionAlpha);
+                                                                                                  dispersionGridSize[2], numParticles, ewaldDispersionAlpha, data.deterministicForces);
             }
         }
     }

--- a/platforms/cuda/src/CudaKernels.cpp
+++ b/platforms/cuda/src/CudaKernels.cpp
@@ -1805,7 +1805,7 @@ void CudaCalcNonbondedForceKernel::initialize(const System& system, const Nonbon
 
                 try {
                     cpuPme = getPlatform().createKernel(CalcPmeReciprocalForceKernel::Name(), *cu.getPlatformData().context);
-                    cpuPme.getAs<CalcPmeReciprocalForceKernel>().initialize(gridSizeX, gridSizeY, gridSizeZ, numParticles, alpha);
+                    cpuPme.getAs<CalcPmeReciprocalForceKernel>().initialize(gridSizeX, gridSizeY, gridSizeZ, numParticles, alpha, cu.getPlatformData().deterministicForces);
                     CUfunction addForcesKernel = cu.getKernel(module, "addForces");
                     pmeio = new PmeIO(cu, addForcesKernel);
                     cu.addPreComputation(new PmePreComputation(cu, cpuPme, *pmeio));

--- a/platforms/opencl/src/OpenCLKernels.cpp
+++ b/platforms/opencl/src/OpenCLKernels.cpp
@@ -1780,7 +1780,7 @@ void OpenCLCalcNonbondedForceKernel::initialize(const System& system, const Nonb
 
                 try {
                     cpuPme = getPlatform().createKernel(CalcPmeReciprocalForceKernel::Name(), *cl.getPlatformData().context);
-                    cpuPme.getAs<CalcPmeReciprocalForceKernel>().initialize(gridSizeX, gridSizeY, gridSizeZ, numParticles, alpha);
+                    cpuPme.getAs<CalcPmeReciprocalForceKernel>().initialize(gridSizeX, gridSizeY, gridSizeZ, numParticles, alpha, false);
                     cl::Program program = cl.createProgram(OpenCLKernelSources::pme, pmeDefines);
                     cl::Kernel addForcesKernel = cl::Kernel(program, "addForces");
                     pmeio = new PmeIO(cl, addForcesKernel);

--- a/plugins/cpupme/src/CpuPmeKernels.h
+++ b/plugins/cpupme/src/CpuPmeKernels.h
@@ -62,8 +62,9 @@ public:
      * @param gridz        the z size of the PME grid
      * @param numParticles the number of particles in the system
      * @param alpha        the Ewald blending parameter
+     * @param deterministic whether it should attempt to make the resulting forces deterministic
      */
-    void initialize(int xsize, int ysize, int zsize, int numParticles, double alpha);
+    void initialize(int xsize, int ysize, int zsize, int numParticles, double alpha, bool deterministic);
     ~CpuCalcPmeReciprocalForceKernel();
     /**
      * Begin computing the force and energy.
@@ -110,6 +111,7 @@ private:
     static int numThreads;
     int gridx, gridy, gridz, numParticles;
     double alpha;
+    bool deterministic;
     bool hasCreatedPlan, isFinished, isDeleted;
     std::vector<float> force;
     std::vector<float> bsplineModuli[3];
@@ -153,8 +155,9 @@ public:
      * @param gridz        the z size of the PME grid
      * @param numParticles the number of particles in the system
      * @param alpha        the Ewald blending parameter
+     * @param deterministic whether it should attempt to make the resulting forces deterministic
      */
-    void initialize(int xsize, int ysize, int zsize, int numParticles, double alpha);
+    void initialize(int xsize, int ysize, int zsize, int numParticles, double alpha, bool deterministic);
     ~CpuCalcDispersionPmeReciprocalForceKernel();
     /**
      * Begin computing the force and energy.
@@ -202,6 +205,7 @@ private:
     static int numThreads;
     int gridx, gridy, gridz, numParticles;
     double alpha;
+    bool deterministic;
     bool hasCreatedPlan, isFinished, isDeleted;
     std::vector<float> force;
     std::vector<float> bsplineModuli[3];

--- a/plugins/cpupme/tests/TestCpuPme.cpp
+++ b/plugins/cpupme/tests/TestCpuPme.cpp
@@ -535,7 +535,7 @@ void test_water2_dpme_energies_forces_no_exclusions() {
         io.posq.push_back(c6);
         selfEwaldEnergy += dalpha6 * c6 * c6 / 12.0;
     }
-    pme.initialize(grid, grid, grid, NATOMS, dalpha);
+    pme.initialize(grid, grid, grid, NATOMS, dalpha, false);
     Vec3 boxVectors[3];
     system.getDefaultPeriodicBoxVectors(boxVectors[0], boxVectors[1], boxVectors[2]);
     pme.beginComputation(io, boxVectors, true);
@@ -626,7 +626,7 @@ void testPME(bool triclinic) {
         sumSquaredCharges += charge*charge;
     }
     double ewaldSelfEnergy = -ONE_4PI_EPS0*alpha*sumSquaredCharges/sqrt(M_PI);
-    pme.initialize(gridx, gridy, gridz, numParticles, alpha);
+    pme.initialize(gridx, gridy, gridz, numParticles, alpha, true);
     pme.beginComputation(io, boxVectors, true);
     double energy = pme.finishComputation(io);
 


### PR DESCRIPTION
Fixes #1799.  The interface is the same as for CUDA: specify `'DeterministicForces':'true'` when you create your context.  This *only* affects the behavior of PME, so unlike with CUDA, the results are still not fully deterministic.  But PME is often the largest source of non-determinism, so the variation should at least be reduced.