### PR TITLE
Require atoms and residues to be contiguous

### DIFF
--- a/wrappers/python/simtk/openmm/app/topology.py
+++ b/wrappers/python/simtk/openmm/app/topology.py
@@ -154,6 +154,8 @@ class Topology(object):
         Residue
              the newly created Residue
         """
+        if len(chain._residues) > 0 and self._numResidues != chain._residues[-1].index+1:
+            raise ValueError('All residues within a chain must be contiguous')
         if id is None:
             id = str(self._numResidues+1)
         residue = Residue(name, self._numResidues, chain, id)
@@ -181,6 +183,8 @@ class Topology(object):
         Atom
              the newly created Atom
         """
+        if len(residue._atoms) > 0 and self._numAtoms != residue._atoms[-1].index+1:
+            raise ValueError('All atoms within a residue must be contiguous')
         if id is None:
             id = str(self._numAtoms+1)
         atom = Atom(name, element, self._numAtoms, residue, id)


### PR DESCRIPTION
Fixes #1931.  If you try to add atoms to a residue or residues to a chain out of order, it throws an exception.