### PR TITLE
allow the user to skip parameter condensing CHARMM parameters

### DIFF
--- a/wrappers/python/simtk/openmm/app/charmmparameterset.py
+++ b/wrappers/python/simtk/openmm/app/charmmparameterset.py
@@ -116,6 +116,9 @@ class CharmmParameterSet(object):
         self.nbfix_types = dict()
         self.parametersets = []
 
+        # Allow the user to skip parameter condensing
+        self._noCondense = False
+
         # Load all of the files
         tops, pars, strs = [], [], []
         for arg in args:
@@ -603,6 +606,14 @@ class CharmmParameterSet(object):
                 self.readParameterFile(section)
             title, section = f.next_section()
 
+    def noCondense(self):
+        """
+        If you have a very large number of interaction types, condensing
+        can be a slow operation.  Allow the user to specify that it
+        should be skipped.
+        """
+        self._noCondense = True
+
     def condense(self):
         """
         This function goes through each of the parameter type dicts and
@@ -614,6 +625,9 @@ class CharmmParameterSet(object):
         -------
         >>> params = CharmmParameterSet('charmm.prm').condense()
         """
+        if self._noCondense:
+            return self
+
         # First scan through all of the bond types
         self._condense_types(self.bond_types)
         self._condense_types(self.angle_types)

--- a/wrappers/python/simtk/openmm/app/charmmparameterset.py
+++ b/wrappers/python/simtk/openmm/app/charmmparameterset.py
@@ -116,9 +116,6 @@ class CharmmParameterSet(object):
         self.nbfix_types = dict()
         self.parametersets = []
 
-        # Allow the user to skip parameter condensing
-        self._noCondense = False
-
         # Load all of the files
         tops, pars, strs = [], [], []
         for arg in args:
@@ -606,14 +603,6 @@ class CharmmParameterSet(object):
                 self.readParameterFile(section)
             title, section = f.next_section()
 
-    def noCondense(self):
-        """
-        If you have a very large number of interaction types, condensing
-        can be a slow operation.  Allow the user to specify that it
-        should be skipped.
-        """
-        self._noCondense = True
-
     def condense(self):
         """
         This function goes through each of the parameter type dicts and
@@ -625,9 +614,6 @@ class CharmmParameterSet(object):
         -------
         >>> params = CharmmParameterSet('charmm.prm').condense()
         """
-        if self._noCondense:
-            return self
-
         # First scan through all of the bond types
         self._condense_types(self.bond_types)
         self._condense_types(self.angle_types)

--- a/wrappers/python/simtk/openmm/app/charmmpsffile.py
+++ b/wrappers/python/simtk/openmm/app/charmmpsffile.py
@@ -740,7 +740,7 @@ class CharmmPsfFile(object):
             raise a ValueError
         """
         # Load the parameter set
-        self.loadParameters(params.condense())
+        self.loadParameters(params)
         hasbox = self.topology.getUnitCellDimensions() is not None
         # Check GB input parameters
         if implicitSolvent is not None and gbsaModel not in ('ACE', None):


### PR DESCRIPTION
I've run into a situation (admittedly fairly perverse) situation where condensing the parameters is painfully slow (>20 minutes for a toy system).  As far as I can tell, the condensing operation is there solely to save memory, so it's not unreasonable to let the user choose to skip this step.  I've added a boolean flag and a function to turn this behavior off.