### PR TITLE
Fixed bug in CustomManyParticleForce.

### DIFF
--- a/platforms/cuda/src/kernels/customManyParticle.cu
+++ b/platforms/cuda/src/kernels/customManyParticle.cu
@@ -60,6 +60,11 @@ inline __device__ real4 computeCross(real4 vec1, real4 vec2) {
  * Determine whether a particular interaction is in the list of exclusions.
  */
 inline __device__ bool isInteractionExcluded(int atom1, int atom2, const int* __restrict__ exclusions, const int* __restrict__ exclusionStartIndex) {
+    if (atom1 > atom2) {
+        int temp = atom1;
+        atom1 = atom2;
+        atom2 = temp;
+    }
     int first = exclusionStartIndex[atom1];
     int last = exclusionStartIndex[atom1+1];
     for (int i = last-1; i >= first; i--) {

--- a/platforms/opencl/src/kernels/customManyParticle.cl
+++ b/platforms/opencl/src/kernels/customManyParticle.cl
@@ -56,6 +56,11 @@ inline real4 computeCross(real4 vec1, real4 vec2) {
  * Determine whether a particular interaction is in the list of exclusions.
  */
 inline bool isInteractionExcluded(int atom1, int atom2, __global const int* restrict exclusions, __global const int* restrict exclusionStartIndex) {
+    if (atom1 > atom2) {
+        int temp = atom1;
+        atom1 = atom2;
+        atom2 = temp;
+    }
     int first = exclusionStartIndex[atom1];
     int last = exclusionStartIndex[atom1+1];
     for (int i = last-1; i >= first; i--) {


### PR DESCRIPTION
See #1794.  The effect was that on the CUDA and OpenCL platforms, it would sometimes include an interaction that was supposed to be excluded.