### PR TITLE
Fix Bond pickling in Python 2.7

### DIFF
--- a/wrappers/python/simtk/openmm/app/topology.py
+++ b/wrappers/python/simtk/openmm/app/topology.py
@@ -465,6 +465,14 @@ class Bond(namedtuple('Bond', ['atom1', 'atom2'])):
         "Support for pickle protocol 2: http://docs.python.org/2/library/pickle.html#pickling-and-unpickling-normal-class-instances"
         return self[0], self[1], self.type, self.order
 
+    def __getstate__(self):
+        """
+        Additional support for pickle since parent class implements its own __getstate__
+        so pickle does not store or restore the type and order, python 2 problem only
+        https://www.python.org/dev/peps/pep-0307/#case-3-pickling-new-style-class-instances-using-protocol-2
+        """
+        return self.__dict__
+
     def __deepcopy__(self, memo):
         return Bond(self[0], self[1], self.type, self.order)
 


### PR DESCRIPTION
The pickle round trip for the Bond object does not preserve the `type` and `order` parameters in Python 2.7.

Near as I can tell, its because the parent `namedtuple` already has a __getstate__ method, so the default of returning the `__dict__` is never given, so `__setstate__` is not called (as default). This leads to pickle restoring the state, but never invoking the `__new__` statement, resulting in `type` and `order` being lost.

 This PR fixes this problem in python 2.7, without breaking python 3.x versions.

xref: mdtraj/mdtraj#1308 and #1543