### PR TITLE
Improvement to processing of includes in force fields

### DIFF
--- a/docs-source/usersguide/application.rst
+++ b/docs-source/usersguide/application.rst
@@ -2959,12 +2959,6 @@ relative either to the directory containing the parent XML file (the one with
 the :code:`<Include>` tag) or the OpenMM data directory (the one containing
 built in force fields).
 
-The included file is fully processed before any other tags in the parent file
-are processed, and its definitions are added to the force field.  This means the
-parent file can refer to atom types defined in the included file, but not the
-other way around.  If there are multiple :code:`<Include>` tags, they are processed
-in the order they appear in the file.
-
 
 Using Multiple Files
 ********************

--- a/wrappers/python/simtk/openmm/app/forcefield.py
+++ b/wrappers/python/simtk/openmm/app/forcefield.py
@@ -190,12 +190,16 @@ class ForceField(object):
             method from which the forcefield XML data can be loaded.
         """
 
-        if not isinstance(files, tuple):
-            files = (files,)
+        if isinstance(files, tuple):
+            files = list(files)
+        else:
+            files = [files]
 
         trees = []
 
-        for file in files:
+        i = 0
+        while i < len(files):
+            file = files[i]
             tree = None
             try:
                 # this handles either filenames or open file-like objects
@@ -221,12 +225,12 @@ class ForceField(object):
                 raise ValueError('Could not locate file "%s"' % file)
 
             trees.append(tree)
+            i += 1
 
-        # Process includes.
+            # Process includes in this file.
 
-        for parentFile, tree in zip(files, trees):
-            if isinstance(parentFile, str):
-                parentDir = os.path.dirname(parentFile)
+            if isinstance(file, str):
+                parentDir = os.path.dirname(file)
             else:
                 parentDir = ''
             for include in tree.getroot().findall('Include'):
@@ -234,7 +238,8 @@ class ForceField(object):
                 joined = os.path.join(parentDir, includeFile)
                 if os.path.isfile(joined):
                     includeFile = joined
-                self.loadFile(includeFile)
+                if includeFile not in files:
+                    files.append(includeFile)
 
         # Load the atom types.
 


### PR DESCRIPTION
This makes two changes.  First, included files now get processed together with their parent files exactly as if you had directly specified all of them.  That means there are no longer restrictions about which files can reference each other.  All atom types in all files are processed before any templates or force field terms, so they're visible to all files.

Second, if two files each include the same other file, that other file only gets processed once.  It won't lead to duplicate definitions.