### PR TITLE
CustomIntegrator avoids unnecessary force/energy computations

### DIFF
--- a/platforms/cuda/include/CudaKernels.h
+++ b/platforms/cuda/include/CudaKernels.h
@@ -1507,6 +1507,7 @@ private:
     CudaArray* randomSeed;
     CudaArray* perDofEnergyParamDerivs;
     std::vector<CudaArray*> tabulatedFunctions;
+    std::map<int, double> savedEnergy;
     std::map<int, CudaArray*> savedForces;
     std::set<int> validSavedForces;
     CudaParameterSet* perDofValues;

--- a/platforms/opencl/include/OpenCLKernels.h
+++ b/platforms/opencl/include/OpenCLKernels.h
@@ -1494,6 +1494,7 @@ private:
     OpenCLArray* randomSeed;
     OpenCLArray* perDofEnergyParamDerivs;
     std::vector<OpenCLArray*> tabulatedFunctions;
+    std::map<int, double> savedEnergy;
     std::map<int, OpenCLArray*> savedForces;
     std::set<int> validSavedForces;
     OpenCLParameterSet* perDofValues;


### PR DESCRIPTION
See #1815.  It's now better at not repeating the same calculation when you're switching back and forth between force groups.