### PR TITLE
Fixed bug in CustomGBForce

### DIFF
--- a/platforms/cpu/include/CpuKernels.h
+++ b/platforms/cpu/include/CpuKernels.h
@@ -373,7 +373,7 @@ private:
 class CpuCalcCustomGBForceKernel : public CalcCustomGBForceKernel {
 public:
     CpuCalcCustomGBForceKernel(std::string name, const Platform& platform, CpuPlatform::PlatformData& data) :
-            CalcCustomGBForceKernel(name, platform), data(data) {
+            CalcCustomGBForceKernel(name, platform), data(data), ixn(NULL), neighborList(NULL) {
     }
     ~CpuCalcCustomGBForceKernel();
     /**
@@ -406,6 +406,7 @@ private:
     double **particleParamArray;
     double nonbondedCutoff;
     CpuCustomGBForce* ixn;
+    CpuNeighborList* neighborList;
     std::vector<std::set<int> > exclusions;
     std::vector<std::string> particleParameterNames, globalParameterNames, energyParamDerivNames, valueNames;
     std::vector<OpenMM::CustomGBForce::ComputationType> valueTypes;

--- a/platforms/reference/src/ReferenceKernels.cpp
+++ b/platforms/reference/src/ReferenceKernels.cpp
@@ -1474,7 +1474,8 @@ double ReferenceCalcCustomGBForceKernel::execute(ContextImpl& context, bool incl
     if (periodic)
         ixn.setPeriodic(extractBoxVectors(context));
     if (nonbondedMethod != NoCutoff) {
-        computeNeighborListVoxelHash(*neighborList, numParticles, posData, exclusions, extractBoxVectors(context), periodic, nonbondedCutoff, 0.0);
+        vector<set<int> > empty(context.getSystem().getNumParticles()); // Don't omit exclusions from the neighbor list
+        computeNeighborListVoxelHash(*neighborList, numParticles, posData, empty, extractBoxVectors(context), periodic, nonbondedCutoff, 0.0);
         ixn.setUseCutoff(nonbondedCutoff, *neighborList);
     }
     map<string, double> globalParameters;

--- a/tests/TestCustomGBForce.h
+++ b/tests/TestCustomGBForce.h
@@ -118,6 +118,7 @@ void testOBC(GBSAOBCForce::NonbondedMethod obcMethod, CustomGBForce::NonbondedMe
             params[1] = 0.1;
             custom->addParticle(params);
         }
+        custom->addExclusion(2*i, 2*i+1);
         positions[2*i] = Vec3(boxSize*genrand_real2(sfmt), boxSize*genrand_real2(sfmt), boxSize*genrand_real2(sfmt));
         positions[2*i+1] = Vec3(positions[2*i][0]+1.0, positions[2*i][1], positions[2*i][2]);
         velocities[2*i] = Vec3(genrand_real2(sfmt), genrand_real2(sfmt), genrand_real2(sfmt));


### PR DESCRIPTION
Fixes #1848.

This error happened when *all* of the following conditions were met:

- You were using the Reference or CPU platform.
- You were using a cutoff.
- Your system included a CustomGBForce.
- The force had a computation of type `ParticlePairNoExclusions`.
- The force also had exclusions.  On the CPU platform, it could also happen if the CustomGBForce didn't itself have exclusions, but the system contained a NonbondedForce or CustomNonbondedForce that had exclusions.

In that case, the excluded interactions would incorrectly be omitted from the `ParticlePairNoExclusions` computation.