### PR TITLE
Ignore duplicate patch specifications

### DIFF
--- a/wrappers/python/simtk/openmm/app/forcefield.py
+++ b/wrappers/python/simtk/openmm/app/forcefield.py
@@ -426,8 +426,8 @@ class ForceField(object):
     def registerTemplatePatch(self, residue, patch, patchResidueIndex):
         """Register that a particular patch can be used with a particular residue."""
         if residue not in self._templatePatches:
-            self._templatePatches[residue] = []
-        self._templatePatches[residue].append((patch, patchResidueIndex))
+            self._templatePatches[residue] = set()
+        self._templatePatches[residue].add((patch, patchResidueIndex))
 
     def registerScript(self, script):
         """Register a new script to be executed after building the System."""

--- a/wrappers/python/tests/TestPatches.py
+++ b/wrappers/python/tests/TestPatches.py
@@ -67,8 +67,9 @@ class TestPatches(unittest.TestCase):
         self.assertEqual(0, patch.addedExternalBonds[0].residue)
         self.assertEqual('C', patch.deletedExternalBonds[0].name)
         self.assertEqual(0, patch.deletedExternalBonds[0].residue)
-        self.assertEqual('Test', ff._templatePatches['RES'][0][0])
-        self.assertEqual(0, ff._templatePatches['RES'][0][1])
+        patch = list(ff._templatePatches['RES'])[0]
+        self.assertEqual('Test', patch[0])
+        self.assertEqual(0, patch[1])
 
     def testParseMultiresiduePatch(self):
         """Test parsing a <Patch> tag that affects two residues."""
@@ -110,10 +111,12 @@ class TestPatches(unittest.TestCase):
         self.assertEqual(0, patch.addedBonds[0][0].residue)
         self.assertEqual('B', patch.addedBonds[0][1].name)
         self.assertEqual(1, patch.addedBonds[0][1].residue)
-        self.assertEqual('Test', ff._templatePatches['RESA'][0][0])
-        self.assertEqual(0, ff._templatePatches['RESA'][0][1])
-        self.assertEqual('Test', ff._templatePatches['RESB'][0][0])
-        self.assertEqual(1, ff._templatePatches['RESB'][0][1])
+        patchA = list(ff._templatePatches['RESA'])[0]
+        self.assertEqual('Test', patchA[0])
+        self.assertEqual(0, patchA[1])
+        patchB = list(ff._templatePatches['RESB'])[0]
+        self.assertEqual('Test', patchB[0])
+        self.assertEqual(1, patchB[1])
 
     def testApplyPatch(self):
         """Test applying a patch to a template."""


### PR DESCRIPTION
Tolerate the case where for some reason the user specifies multiple times that a patch can be applied to a residue.