### PR TITLE
Fix Quantity.__setitem__ bug with slice assignment

### DIFF
--- a/wrappers/python/simtk/unit/quantity.py
+++ b/wrappers/python/simtk/unit/quantity.py
@@ -737,8 +737,8 @@ class Quantity(object):
         # Delegate slices to one-at-a time ___setitem___
         if isinstance(key, slice): # slice
             indices = key.indices(len(self))
-            for i in range(*indices):
-                self[i] = value[i]
+            for value_idx, self_idx in enumerate(range(*indices)):
+                self[self_idx] = value[value_idx]
         else: # single index
             # Check unit compatibility
             if self.unit.is_dimensionless() and is_dimensionless(value):

--- a/wrappers/python/tests/TestUnits.py
+++ b/wrappers/python/tests/TestUnits.py
@@ -288,6 +288,10 @@ class TestUnits(QuantityTestCase):
         # Tests that __setitem__ converts to the unit of the container
         s[0] = 1 * u.nanometers
         self.assertEqual(s[0]._value, 10)
+        # Tests that __setitem__ handles slice assignment correctly
+        x = [0, 1, 2, 3, 4] * u.kelvin
+        x[2:4] = [-2, -3] * u.kelvin
+        self.assertEqual(x._value, [0, 1, -2, -3, 4])
         # Tests standard unit conversions
         x = [1, 2, 3] * u.centimeters
         self.assertEqual(x / u.millimeters, [10, 20, 30])


### PR DESCRIPTION
Fix #1940: Bug in `Quantity.__setitem__` when assigning slices. I've also added a test case.