### PR TITLE
Bug fix to finding identical molecules

### DIFF
--- a/platforms/cuda/src/CudaContext.cpp
+++ b/platforms/cuda/src/CudaContext.cpp
@@ -1083,9 +1083,16 @@ void CudaContext::findMoleculeGroups() {
             for (int i = 0; i < (int) forces.size() && identical; i++) {
                 if (mol.groups[i].size() != mol2.groups[i].size())
                     identical = false;
-                for (int k = 0; k < (int) mol.groups[i].size() && identical; k++)
+                for (int k = 0; k < (int) mol.groups[i].size() && identical; k++) {
                     if (!forces[i]->areGroupsIdentical(mol.groups[i][k], mol2.groups[i][k]))
                         identical = false;
+                    vector<int> p1, p2;
+                    forces[i]->getParticlesInGroup(mol.groups[i][k], p1);
+                    forces[i]->getParticlesInGroup(mol2.groups[i][k], p2);
+                    for (int m = 0; m < p1.size(); m++)
+                        if (p1[m] != p2[m]-atomOffset)
+                            identical = false;
+                }
             }
             if (identical) {
                 moleculeInstances[j].push_back(molIndex);

--- a/platforms/opencl/src/OpenCLContext.cpp
+++ b/platforms/opencl/src/OpenCLContext.cpp
@@ -978,9 +978,16 @@ void OpenCLContext::findMoleculeGroups() {
             for (int i = 0; i < (int) forces.size() && identical; i++) {
                 if (mol.groups[i].size() != mol2.groups[i].size())
                     identical = false;
-                for (int k = 0; k < (int) mol.groups[i].size() && identical; k++)
+                for (int k = 0; k < (int) mol.groups[i].size() && identical; k++) {
                     if (!forces[i]->areGroupsIdentical(mol.groups[i][k], mol2.groups[i][k]))
                         identical = false;
+                    vector<int> p1, p2;
+                    forces[i]->getParticlesInGroup(mol.groups[i][k], p1);
+                    forces[i]->getParticlesInGroup(mol2.groups[i][k], p2);
+                    for (int m = 0; m < p1.size(); m++)
+                        if (p1[m] != p2[m]-atomOffset)
+                            identical = false;
+                }
             }
             if (identical) {
                 moleculeInstances[j].push_back(molIndex);


### PR DESCRIPTION
This fixes an obscure bug in the logic for identifying identical molecules that can be reordered internally.  It happens when two molecules are identical except for their bonds.  Furthermore, each molecule has the same number of bonds of each type, and corresponding bonds even have identical parameters, but don't connect corresponding atoms.  In that case, it will incorrectly conclude they are identical.

This came up when someone was simulating graphite sheets, so all atoms and all bonds had identical parameters.  See https://simtk.org/plugins/phpBB/viewtopicPhpbb.php?f=161&t=8138&p=0&start=0&view=&sid=4f4b9091e65d616b177f72d2fd0739ac.