### PR TITLE
Flexible constraints

### DIFF
--- a/wrappers/python/tests/TestForceField.py
+++ b/wrappers/python/tests/TestForceField.py
@@ -102,6 +102,7 @@ class TestForceField(unittest.TestCase):
                                                 rigidWater=True)
         system2 = self.forcefield1.createSystem(topology, constraints=HAngles,
                                                 rigidWater=True, flexibleConstraints=True)
+        system3 = self.forcefield1.createSystem(topology, constraints=None, rigidWater=False)
         validateConstraints(self, topology, system1, HAngles, True)
         # validateConstraints fails for system2 since by definition atom pairs can be in both bond
         # and constraint lists. So just check that the number of constraints is the same for both
@@ -117,9 +118,13 @@ class TestForceField(unittest.TestCase):
                 bf2 = force
             elif isinstance(force, HarmonicAngleForce):
                 af2 = force
-        # Make sure we picked up extra terms with flexibleConstraints
+        for force in system3.getForces():
+            if isinstance(force, HarmonicAngleForce):
+                af3 = force
+        # Make sure we picked up extra bond terms with flexibleConstraints
         self.assertGreater(bf2.getNumBonds(), bf1.getNumBonds())
-        self.assertGreater(af2.getNumAngles(), af2.getNumAngles())
+        # Make sure flexibleConstraints yields just as many angles as no constraints
+        self.assertEqual(af2.getNumAngles(), af3.getNumAngles())
 
     def test_ImplicitSolvent(self):
         """Test the four types of implicit solvents using the implicitSolvent

--- a/wrappers/python/tests/TestForceField.py
+++ b/wrappers/python/tests/TestForceField.py
@@ -103,7 +103,10 @@ class TestForceField(unittest.TestCase):
         system2 = self.forcefield1.createSystem(topology, constraints=HAngles,
                                                 rigidWater=True, flexibleConstraints=True)
         validateConstraints(self, topology, system1, HAngles, True)
-        validateConstraints(self, topology, system2, HAngles, True)
+        # validateConstraints fails for system2 since by definition atom pairs can be in both bond
+        # and constraint lists. So just check that the number of constraints is the same for both
+        # system1 and system2
+        self.assertEqual(system1.getNumConstraints(), system2.getNumConstraints())
         for force in system1.getForces():
             if isinstance(force, HarmonicBondForce):
                 bf1 = force


### PR DESCRIPTION
Add support for flexibleConstraints to ForceField.createSystem

There are times when it is helpful to have the energy terms actually
added to the System even if that degree of freedom is constrained. Other
parsers (notably the Amber parsers) already support this keyword, so add
that support to ForceField as well

This also replaces some string-based element detection algorithms with
whatever the PDB parser does (by comparing directly to atom.element)