### PR TITLE
Simplification to CudaArray and OpenCLArray

### DIFF
--- a/platforms/cuda/include/CudaArray.h
+++ b/platforms/cuda/include/CudaArray.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2009-2012 Stanford University and the Authors.      *
+ * Portions copyright (c) 2009-2018 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -58,6 +58,11 @@ public:
         return new CudaArray(context, size, sizeof(T), name);
     }
     /**
+     * Create an uninitialized CudaArray object.  It does not point to any device memory,
+     * and cannot be used until initialize() is called on it.
+     */
+    CudaArray();
+    /**
      * Create a CudaArray object.
      *
      * @param context           the context for which to create the array
@@ -67,6 +72,36 @@ public:
      */
     CudaArray(CudaContext& context, int size, int elementSize, const std::string& name);
     ~CudaArray();
+    /**
+     * Initialize this object.
+     *
+     * @param context           the context for which to create the array
+     * @param size              the number of elements in the array
+     * @param elementSize       the size of each element in bytes
+     * @param name              the name of the array
+     */
+    void initialize(CudaContext& context, int size, int elementSize, const std::string& name);
+    /**
+     * Initialize this object.  The template argument is the data type of each array element.
+     *
+     * @param context           the context for which to create the array
+     * @param size              the number of elements in the array
+     * @param name              the name of the array
+     */
+    template <class T>
+    void initialize(CudaContext& context, int size, const std::string& name) {
+        initialize(context, size, sizeof(T), name);
+    }
+    /**
+     * Recreate the internal storage to have a different size.
+     */
+    void resize(int size);
+    /**
+     * Get whether this array has been initialized.
+     */
+    bool isInitialized() const {
+        return (pointer != 0);
+    }
     /**
      * Get the number of elements in the array.
      */
@@ -134,7 +169,7 @@ public:
      */
     void copyTo(CudaArray& dest) const;
 private:
-    CudaContext& context;
+    CudaContext* context;
     CUdeviceptr pointer;
     int size, elementSize;
     bool ownsMemory;

--- a/platforms/cuda/include/CudaBondedUtilities.h
+++ b/platforms/cuda/include/CudaBondedUtilities.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2011-2016 Stanford University and the Authors.      *
+ * Portions copyright (c) 2011-2018 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -81,7 +81,6 @@ namespace OpenMM {
 class OPENMM_EXPORT_CUDA CudaBondedUtilities {
 public:
     CudaBondedUtilities(CudaContext& context);
-    ~CudaBondedUtilities();
     /**
      * Add a bonded interaction.
      *
@@ -136,7 +135,7 @@ private:
     std::vector<int> forceGroup;
     std::vector<CUdeviceptr> arguments;
     std::vector<std::string> argTypes;
-    std::vector<std::vector<CudaArray*> > atomIndices;
+    std::vector<std::vector<CudaArray> > atomIndices;
     std::vector<std::string> prefixCode;
     std::vector<std::string> energyParameterDerivatives;
     std::vector<void*> kernelArgs;

--- a/platforms/cuda/include/CudaContext.h
+++ b/platforms/cuda/include/CudaContext.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2009-2017 Stanford University and the Authors.      *
+ * Portions copyright (c) 2009-2018 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -41,6 +41,7 @@
 #include <builtin_types.h>
 #include <vector_functions.h>
 #include "windowsExportCuda.h"
+#include "CudaArray.h"
 #include "CudaPlatform.h"
 #include "openmm/Kernel.h"
 
@@ -48,7 +49,6 @@ typedef unsigned int tileflags;
 
 namespace OpenMM {
 
-class CudaArray;
 class CudaForceInfo;
 class CudaExpressionUtilities;
 class CudaIntegrationUtilities;
@@ -152,37 +152,37 @@ public:
      * Get the array which contains the position (the xyz components) and charge (the w component) of each atom.
      */
     CudaArray& getPosq() {
-        return *posq;
+        return posq;
     }
     /**
      * Get the array which contains a correction to the position of each atom.  This only exists if getUseMixedPrecision() returns true.
      */
     CudaArray& getPosqCorrection() {
-        return *posqCorrection;
+        return posqCorrection;
     }
     /**
      * Get the array which contains the velocity (the xyz components) and inverse mass (the w component) of each atom.
      */
     CudaArray& getVelm() {
-        return *velm;
+        return velm;
     }
     /**
      * Get the array which contains the force on each atom (represented as three long longs in 64 bit fixed point).
      */
     CudaArray& getForce() {
-        return *force;
+        return force;
     }
     /**
      * Get the array which contains the buffer in which energy is computed.
      */
     CudaArray& getEnergyBuffer() {
-        return *energyBuffer;
+        return energyBuffer;
     }
     /**
      * Get the array which contains the buffer in which derivatives of the energy with respect to parameters are computed.
      */
     CudaArray& getEnergyParamDerivBuffer() {
-        return *energyParamDerivBuffer;
+        return energyParamDerivBuffer;
     }
     /**
      * Get a pointer to a block of pinned memory that can be used for efficient transfers between host and device.
@@ -201,7 +201,7 @@ public:
      * Get the array which contains the index of each atom.
      */
     CudaArray& getAtomIndexArray() {
-        return *atomIndexDevice;
+        return atomIndexDevice;
     }
     /**
      * Get the number of cells by which the positions are offset.
@@ -649,15 +649,15 @@ private:
     std::vector<MoleculeGroup> moleculeGroups;
     std::vector<int4> posCellOffsets;
     void* pinnedBuffer;
-    CudaArray* posq;
-    CudaArray* posqCorrection;
-    CudaArray* velm;
-    CudaArray* force;
-    CudaArray* energyBuffer;
-    CudaArray* energySum;
-    CudaArray* energyParamDerivBuffer;
-    CudaArray* atomIndexDevice;
-    CudaArray* chargeBuffer;
+    CudaArray posq;
+    CudaArray posqCorrection;
+    CudaArray velm;
+    CudaArray force;
+    CudaArray energyBuffer;
+    CudaArray energySum;
+    CudaArray energyParamDerivBuffer;
+    CudaArray atomIndexDevice;
+    CudaArray chargeBuffer;
     std::vector<std::string> energyParamDerivNames;
     std::map<std::string, double> energyParamDerivWorkspace;
     std::vector<int> atomIndex;

--- a/platforms/cuda/include/CudaIntegrationUtilities.h
+++ b/platforms/cuda/include/CudaIntegrationUtilities.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2009-2017 Stanford University and the Authors.      *
+ * Portions copyright (c) 2009-2018 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -47,20 +47,20 @@ public:
      * Get the array which contains position deltas.
      */
     CudaArray& getPosDelta() {
-        return *posDelta;
+        return posDelta;
     }
     /**
      * Get the array which contains random values.  Each element is a float4, whose components
      * are independent, normally distributed random numbers with mean 0 and variance 1.
      */
     CudaArray& getRandom() {
-        return *random;
+        return random;
     }
     /**
      * Get the array which contains the current step size.
      */
     CudaArray& getStepSize() {
-        return *stepSize;
+        return stepSize;
     }
     /**
      * Set the size to use for the next step.
@@ -131,38 +131,38 @@ private:
     CUfunction ccmaUpdateKernel;
     CUfunction vsitePositionKernel, vsiteForceKernel;
     CUfunction randomKernel, timeShiftKernel;
-    CudaArray* posDelta;
-    CudaArray* settleAtoms;
-    CudaArray* settleParams;
-    CudaArray* shakeAtoms;
-    CudaArray* shakeParams;
-    CudaArray* random;
-    CudaArray* randomSeed;
-    CudaArray* stepSize;
-    CudaArray* ccmaAtoms;
-    CudaArray* ccmaDistance;
-    CudaArray* ccmaReducedMass;
-    CudaArray* ccmaAtomConstraints;
-    CudaArray* ccmaNumAtomConstraints;
-    CudaArray* ccmaConstraintMatrixColumn;
-    CudaArray* ccmaConstraintMatrixValue;
-    CudaArray* ccmaDelta1;
-    CudaArray* ccmaDelta2;
-    CudaArray* ccmaConverged;
+    CudaArray posDelta;
+    CudaArray settleAtoms;
+    CudaArray settleParams;
+    CudaArray shakeAtoms;
+    CudaArray shakeParams;
+    CudaArray random;
+    CudaArray randomSeed;
+    CudaArray stepSize;
+    CudaArray ccmaAtoms;
+    CudaArray ccmaDistance;
+    CudaArray ccmaReducedMass;
+    CudaArray ccmaAtomConstraints;
+    CudaArray ccmaNumAtomConstraints;
+    CudaArray ccmaConstraintMatrixColumn;
+    CudaArray ccmaConstraintMatrixValue;
+    CudaArray ccmaDelta1;
+    CudaArray ccmaDelta2;
+    CudaArray ccmaConverged;
     int* ccmaConvergedMemory;
     CUdeviceptr ccmaConvergedDeviceMemory;
     CUevent ccmaEvent;
-    CudaArray* vsite2AvgAtoms;
-    CudaArray* vsite2AvgWeights;
-    CudaArray* vsite3AvgAtoms;
-    CudaArray* vsite3AvgWeights;
-    CudaArray* vsiteOutOfPlaneAtoms;
-    CudaArray* vsiteOutOfPlaneWeights;
-    CudaArray* vsiteLocalCoordsIndex;
-    CudaArray* vsiteLocalCoordsAtoms;
-    CudaArray* vsiteLocalCoordsWeights;
-    CudaArray* vsiteLocalCoordsPos;
-    CudaArray* vsiteLocalCoordsStartIndex;
+    CudaArray vsite2AvgAtoms;
+    CudaArray vsite2AvgWeights;
+    CudaArray vsite3AvgAtoms;
+    CudaArray vsite3AvgWeights;
+    CudaArray vsiteOutOfPlaneAtoms;
+    CudaArray vsiteOutOfPlaneWeights;
+    CudaArray vsiteLocalCoordsIndex;
+    CudaArray vsiteLocalCoordsAtoms;
+    CudaArray vsiteLocalCoordsWeights;
+    CudaArray vsiteLocalCoordsPos;
+    CudaArray vsiteLocalCoordsStartIndex;
     int randomPos;
     int lastSeed, numVsites;
     double2 lastStepSize;

--- a/platforms/cuda/include/CudaKernels.h
+++ b/platforms/cuda/include/CudaKernels.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2017 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2018 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -265,9 +265,8 @@ private:
 class CudaCalcHarmonicBondForceKernel : public CalcHarmonicBondForceKernel {
 public:
     CudaCalcHarmonicBondForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system) : CalcHarmonicBondForceKernel(name, platform),
-            hasInitializedKernel(false), cu(cu), system(system), params(NULL) {
+            hasInitializedKernel(false), cu(cu), system(system) {
     }
-    ~CudaCalcHarmonicBondForceKernel();
     /**
      * Initialize the kernel.
      *
@@ -298,7 +297,7 @@ private:
     CudaContext& cu;
     ForceInfo* info;
     const System& system;
-    CudaArray* params;
+    CudaArray params;
 };
 
 /**
@@ -307,7 +306,7 @@ private:
 class CudaCalcCustomBondForceKernel : public CalcCustomBondForceKernel {
 public:
     CudaCalcCustomBondForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system) : CalcCustomBondForceKernel(name, platform),
-            hasInitializedKernel(false), cu(cu), system(system), params(NULL), globals(NULL) {
+            hasInitializedKernel(false), cu(cu), system(system), params(NULL) {
     }
     ~CudaCalcCustomBondForceKernel();
     /**
@@ -341,7 +340,7 @@ private:
     ForceInfo* info;
     const System& system;
     CudaParameterSet* params;
-    CudaArray* globals;
+    CudaArray globals;
     std::vector<std::string> globalParamNames;
     std::vector<float> globalParamValues;
 };
@@ -352,9 +351,8 @@ private:
 class CudaCalcHarmonicAngleForceKernel : public CalcHarmonicAngleForceKernel {
 public:
     CudaCalcHarmonicAngleForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system) : CalcHarmonicAngleForceKernel(name, platform),
-            hasInitializedKernel(false), cu(cu), system(system), params(NULL) {
+            hasInitializedKernel(false), cu(cu), system(system) {
     }
-    ~CudaCalcHarmonicAngleForceKernel();
     /**
      * Initialize the kernel.
      *
@@ -385,7 +383,7 @@ private:
     CudaContext& cu;
     ForceInfo* info;
     const System& system;
-    CudaArray* params;
+    CudaArray params;
 };
 
 /**
@@ -394,7 +392,7 @@ private:
 class CudaCalcCustomAngleForceKernel : public CalcCustomAngleForceKernel {
 public:
     CudaCalcCustomAngleForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system) : CalcCustomAngleForceKernel(name, platform),
-            hasInitializedKernel(false), cu(cu), system(system), params(NULL), globals(NULL) {
+            hasInitializedKernel(false), cu(cu), system(system), params(NULL) {
     }
     ~CudaCalcCustomAngleForceKernel();
     /**
@@ -428,7 +426,7 @@ private:
     ForceInfo* info;
     const System& system;
     CudaParameterSet* params;
-    CudaArray* globals;
+    CudaArray globals;
     std::vector<std::string> globalParamNames;
     std::vector<float> globalParamValues;
 };
@@ -439,9 +437,8 @@ private:
 class CudaCalcPeriodicTorsionForceKernel : public CalcPeriodicTorsionForceKernel {
 public:
     CudaCalcPeriodicTorsionForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system) : CalcPeriodicTorsionForceKernel(name, platform),
-            hasInitializedKernel(false), cu(cu), system(system), params(NULL) {
+            hasInitializedKernel(false), cu(cu), system(system) {
     }
-    ~CudaCalcPeriodicTorsionForceKernel();
     /**
      * Initialize the kernel.
      *
@@ -472,7 +469,7 @@ private:
     CudaContext& cu;
     ForceInfo* info;
     const System& system;
-    CudaArray* params;
+    CudaArray params;
 };
 
 /**
@@ -481,9 +478,8 @@ private:
 class CudaCalcRBTorsionForceKernel : public CalcRBTorsionForceKernel {
 public:
     CudaCalcRBTorsionForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system) : CalcRBTorsionForceKernel(name, platform),
-            hasInitializedKernel(false), cu(cu), system(system), params1(NULL), params2(NULL) {
+            hasInitializedKernel(false), cu(cu), system(system) {
     }
-    ~CudaCalcRBTorsionForceKernel();
     /**
      * Initialize the kernel.
      *
@@ -514,8 +510,8 @@ private:
     CudaContext& cu;
     ForceInfo* info;
     const System& system;
-    CudaArray* params1;
-    CudaArray* params2;
+    CudaArray params1;
+    CudaArray params2;
 };
 
 /**
@@ -524,9 +520,8 @@ private:
 class CudaCalcCMAPTorsionForceKernel : public CalcCMAPTorsionForceKernel {
 public:
     CudaCalcCMAPTorsionForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system) : CalcCMAPTorsionForceKernel(name, platform),
-            hasInitializedKernel(false), cu(cu), system(system), coefficients(NULL), mapPositions(NULL), torsionMaps(NULL) {
+            hasInitializedKernel(false), cu(cu), system(system) {
     }
-    ~CudaCalcCMAPTorsionForceKernel();
     /**
      * Initialize the kernel.
      *
@@ -558,9 +553,9 @@ private:
     ForceInfo* info;
     const System& system;
     std::vector<int2> mapPositionsVec;
-    CudaArray* coefficients;
-    CudaArray* mapPositions;
-    CudaArray* torsionMaps;
+    CudaArray coefficients;
+    CudaArray mapPositions;
+    CudaArray torsionMaps;
 };
 
 /**
@@ -569,7 +564,7 @@ private:
 class CudaCalcCustomTorsionForceKernel : public CalcCustomTorsionForceKernel {
 public:
     CudaCalcCustomTorsionForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system) : CalcCustomTorsionForceKernel(name, platform),
-            hasInitializedKernel(false), cu(cu), system(system), params(NULL), globals(NULL) {
+            hasInitializedKernel(false), cu(cu), system(system), params(NULL) {
     }
     ~CudaCalcCustomTorsionForceKernel();
     /**
@@ -603,7 +598,7 @@ private:
     ForceInfo* info;
     const System& system;
     CudaParameterSet* params;
-    CudaArray* globals;
+    CudaArray globals;
     std::vector<std::string> globalParamNames;
     std::vector<float> globalParamValues;
 };
@@ -614,9 +609,7 @@ private:
 class CudaCalcNonbondedForceKernel : public CalcNonbondedForceKernel {
 public:
     CudaCalcNonbondedForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system) : CalcNonbondedForceKernel(name, platform),
-            cu(cu), hasInitializedFFT(false), sigmaEpsilon(NULL), exceptionParams(NULL), cosSinSums(NULL), directPmeGrid(NULL), reciprocalPmeGrid(NULL),
-            pmeBsplineModuliX(NULL), pmeBsplineModuliY(NULL), pmeBsplineModuliZ(NULL), pmeDispersionBsplineModuliX(NULL), pmeDispersionBsplineModuliY(NULL),
-            pmeDispersionBsplineModuliZ(NULL), pmeAtomRange(NULL), pmeAtomGridIndex(NULL), pmeEnergyBuffer(NULL), sort(NULL), dispersionFft(NULL), fft(NULL), pmeio(NULL) {
+            cu(cu), hasInitializedFFT(false), sort(NULL), dispersionFft(NULL), fft(NULL), pmeio(NULL) {
     }
     ~CudaCalcNonbondedForceKernel();
     /**
@@ -682,20 +675,20 @@ private:
     CudaContext& cu;
     ForceInfo* info;
     bool hasInitializedFFT;
-    CudaArray* sigmaEpsilon;
-    CudaArray* exceptionParams;
-    CudaArray* cosSinSums;
-    CudaArray* directPmeGrid;
-    CudaArray* reciprocalPmeGrid;
-    CudaArray* pmeBsplineModuliX;
-    CudaArray* pmeBsplineModuliY;
-    CudaArray* pmeBsplineModuliZ;
-    CudaArray* pmeDispersionBsplineModuliX;
-    CudaArray* pmeDispersionBsplineModuliY;
-    CudaArray* pmeDispersionBsplineModuliZ;
-    CudaArray* pmeAtomRange;
-    CudaArray* pmeAtomGridIndex;
-    CudaArray* pmeEnergyBuffer;
+    CudaArray sigmaEpsilon;
+    CudaArray exceptionParams;
+    CudaArray cosSinSums;
+    CudaArray directPmeGrid;
+    CudaArray reciprocalPmeGrid;
+    CudaArray pmeBsplineModuliX;
+    CudaArray pmeBsplineModuliY;
+    CudaArray pmeBsplineModuliZ;
+    CudaArray pmeDispersionBsplineModuliX;
+    CudaArray pmeDispersionBsplineModuliY;
+    CudaArray pmeDispersionBsplineModuliZ;
+    CudaArray pmeAtomRange;
+    CudaArray pmeAtomGridIndex;
+    CudaArray pmeEnergyBuffer;
     CudaSort* sort;
     Kernel cpuPme;
     PmeIO* pmeio;
@@ -737,7 +730,7 @@ private:
 class CudaCalcCustomNonbondedForceKernel : public CalcCustomNonbondedForceKernel {
 public:
     CudaCalcCustomNonbondedForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system) : CalcCustomNonbondedForceKernel(name, platform),
-            cu(cu), params(NULL), globals(NULL), interactionGroupData(NULL), forceCopy(NULL), system(system), hasInitializedKernel(false) {
+            cu(cu), params(NULL), forceCopy(NULL), system(system), hasInitializedKernel(false) {
     }
     ~CudaCalcCustomNonbondedForceKernel();
     /**
@@ -769,13 +762,13 @@ private:
     CudaContext& cu;
     ForceInfo* info;
     CudaParameterSet* params;
-    CudaArray* globals;
-    CudaArray* interactionGroupData;
+    CudaArray globals;
+    CudaArray interactionGroupData;
     CUfunction interactionGroupKernel;
     std::vector<void*> interactionGroupArgs;
     std::vector<std::string> globalParamNames;
     std::vector<float> globalParamValues;
-    std::vector<CudaArray*> tabulatedFunctions;
+    std::vector<CudaArray> tabulatedFunctions;
     double longRangeCoefficient;
     std::vector<double> longRangeCoefficientDerivs;
     bool hasInitializedLongRangeCorrection, hasInitializedKernel, hasParamDerivs;
@@ -790,9 +783,8 @@ private:
 class CudaCalcGBSAOBCForceKernel : public CalcGBSAOBCForceKernel {
 public:
     CudaCalcGBSAOBCForceKernel(std::string name, const Platform& platform, CudaContext& cu) : CalcGBSAOBCForceKernel(name, platform), cu(cu),
-            hasCreatedKernels(false), params(NULL), bornSum(NULL), bornRadii(NULL), bornForce(NULL), obcChain(NULL) {
+            hasCreatedKernels(false) {
     }
-    ~CudaCalcGBSAOBCForceKernel();
     /**
      * Initialize the kernel.
      *
@@ -823,11 +815,11 @@ private:
     int maxTiles;
     CudaContext& cu;
     ForceInfo* info;
-    CudaArray* params;
-    CudaArray* bornSum;
-    CudaArray* bornRadii;
-    CudaArray* bornForce;
-    CudaArray* obcChain;
+    CudaArray params;
+    CudaArray bornSum;
+    CudaArray bornRadii;
+    CudaArray bornForce;
+    CudaArray obcChain;
     CUfunction computeBornSumKernel;
     CUfunction reduceBornSumKernel;
     CUfunction force1Kernel;
@@ -841,8 +833,7 @@ private:
 class CudaCalcCustomGBForceKernel : public CalcCustomGBForceKernel {
 public:
     CudaCalcCustomGBForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system) : CalcCustomGBForceKernel(name, platform),
-            hasInitializedKernels(false), cu(cu), params(NULL), computedValues(NULL), energyDerivs(NULL), energyDerivChain(NULL), longEnergyDerivs(NULL), globals(NULL),
-            valueBuffers(NULL), system(system) {
+            hasInitializedKernels(false), cu(cu), params(NULL), computedValues(NULL), energyDerivs(NULL), energyDerivChain(NULL), system(system) {
     }
     ~CudaCalcCustomGBForceKernel();
     /**
@@ -880,13 +871,13 @@ private:
     CudaParameterSet* energyDerivs;
     CudaParameterSet* energyDerivChain;
     std::vector<CudaParameterSet*> dValuedParam;
-    std::vector<CudaArray*> dValue0dParam;
-    CudaArray* longEnergyDerivs;
-    CudaArray* globals;
-    CudaArray* valueBuffers;
+    std::vector<CudaArray> dValue0dParam;
+    CudaArray longEnergyDerivs;
+    CudaArray globals;
+    CudaArray valueBuffers;
     std::vector<std::string> globalParamNames;
     std::vector<float> globalParamValues;
-    std::vector<CudaArray*> tabulatedFunctions;
+    std::vector<CudaArray> tabulatedFunctions;
     std::vector<bool> pairValueUsesParam, pairEnergyUsesParam, pairEnergyUsesValue;
     const System& system;
     CUfunction pairValueKernel, perParticleValueKernel, pairEnergyKernel, perParticleEnergyKernel, gradientChainRuleKernel;
@@ -901,7 +892,7 @@ private:
 class CudaCalcCustomExternalForceKernel : public CalcCustomExternalForceKernel {
 public:
     CudaCalcCustomExternalForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system) : CalcCustomExternalForceKernel(name, platform),
-            hasInitializedKernel(false), cu(cu), system(system), params(NULL), globals(NULL) {
+            hasInitializedKernel(false), cu(cu), system(system), params(NULL) {
     }
     ~CudaCalcCustomExternalForceKernel();
     /**
@@ -935,7 +926,7 @@ private:
     ForceInfo* info;
     const System& system;
     CudaParameterSet* params;
-    CudaArray* globals;
+    CudaArray globals;
     std::vector<std::string> globalParamNames;
     std::vector<float> globalParamValues;
 };
@@ -946,8 +937,7 @@ private:
 class CudaCalcCustomHbondForceKernel : public CalcCustomHbondForceKernel {
 public:
     CudaCalcCustomHbondForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system) : CalcCustomHbondForceKernel(name, platform),
-            hasInitializedKernel(false), cu(cu), donorParams(NULL), acceptorParams(NULL), donors(NULL), acceptors(NULL),
-            globals(NULL), donorExclusions(NULL), acceptorExclusions(NULL), system(system) {
+            hasInitializedKernel(false), cu(cu), donorParams(NULL), acceptorParams(NULL), system(system) {
     }
     ~CudaCalcCustomHbondForceKernel();
     /**
@@ -981,14 +971,14 @@ private:
     ForceInfo* info;
     CudaParameterSet* donorParams;
     CudaParameterSet* acceptorParams;
-    CudaArray* globals;
-    CudaArray* donors;
-    CudaArray* acceptors;
-    CudaArray* donorExclusions;
-    CudaArray* acceptorExclusions;
+    CudaArray globals;
+    CudaArray donors;
+    CudaArray acceptors;
+    CudaArray donorExclusions;
+    CudaArray acceptorExclusions;
     std::vector<std::string> globalParamNames;
     std::vector<float> globalParamValues;
-    std::vector<CudaArray*> tabulatedFunctions;
+    std::vector<CudaArray> tabulatedFunctions;
     std::vector<void*> donorArgs, acceptorArgs;
     const System& system;
     CUfunction donorKernel, acceptorKernel;
@@ -1000,7 +990,7 @@ private:
 class CudaCalcCustomCentroidBondForceKernel : public CalcCustomCentroidBondForceKernel {
 public:
     CudaCalcCustomCentroidBondForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system) : CalcCustomCentroidBondForceKernel(name, platform),
-            cu(cu), params(NULL), globals(NULL), groupParticles(NULL), groupWeights(NULL), groupOffsets(NULL), groupForces(NULL), bondGroups(NULL), centerPositions(NULL), system(system) {
+            cu(cu), params(NULL), system(system) {
     }
     ~CudaCalcCustomCentroidBondForceKernel();
     /**
@@ -1034,16 +1024,16 @@ private:
     CudaContext& cu;
     ForceInfo* info;
     CudaParameterSet* params;
-    CudaArray* globals;
-    CudaArray* groupParticles;
-    CudaArray* groupWeights;
-    CudaArray* groupOffsets;
-    CudaArray* groupForces;
-    CudaArray* bondGroups;
-    CudaArray* centerPositions;
+    CudaArray globals;
+    CudaArray groupParticles;
+    CudaArray groupWeights;
+    CudaArray groupOffsets;
+    CudaArray groupForces;
+    CudaArray bondGroups;
+    CudaArray centerPositions;
     std::vector<std::string> globalParamNames;
     std::vector<float> globalParamValues;
-    std::vector<CudaArray*> tabulatedFunctions;
+    std::vector<CudaArray> tabulatedFunctions;
     std::vector<void*> groupForcesArgs;
     CUfunction computeCentersKernel, groupForcesKernel, applyForcesKernel;
     const System& system;
@@ -1055,7 +1045,7 @@ private:
 class CudaCalcCustomCompoundBondForceKernel : public CalcCustomCompoundBondForceKernel {
 public:
     CudaCalcCustomCompoundBondForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system) : CalcCustomCompoundBondForceKernel(name, platform),
-            cu(cu), params(NULL), globals(NULL), system(system) {
+            cu(cu), params(NULL), system(system) {
     }
     ~CudaCalcCustomCompoundBondForceKernel();
     /**
@@ -1088,10 +1078,10 @@ private:
     CudaContext& cu;
     ForceInfo* info;
     CudaParameterSet* params;
-    CudaArray* globals;
+    CudaArray globals;
     std::vector<std::string> globalParamNames;
     std::vector<float> globalParamValues;
-    std::vector<CudaArray*> tabulatedFunctions;
+    std::vector<CudaArray> tabulatedFunctions;
     const System& system;
 };
 
@@ -1101,9 +1091,7 @@ private:
 class CudaCalcCustomManyParticleForceKernel : public CalcCustomManyParticleForceKernel {
 public:
     CudaCalcCustomManyParticleForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system) : CalcCustomManyParticleForceKernel(name, platform),
-            hasInitializedKernel(false), cu(cu), params(NULL), particleTypes(NULL), orderIndex(NULL), particleOrder(NULL), exclusions(NULL),
-            exclusionStartIndex(NULL), blockCenter(NULL), blockBoundingBox(NULL), neighborPairs(NULL), numNeighborPairs(NULL), neighborStartIndex(NULL),
-            numNeighborsForAtom(NULL), neighbors(NULL), system(system) {
+            hasInitializedKernel(false), cu(cu), params(NULL), system(system) {
     }
     ~CudaCalcCustomManyParticleForceKernel();
     /**
@@ -1138,21 +1126,21 @@ private:
     NonbondedMethod nonbondedMethod;
     int maxNeighborPairs, forceWorkgroupSize, findNeighborsWorkgroupSize;
     CudaParameterSet* params;
-    CudaArray* particleTypes;
-    CudaArray* orderIndex;
-    CudaArray* particleOrder;
-    CudaArray* exclusions;
-    CudaArray* exclusionStartIndex;
-    CudaArray* blockCenter;
-    CudaArray* blockBoundingBox;
-    CudaArray* neighborPairs;
-    CudaArray* numNeighborPairs;
-    CudaArray* neighborStartIndex;
-    CudaArray* numNeighborsForAtom;
-    CudaArray* neighbors;
+    CudaArray particleTypes;
+    CudaArray orderIndex;
+    CudaArray particleOrder;
+    CudaArray exclusions;
+    CudaArray exclusionStartIndex;
+    CudaArray blockCenter;
+    CudaArray blockBoundingBox;
+    CudaArray neighborPairs;
+    CudaArray numNeighborPairs;
+    CudaArray neighborStartIndex;
+    CudaArray numNeighborsForAtom;
+    CudaArray neighbors;
     std::vector<std::string> globalParamNames;
     std::vector<float> globalParamValues;
-    std::vector<CudaArray*> tabulatedFunctions;
+    std::vector<CudaArray> tabulatedFunctions;
     std::vector<void*> forceArgs, blockBoundsArgs, neighborsArgs, startIndicesArgs, copyPairsArgs;
     const System& system;
     CUfunction forceKernel, blockBoundsKernel, neighborsKernel, startIndicesKernel, copyPairsKernel;

--- a/platforms/cuda/include/CudaKernels.h
+++ b/platforms/cuda/include/CudaKernels.h
@@ -1154,12 +1154,8 @@ private:
 class CudaCalcGayBerneForceKernel : public CalcGayBerneForceKernel {
 public:
     CudaCalcGayBerneForceKernel(std::string name, const Platform& platform, CudaContext& cu) : CalcGayBerneForceKernel(name, platform), cu(cu),
-            hasInitializedKernels(false), sortedParticles(NULL), axisParticleIndices(NULL), sigParams(NULL), epsParams(NULL), scale(NULL), exceptionParticles(NULL),
-            exceptionParams(NULL), aMatrix(NULL),
-            bMatrix(NULL), gMatrix(NULL), exclusions(NULL), exclusionStartIndex(NULL), blockCenter(NULL), blockBoundingBox(NULL), neighbors(NULL),
-            neighborIndex(NULL), neighborBlockCount(NULL), sortedPos(NULL), torque(NULL) {
+            hasInitializedKernels(false) {
     }
-    ~CudaCalcGayBerneForceKernel();
     /**
      * Initialize the kernel.
      *
@@ -1191,25 +1187,25 @@ private:
     bool hasInitializedKernels;
     int numRealParticles, numExceptions, maxNeighborBlocks;
     GayBerneForce::NonbondedMethod nonbondedMethod;
-    CudaArray* sortedParticles;
-    CudaArray* axisParticleIndices;
-    CudaArray* sigParams;
-    CudaArray* epsParams;
-    CudaArray* scale;
-    CudaArray* exceptionParticles;
-    CudaArray* exceptionParams;
-    CudaArray* aMatrix;
-    CudaArray* bMatrix;
-    CudaArray* gMatrix;
-    CudaArray* exclusions;
-    CudaArray* exclusionStartIndex;
-    CudaArray* blockCenter;
-    CudaArray* blockBoundingBox;
-    CudaArray* neighbors;
-    CudaArray* neighborIndex;
-    CudaArray* neighborBlockCount;
-    CudaArray* sortedPos;
-    CudaArray* torque;
+    CudaArray sortedParticles;
+    CudaArray axisParticleIndices;
+    CudaArray sigParams;
+    CudaArray epsParams;
+    CudaArray scale;
+    CudaArray exceptionParticles;
+    CudaArray exceptionParams;
+    CudaArray aMatrix;
+    CudaArray bMatrix;
+    CudaArray gMatrix;
+    CudaArray exclusions;
+    CudaArray exclusionStartIndex;
+    CudaArray blockCenter;
+    CudaArray blockBoundingBox;
+    CudaArray neighbors;
+    CudaArray neighborIndex;
+    CudaArray neighborBlockCount;
+    CudaArray sortedPos;
+    CudaArray torque;
     std::vector<bool> isRealParticle;
     std::vector<std::pair<int, int> > exceptionAtoms;
     std::vector<std::pair<int, int> > excludedPairs;
@@ -1224,9 +1220,8 @@ private:
 class CudaCalcCustomCVForceKernel : public CalcCustomCVForceKernel {
 public:
     CudaCalcCustomCVForceKernel(std::string name, const Platform& platform, CudaContext& cu) : CalcCustomCVForceKernel(name, platform),
-            cu(cu), hasInitializedListeners(false), invAtomOrder(NULL), innerInvAtomOrder(NULL) {
+            cu(cu), hasInitializedListeners(false) {
     }
-    ~CudaCalcCustomCVForceKernel();
     /**
      * Initialize the kernel.
      *
@@ -1260,9 +1255,9 @@ private:
     std::vector<std::string> variableNames, paramDerivNames, globalParameterNames;
     std::vector<Lepton::ExpressionProgram> variableDerivExpressions;
     std::vector<Lepton::ExpressionProgram> paramDerivExpressions;
-    std::vector<CudaArray*> cvForces;
-    CudaArray* invAtomOrder;
-    CudaArray* innerInvAtomOrder;
+    std::vector<CudaArray> cvForces;
+    CudaArray invAtomOrder;
+    CudaArray innerInvAtomOrder;
     CUfunction copyStateKernel, copyForcesKernel, addForcesKernel;
 };
 
@@ -1271,10 +1266,8 @@ private:
  */
 class CudaCalcRMSDForceKernel : public CalcRMSDForceKernel {
 public:
-    CudaCalcRMSDForceKernel(std::string name, const Platform& platform, CudaContext& cu) : CalcRMSDForceKernel(name, platform),
-            cu(cu), referencePos(NULL), particles(NULL), buffer(NULL) {
+    CudaCalcRMSDForceKernel(std::string name, const Platform& platform, CudaContext& cu) : CalcRMSDForceKernel(name, platform), cu(cu) {
     }
-    ~CudaCalcRMSDForceKernel();
     /**
      * Initialize the kernel.
      *
@@ -1313,9 +1306,9 @@ private:
     CudaContext& cu;
     ForceInfo* info;
     double sumNormRef;
-    CudaArray* referencePos;
-    CudaArray* particles;
-    CudaArray* buffer;
+    CudaArray referencePos;
+    CudaArray particles;
+    CudaArray buffer;
     CUfunction kernel1, kernel2;
 };
 
@@ -1326,7 +1319,6 @@ class CudaIntegrateVerletStepKernel : public IntegrateVerletStepKernel {
 public:
     CudaIntegrateVerletStepKernel(std::string name, const Platform& platform, CudaContext& cu) : IntegrateVerletStepKernel(name, platform), cu(cu) {
     }
-    ~CudaIntegrateVerletStepKernel();
     /**
      * Initialize the kernel.
      *
@@ -1358,9 +1350,8 @@ private:
  */
 class CudaIntegrateLangevinStepKernel : public IntegrateLangevinStepKernel {
 public:
-    CudaIntegrateLangevinStepKernel(std::string name, const Platform& platform, CudaContext& cu) : IntegrateLangevinStepKernel(name, platform), cu(cu), params(NULL) {
+    CudaIntegrateLangevinStepKernel(std::string name, const Platform& platform, CudaContext& cu) : IntegrateLangevinStepKernel(name, platform), cu(cu) {
     }
-    ~CudaIntegrateLangevinStepKernel();
     /**
      * Initialize the kernel, setting up the particle masses.
      *
@@ -1385,7 +1376,7 @@ public:
 private:
     CudaContext& cu;
     double prevTemp, prevFriction, prevStepSize;
-    CudaArray* params;
+    CudaArray params;
     CUfunction kernel1, kernel2;
 };
 
@@ -1396,7 +1387,6 @@ class CudaIntegrateBrownianStepKernel : public IntegrateBrownianStepKernel {
 public:
     CudaIntegrateBrownianStepKernel(std::string name, const Platform& platform, CudaContext& cu) : IntegrateBrownianStepKernel(name, platform), cu(cu) {
     }
-    ~CudaIntegrateBrownianStepKernel();
     /**
      * Initialize the kernel.
      *
@@ -1431,7 +1421,6 @@ class CudaIntegrateVariableVerletStepKernel : public IntegrateVariableVerletStep
 public:
     CudaIntegrateVariableVerletStepKernel(std::string name, const Platform& platform, CudaContext& cu) : IntegrateVariableVerletStepKernel(name, platform), cu(cu) {
     }
-    ~CudaIntegrateVariableVerletStepKernel();
     /**
      * Initialize the kernel.
      *
@@ -1466,10 +1455,8 @@ private:
  */
 class CudaIntegrateVariableLangevinStepKernel : public IntegrateVariableLangevinStepKernel {
 public:
-    CudaIntegrateVariableLangevinStepKernel(std::string name, const Platform& platform, CudaContext& cu) : IntegrateVariableLangevinStepKernel(name, platform),
-            cu(cu), params(NULL) {
+    CudaIntegrateVariableLangevinStepKernel(std::string name, const Platform& platform, CudaContext& cu) : IntegrateVariableLangevinStepKernel(name, platform), cu(cu) {
     }
-    ~CudaIntegrateVariableLangevinStepKernel();
     /**
      * Initialize the kernel, setting up the particle masses.
      *
@@ -1496,7 +1483,7 @@ public:
 private:
     CudaContext& cu;
     int blockSize;
-    CudaArray* params;
+    CudaArray params;
     CUfunction kernel1, kernel2, selectSizeKernel;
     double prevTemp, prevFriction, prevErrorTol;
 };
@@ -1508,8 +1495,7 @@ class CudaIntegrateCustomStepKernel : public IntegrateCustomStepKernel {
 public:
     enum GlobalTargetType {DT, VARIABLE, PARAMETER};
     CudaIntegrateCustomStepKernel(std::string name, const Platform& platform, CudaContext& cu) : IntegrateCustomStepKernel(name, platform), cu(cu),
-            hasInitializedKernels(false), localValuesAreCurrent(false), globalValues(NULL), sumBuffer(NULL), summedValue(NULL), uniformRandoms(NULL),
-            randomSeed(NULL), perDofEnergyParamDerivs(NULL), perDofValues(NULL), needsEnergyParamDerivs(false) {
+            hasInitializedKernels(false), localValuesAreCurrent(false), perDofValues(NULL), needsEnergyParamDerivs(false) {
     }
     ~CudaIntegrateCustomStepKernel();
     /**
@@ -1590,15 +1576,15 @@ private:
     int numGlobalVariables, sumWorkGroupSize;
     bool hasInitializedKernels, deviceValuesAreCurrent, deviceGlobalsAreCurrent, modifiesParameters, keNeedsForce, hasAnyConstraints, needsEnergyParamDerivs;
     mutable bool localValuesAreCurrent;
-    CudaArray* globalValues;
-    CudaArray* sumBuffer;
-    CudaArray* summedValue;
-    CudaArray* uniformRandoms;
-    CudaArray* randomSeed;
-    CudaArray* perDofEnergyParamDerivs;
-    std::vector<CudaArray*> tabulatedFunctions;
+    CudaArray globalValues;
+    CudaArray sumBuffer;
+    CudaArray summedValue;
+    CudaArray uniformRandoms;
+    CudaArray randomSeed;
+    CudaArray perDofEnergyParamDerivs;
+    std::vector<CudaArray> tabulatedFunctions;
     std::map<int, double> savedEnergy;
-    std::map<int, CudaArray*> savedForces;
+    std::map<int, CudaArray> savedForces;
     std::set<int> validSavedForces;
     CudaParameterSet* perDofValues;
     mutable std::vector<std::vector<float> > localPerDofValuesFloat;
@@ -1651,10 +1637,8 @@ public:
  */
 class CudaApplyAndersenThermostatKernel : public ApplyAndersenThermostatKernel {
 public:
-    CudaApplyAndersenThermostatKernel(std::string name, const Platform& platform, CudaContext& cu) : ApplyAndersenThermostatKernel(name, platform), cu(cu),
-            atomGroups(NULL) {
+    CudaApplyAndersenThermostatKernel(std::string name, const Platform& platform, CudaContext& cu) : ApplyAndersenThermostatKernel(name, platform), cu(cu) {
     }
-    ~CudaApplyAndersenThermostatKernel();
     /**
      * Initialize the kernel.
      *
@@ -1671,7 +1655,7 @@ public:
 private:
     CudaContext& cu;
     int randomSeed;
-    CudaArray* atomGroups;
+    CudaArray atomGroups;
     CUfunction kernel;
 };
 
@@ -1681,9 +1665,8 @@ private:
 class CudaApplyMonteCarloBarostatKernel : public ApplyMonteCarloBarostatKernel {
 public:
     CudaApplyMonteCarloBarostatKernel(std::string name, const Platform& platform, CudaContext& cu) : ApplyMonteCarloBarostatKernel(name, platform), cu(cu),
-            hasInitializedKernels(false), savedPositions(NULL), savedForces(NULL), moleculeAtoms(NULL), moleculeStartIndex(NULL) {
+            hasInitializedKernels(false) {
     }
-    ~CudaApplyMonteCarloBarostatKernel();
     /**
      * Initialize the kernel.
      *
@@ -1715,10 +1698,10 @@ private:
     CudaContext& cu;
     bool hasInitializedKernels;
     int numMolecules;
-    CudaArray* savedPositions;
-    CudaArray* savedForces;
-    CudaArray* moleculeAtoms;
-    CudaArray* moleculeStartIndex;
+    CudaArray savedPositions;
+    CudaArray savedForces;
+    CudaArray moleculeAtoms;
+    CudaArray moleculeStartIndex;
     CUfunction kernel;
     std::vector<int> lastAtomOrder;
 };
@@ -1728,9 +1711,8 @@ private:
  */
 class CudaRemoveCMMotionKernel : public RemoveCMMotionKernel {
 public:
-    CudaRemoveCMMotionKernel(std::string name, const Platform& platform, CudaContext& cu) : RemoveCMMotionKernel(name, platform), cu(cu), cmMomentum(NULL) {
+    CudaRemoveCMMotionKernel(std::string name, const Platform& platform, CudaContext& cu) : RemoveCMMotionKernel(name, platform), cu(cu) {
     }
-    ~CudaRemoveCMMotionKernel();
     /**
      * Initialize the kernel, setting up the particle masses.
      *
@@ -1747,7 +1729,7 @@ public:
 private:
     CudaContext& cu;
     int frequency;
-    CudaArray* cmMomentum;
+    CudaArray cmMomentum;
     CUfunction kernel1, kernel2;
 };
 

--- a/platforms/cuda/include/CudaNonbondedUtilities.h
+++ b/platforms/cuda/include/CudaNonbondedUtilities.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2009-2016 Stanford University and the Authors.      *
+ * Portions copyright (c) 2009-2018 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -164,61 +164,61 @@ public:
      * Get the array containing the center of each atom block.
      */
     CudaArray& getBlockCenters() {
-        return *blockCenter;
+        return blockCenter;
     }
     /**
      * Get the array containing the dimensions of each atom block.
      */
     CudaArray& getBlockBoundingBoxes() {
-        return *blockBoundingBox;
+        return blockBoundingBox;
     }
     /**
      * Get the array whose first element contains the number of tiles with interactions.
      */
     CudaArray& getInteractionCount() {
-        return *interactionCount;
+        return interactionCount;
     }
     /**
      * Get the array containing tiles with interactions.
      */
     CudaArray& getInteractingTiles() {
-        return *interactingTiles;
+        return interactingTiles;
     }
     /**
      * Get the array containing the atoms in each tile with interactions.
      */
     CudaArray& getInteractingAtoms() {
-        return *interactingAtoms;
+        return interactingAtoms;
     }
     /**
      * Get the array containing single pairs in the neighbor list.
      */
     CudaArray& getSinglePairs() {
-        return *singlePairs;
+        return singlePairs;
     }
     /**
      * Get the array containing exclusion flags.
      */
     CudaArray& getExclusions() {
-        return *exclusions;
+        return exclusions;
     }
     /**
      * Get the array containing tiles with exclusions.
      */
     CudaArray& getExclusionTiles() {
-        return *exclusionTiles;
+        return exclusionTiles;
     }
     /**
      * Get the array containing the index into the exclusion array for each tile.
      */
     CudaArray& getExclusionIndices() {
-        return *exclusionIndices;
+        return exclusionIndices;
     }
     /**
      * Get the array listing where the exclusion data starts for each row.
      */
     CudaArray& getExclusionRowIndices() {
-        return *exclusionRowIndices;
+        return exclusionRowIndices;
     }
     /**
      * Get the index of the first tile this context is responsible for processing.
@@ -270,22 +270,22 @@ private:
     class BlockSortTrait;
     CudaContext& context;
     std::map<int, KernelSet> groupKernels;
-    CudaArray* exclusionTiles;
-    CudaArray* exclusions;
-    CudaArray* exclusionIndices;
-    CudaArray* exclusionRowIndices;
-    CudaArray* interactingTiles;
-    CudaArray* interactingAtoms;
-    CudaArray* interactionCount;
-    CudaArray* singlePairs;
-    CudaArray* singlePairCount;
-    CudaArray* blockCenter;
-    CudaArray* blockBoundingBox;
-    CudaArray* sortedBlocks;
-    CudaArray* sortedBlockCenter;
-    CudaArray* sortedBlockBoundingBox;
-    CudaArray* oldPositions;
-    CudaArray* rebuildNeighborList;
+    CudaArray exclusionTiles;
+    CudaArray exclusions;
+    CudaArray exclusionIndices;
+    CudaArray exclusionRowIndices;
+    CudaArray interactingTiles;
+    CudaArray interactingAtoms;
+    CudaArray interactionCount;
+    CudaArray singlePairs;
+    CudaArray singlePairCount;
+    CudaArray blockCenter;
+    CudaArray blockBoundingBox;
+    CudaArray sortedBlocks;
+    CudaArray sortedBlockCenter;
+    CudaArray sortedBlockBoundingBox;
+    CudaArray oldPositions;
+    CudaArray rebuildNeighborList;
     CudaSort* blockSorter;
     CUevent downloadCountEvent;
     int* pinnedCountBuffer;

--- a/platforms/cuda/include/CudaParallelKernels.h
+++ b/platforms/cuda/include/CudaParallelKernels.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2011-2015 Stanford University and the Authors.      *
+ * Portions copyright (c) 2011-2018 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -84,7 +84,7 @@ private:
     std::vector<long long> completionTimes;
     std::vector<double> contextNonbondedFractions;
     int2* interactionCounts;
-    CudaArray* contextForces;
+    CudaArray contextForces;
     void* pinnedPositionBuffer;
     long long* pinnedForceBuffer;
     CUfunction sumKernel;

--- a/platforms/cuda/include/CudaSort.h
+++ b/platforms/cuda/include/CudaSort.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2010-2012 Stanford University and the Authors.      *
+ * Portions copyright (c) 2010-2018 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -87,11 +87,11 @@ public:
 private:
     CudaContext& context;
     SortTrait* trait;
-    CudaArray* dataRange;
-    CudaArray* bucketOfElement;
-    CudaArray* offsetInBucket;
-    CudaArray* bucketOffset;
-    CudaArray* buckets;
+    CudaArray dataRange;
+    CudaArray bucketOfElement;
+    CudaArray offsetInBucket;
+    CudaArray bucketOffset;
+    CudaArray buckets;
     CUfunction shortListKernel, computeRangeKernel, assignElementsKernel, computeBucketPositionsKernel, copyToBucketsKernel, sortBucketsKernel;
     unsigned int dataLength, rangeKernelSize, positionsKernelSize, sortKernelSize;
     bool isShortList;

--- a/platforms/cuda/src/CudaBondedUtilities.cpp
+++ b/platforms/cuda/src/CudaBondedUtilities.cpp
@@ -84,8 +84,10 @@ void CudaBondedUtilities::initialize(const System& system) {
     for (int i = 0; i < numForces; i++) {
         int numBonds = forceAtoms[i].size();
         int numAtoms = forceAtoms[i][0].size();
+        int numArrays = (numAtoms+3)/4;
         int startAtom = 0;
-        while (startAtom < numAtoms) {
+        atomIndices[i].resize(numArrays);
+        for (int j = 0; j < numArrays; j++) {
             int width = min(numAtoms-startAtom, 4);
             int paddedWidth = (width == 3 ? 4 : width);
             vector<unsigned int> indexVec(paddedWidth*numBonds);
@@ -93,9 +95,8 @@ void CudaBondedUtilities::initialize(const System& system) {
                 for (int atom = 0; atom < width; atom++)
                     indexVec[bond*paddedWidth+atom] = forceAtoms[i][bond][startAtom+atom];
             }
-            atomIndices[i].push_back(CudaArray());
-            atomIndices[i].back().initialize(context, numBonds, 4*paddedWidth, "bondedIndices");
-            atomIndices[i].back().upload(&indexVec[0]);
+            atomIndices[i][j].initialize(context, numBonds, 4*paddedWidth, "bondedIndices");
+            atomIndices[i][j].upload(&indexVec[0]);
             startAtom += width;
         }
     }

--- a/platforms/cuda/src/CudaBondedUtilities.cpp
+++ b/platforms/cuda/src/CudaBondedUtilities.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2011-2016 Stanford University and the Authors.      *
+ * Portions copyright (c) 2011-2018 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -35,12 +35,6 @@ using namespace OpenMM;
 using namespace std;
 
 CudaBondedUtilities::CudaBondedUtilities(CudaContext& context) : context(context), numForceBuffers(0), maxBonds(0), allGroups(0), hasInitializedKernels(false) {
-}
-
-CudaBondedUtilities::~CudaBondedUtilities() {
-    for (int i = 0; i < (int) atomIndices.size(); i++)
-        for (int j = 0; j < (int) atomIndices[i].size(); j++)
-            delete atomIndices[i][j];
 }
 
 void CudaBondedUtilities::addInteraction(const vector<vector<int> >& atoms, const string& source, int group) {
@@ -99,9 +93,9 @@ void CudaBondedUtilities::initialize(const System& system) {
                 for (int atom = 0; atom < width; atom++)
                     indexVec[bond*paddedWidth+atom] = forceAtoms[i][bond][startAtom+atom];
             }
-            CudaArray* indices = new CudaArray(context, numBonds, 4*paddedWidth, "bondedIndices");
-            indices->upload(&indexVec[0]);
-            atomIndices[i].push_back(indices);
+            atomIndices[i].push_back(CudaArray());
+            atomIndices[i].back().initialize(context, numBonds, 4*paddedWidth, "bondedIndices");
+            atomIndices[i].back().upload(&indexVec[0]);
             startAtom += width;
         }
     }
@@ -115,7 +109,7 @@ void CudaBondedUtilities::initialize(const System& system) {
     s<<"extern \"C\" __global__ void computeBondedForces(unsigned long long* __restrict__ forceBuffer, mixed* __restrict__ energyBuffer, const real4* __restrict__ posq, int groups, real4 periodicBoxSize, real4 invPeriodicBoxSize, real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ";
     for (int force = 0; force < numForces; force++) {
         for (int i = 0; i < (int) atomIndices[force].size(); i++) {
-            int indexWidth = atomIndices[force][i]->getElementSize()/4;
+            int indexWidth = atomIndices[force][i].getElementSize()/4;
             string indexType = "uint"+context.intToString(indexWidth);
             s<<", const "<<indexType<<"* __restrict__ atomIndices"<<force<<"_"<<i;
         }
@@ -154,7 +148,7 @@ string CudaBondedUtilities::createForceSource(int forceIndex, int numBonds, int 
     s<<"for (unsigned int index = blockIdx.x*blockDim.x+threadIdx.x; index < "<<numBonds<<"; index += blockDim.x*gridDim.x) {\n";
     int startAtom = 0;
     for (int i = 0; i < (int) atomIndices[forceIndex].size(); i++) {
-        int indexWidth = atomIndices[forceIndex][i]->getElementSize()/4;
+        int indexWidth = atomIndices[forceIndex][i].getElementSize()/4;
         string indexType = "uint"+context.intToString(indexWidth);
         s<<"    "<<indexType<<" atoms"<<i<<" = atomIndices"<<forceIndex<<"_"<<i<<"[index];\n";
         int atomsToLoad = min(indexWidth, numAtoms-startAtom);
@@ -191,7 +185,7 @@ void CudaBondedUtilities::computeInteractions(int groups) {
         kernelArgs.push_back(context.getPeriodicBoxVecZPointer());
         for (int i = 0; i < (int) atomIndices.size(); i++)
             for (int j = 0; j < (int) atomIndices[i].size(); j++)
-                kernelArgs.push_back(&atomIndices[i][j]->getDevicePointer());
+                kernelArgs.push_back(&atomIndices[i][j].getDevicePointer());
         for (int i = 0; i < (int) arguments.size(); i++)
             kernelArgs.push_back(&arguments[i]);
         if (energyParameterDerivatives.size() > 0)

--- a/platforms/cuda/src/CudaNonbondedUtilities.cpp
+++ b/platforms/cuda/src/CudaNonbondedUtilities.cpp
@@ -63,10 +63,7 @@ private:
 };
 
 CudaNonbondedUtilities::CudaNonbondedUtilities(CudaContext& context) : context(context), useCutoff(false), usePeriodic(false), anyExclusions(false), usePadding(true),
-        exclusionIndices(NULL), exclusionRowIndices(NULL), exclusionTiles(NULL), exclusions(NULL), interactingTiles(NULL), interactingAtoms(NULL),
-        interactionCount(NULL), singlePairs(NULL), blockCenter(NULL), blockBoundingBox(NULL), sortedBlocks(NULL), sortedBlockCenter(NULL), sortedBlockBoundingBox(NULL),
-        oldPositions(NULL), rebuildNeighborList(NULL), blockSorter(NULL), pinnedCountBuffer(NULL), forceRebuildNeighborList(true), lastCutoff(0.0), groupFlags(0),
-        canUsePairList(true) {
+        blockSorter(NULL), pinnedCountBuffer(NULL), forceRebuildNeighborList(true), lastCutoff(0.0), groupFlags(0), canUsePairList(true) {
     // Decide how many thread blocks to use.
 
     string errorMessage = "Error initializing nonbonded utilities";
@@ -79,36 +76,6 @@ CudaNonbondedUtilities::CudaNonbondedUtilities(CudaContext& context) : context(c
 }
 
 CudaNonbondedUtilities::~CudaNonbondedUtilities() {
-    if (exclusionIndices != NULL)
-        delete exclusionIndices;
-    if (exclusionRowIndices != NULL)
-        delete exclusionRowIndices;
-    if (exclusionTiles != NULL)
-        delete exclusionTiles;
-    if (exclusions != NULL)
-        delete exclusions;
-    if (interactingTiles != NULL)
-        delete interactingTiles;
-    if (interactingAtoms != NULL)
-        delete interactingAtoms;
-    if (interactionCount != NULL)
-        delete interactionCount;
-    if (singlePairs != NULL)
-        delete singlePairs;
-    if (blockCenter != NULL)
-        delete blockCenter;
-    if (blockBoundingBox != NULL)
-        delete blockBoundingBox;
-    if (sortedBlocks != NULL)
-        delete sortedBlocks;
-    if (sortedBlockCenter != NULL)
-        delete sortedBlockCenter;
-    if (sortedBlockBoundingBox != NULL)
-        delete sortedBlockBoundingBox;
-    if (oldPositions != NULL)
-        delete oldPositions;
-    if (rebuildNeighborList != NULL)
-        delete rebuildNeighborList;
     if (blockSorter != NULL)
         delete blockSorter;
     if (pinnedCountBuffer != NULL)
@@ -220,8 +187,8 @@ void CudaNonbondedUtilities::initialize(const System& system) {
     for (set<pair<int, int> >::const_iterator iter = tilesWithExclusions.begin(); iter != tilesWithExclusions.end(); ++iter)
         exclusionTilesVec.push_back(make_ushort2((unsigned short) iter->first, (unsigned short) iter->second));
     sort(exclusionTilesVec.begin(), exclusionTilesVec.end(), compareUshort2);
-    exclusionTiles = CudaArray::create<ushort2>(context, exclusionTilesVec.size(), "exclusionTiles");
-    exclusionTiles->upload(exclusionTilesVec);
+    exclusionTiles.initialize<ushort2>(context, exclusionTilesVec.size(), "exclusionTiles");
+    exclusionTiles.upload(exclusionTilesVec);
     map<pair<int, int>, int> exclusionTileMap;
     for (int i = 0; i < (int) exclusionTilesVec.size(); i++) {
         ushort2 tile = exclusionTilesVec[i];
@@ -242,16 +209,16 @@ void CudaNonbondedUtilities::initialize(const System& system) {
     maxExclusions = 0;
     for (int i = 0; i < (int) exclusionBlocksForBlock.size(); i++)
         maxExclusions = (maxExclusions > exclusionBlocksForBlock[i].size() ? maxExclusions : exclusionBlocksForBlock[i].size());
-    exclusionIndices = CudaArray::create<unsigned int>(context, exclusionIndicesVec.size(), "exclusionIndices");
-    exclusionRowIndices = CudaArray::create<unsigned int>(context, exclusionRowIndicesVec.size(), "exclusionRowIndices");
-    exclusionIndices->upload(exclusionIndicesVec);
-    exclusionRowIndices->upload(exclusionRowIndicesVec);
+    exclusionIndices.initialize<unsigned int>(context, exclusionIndicesVec.size(), "exclusionIndices");
+    exclusionRowIndices.initialize<unsigned int>(context, exclusionRowIndicesVec.size(), "exclusionRowIndices");
+    exclusionIndices.upload(exclusionIndicesVec);
+    exclusionRowIndices.upload(exclusionRowIndicesVec);
 
     // Record the exclusion data.
 
-    exclusions = CudaArray::create<tileflags>(context, tilesWithExclusions.size()*CudaContext::TileSize, "exclusions");
+    exclusions.initialize<tileflags>(context, tilesWithExclusions.size()*CudaContext::TileSize, "exclusions");
     tileflags allFlags = (tileflags) -1;
-    vector<tileflags> exclusionVec(exclusions->getSize(), allFlags);
+    vector<tileflags> exclusionVec(exclusions.getSize(), allFlags);
     for (int atom1 = 0; atom1 < (int) atomExclusions.size(); ++atom1) {
         int x = atom1/CudaContext::TileSize;
         int offset1 = atom1-x*CudaContext::TileSize;
@@ -270,7 +237,7 @@ void CudaNonbondedUtilities::initialize(const System& system) {
         }
     }
     atomExclusions.clear(); // We won't use this again, so free the memory it used
-    exclusions->upload(exclusionVec);
+    exclusions.upload(exclusionVec);
 
     // Create data structures for the neighbor list.
 
@@ -284,21 +251,21 @@ void CudaNonbondedUtilities::initialize(const System& system) {
         if (maxTiles < 1)
             maxTiles = 1;
         maxSinglePairs = 5*numAtoms;
-        interactingTiles = CudaArray::create<int>(context, maxTiles, "interactingTiles");
-        interactingAtoms = CudaArray::create<int>(context, CudaContext::TileSize*maxTiles, "interactingAtoms");
-        interactionCount = CudaArray::create<unsigned int>(context, 2, "interactionCount");
-        singlePairs = CudaArray::create<int2>(context, maxSinglePairs, "singlePairs");
+        interactingTiles.initialize<int>(context, maxTiles, "interactingTiles");
+        interactingAtoms.initialize<int>(context, CudaContext::TileSize*maxTiles, "interactingAtoms");
+        interactionCount.initialize<unsigned int>(context, 2, "interactionCount");
+        singlePairs.initialize<int2>(context, maxSinglePairs, "singlePairs");
         int elementSize = (context.getUseDoublePrecision() ? sizeof(double) : sizeof(float));
-        blockCenter = new CudaArray(context, numAtomBlocks, 4*elementSize, "blockCenter");
-        blockBoundingBox = new CudaArray(context, numAtomBlocks, 4*elementSize, "blockBoundingBox");
-        sortedBlocks = new CudaArray(context, numAtomBlocks, 2*elementSize, "sortedBlocks");
-        sortedBlockCenter = new CudaArray(context, numAtomBlocks+1, 4*elementSize, "sortedBlockCenter");
-        sortedBlockBoundingBox = new CudaArray(context, numAtomBlocks+1, 4*elementSize, "sortedBlockBoundingBox");
-        oldPositions = new CudaArray(context, numAtoms, 4*elementSize, "oldPositions");
-        rebuildNeighborList = CudaArray::create<int>(context, 1, "rebuildNeighborList");
+        blockCenter.initialize(context, numAtomBlocks, 4*elementSize, "blockCenter");
+        blockBoundingBox.initialize(context, numAtomBlocks, 4*elementSize, "blockBoundingBox");
+        sortedBlocks.initialize(context, numAtomBlocks, 2*elementSize, "sortedBlocks");
+        sortedBlockCenter.initialize(context, numAtomBlocks+1, 4*elementSize, "sortedBlockCenter");
+        sortedBlockBoundingBox.initialize(context, numAtomBlocks+1, 4*elementSize, "sortedBlockBoundingBox");
+        oldPositions.initialize(context, numAtoms, 4*elementSize, "oldPositions");
+        rebuildNeighborList.initialize<int>(context, 1, "rebuildNeighborList");
         blockSorter = new CudaSort(context, new BlockSortTrait(context.getUseDoublePrecision()), numAtomBlocks);
         vector<unsigned int> count(2, 0);
-        interactionCount->upload(count);
+        interactionCount.upload(count);
     }
 
     // Record arguments for kernels.
@@ -306,24 +273,24 @@ void CudaNonbondedUtilities::initialize(const System& system) {
     forceArgs.push_back(&context.getForce().getDevicePointer());
     forceArgs.push_back(&context.getEnergyBuffer().getDevicePointer());
     forceArgs.push_back(&context.getPosq().getDevicePointer());
-    forceArgs.push_back(&exclusions->getDevicePointer());
-    forceArgs.push_back(&exclusionTiles->getDevicePointer());
+    forceArgs.push_back(&exclusions.getDevicePointer());
+    forceArgs.push_back(&exclusionTiles.getDevicePointer());
     forceArgs.push_back(&startTileIndex);
     forceArgs.push_back(&numTiles);
     if (useCutoff) {
-        forceArgs.push_back(&interactingTiles->getDevicePointer());
-        forceArgs.push_back(&interactionCount->getDevicePointer());
+        forceArgs.push_back(&interactingTiles.getDevicePointer());
+        forceArgs.push_back(&interactionCount.getDevicePointer());
         forceArgs.push_back(context.getPeriodicBoxSizePointer());
         forceArgs.push_back(context.getInvPeriodicBoxSizePointer());
         forceArgs.push_back(context.getPeriodicBoxVecXPointer());
         forceArgs.push_back(context.getPeriodicBoxVecYPointer());
         forceArgs.push_back(context.getPeriodicBoxVecZPointer());
         forceArgs.push_back(&maxTiles);
-        forceArgs.push_back(&blockCenter->getDevicePointer());
-        forceArgs.push_back(&blockBoundingBox->getDevicePointer());
-        forceArgs.push_back(&interactingAtoms->getDevicePointer());
+        forceArgs.push_back(&blockCenter.getDevicePointer());
+        forceArgs.push_back(&blockBoundingBox.getDevicePointer());
+        forceArgs.push_back(&interactingAtoms.getDevicePointer());
         forceArgs.push_back(&maxSinglePairs);
-        forceArgs.push_back(&singlePairs->getDevicePointer());
+        forceArgs.push_back(&singlePairs.getDevicePointer());
     }
     for (int i = 0; i < (int) parameters.size(); i++)
         forceArgs.push_back(&parameters[i].getMemory());
@@ -339,41 +306,41 @@ void CudaNonbondedUtilities::initialize(const System& system) {
         findBlockBoundsArgs.push_back(context.getPeriodicBoxVecYPointer());
         findBlockBoundsArgs.push_back(context.getPeriodicBoxVecZPointer());
         findBlockBoundsArgs.push_back(&context.getPosq().getDevicePointer());
-        findBlockBoundsArgs.push_back(&blockCenter->getDevicePointer());
-        findBlockBoundsArgs.push_back(&blockBoundingBox->getDevicePointer());
-        findBlockBoundsArgs.push_back(&rebuildNeighborList->getDevicePointer());
-        findBlockBoundsArgs.push_back(&sortedBlocks->getDevicePointer());
-        sortBoxDataArgs.push_back(&sortedBlocks->getDevicePointer());
-        sortBoxDataArgs.push_back(&blockCenter->getDevicePointer());
-        sortBoxDataArgs.push_back(&blockBoundingBox->getDevicePointer());
-        sortBoxDataArgs.push_back(&sortedBlockCenter->getDevicePointer());
-        sortBoxDataArgs.push_back(&sortedBlockBoundingBox->getDevicePointer());
+        findBlockBoundsArgs.push_back(&blockCenter.getDevicePointer());
+        findBlockBoundsArgs.push_back(&blockBoundingBox.getDevicePointer());
+        findBlockBoundsArgs.push_back(&rebuildNeighborList.getDevicePointer());
+        findBlockBoundsArgs.push_back(&sortedBlocks.getDevicePointer());
+        sortBoxDataArgs.push_back(&sortedBlocks.getDevicePointer());
+        sortBoxDataArgs.push_back(&blockCenter.getDevicePointer());
+        sortBoxDataArgs.push_back(&blockBoundingBox.getDevicePointer());
+        sortBoxDataArgs.push_back(&sortedBlockCenter.getDevicePointer());
+        sortBoxDataArgs.push_back(&sortedBlockBoundingBox.getDevicePointer());
         sortBoxDataArgs.push_back(&context.getPosq().getDevicePointer());
-        sortBoxDataArgs.push_back(&oldPositions->getDevicePointer());
-        sortBoxDataArgs.push_back(&interactionCount->getDevicePointer());
-        sortBoxDataArgs.push_back(&rebuildNeighborList->getDevicePointer());
+        sortBoxDataArgs.push_back(&oldPositions.getDevicePointer());
+        sortBoxDataArgs.push_back(&interactionCount.getDevicePointer());
+        sortBoxDataArgs.push_back(&rebuildNeighborList.getDevicePointer());
         sortBoxDataArgs.push_back(&forceRebuildNeighborList);
         findInteractingBlocksArgs.push_back(context.getPeriodicBoxSizePointer());
         findInteractingBlocksArgs.push_back(context.getInvPeriodicBoxSizePointer());
         findInteractingBlocksArgs.push_back(context.getPeriodicBoxVecXPointer());
         findInteractingBlocksArgs.push_back(context.getPeriodicBoxVecYPointer());
         findInteractingBlocksArgs.push_back(context.getPeriodicBoxVecZPointer());
-        findInteractingBlocksArgs.push_back(&interactionCount->getDevicePointer());
-        findInteractingBlocksArgs.push_back(&interactingTiles->getDevicePointer());
-        findInteractingBlocksArgs.push_back(&interactingAtoms->getDevicePointer());
-        findInteractingBlocksArgs.push_back(&singlePairs->getDevicePointer());
+        findInteractingBlocksArgs.push_back(&interactionCount.getDevicePointer());
+        findInteractingBlocksArgs.push_back(&interactingTiles.getDevicePointer());
+        findInteractingBlocksArgs.push_back(&interactingAtoms.getDevicePointer());
+        findInteractingBlocksArgs.push_back(&singlePairs.getDevicePointer());
         findInteractingBlocksArgs.push_back(&context.getPosq().getDevicePointer());
         findInteractingBlocksArgs.push_back(&maxTiles);
         findInteractingBlocksArgs.push_back(&maxSinglePairs);
         findInteractingBlocksArgs.push_back(&startBlockIndex);
         findInteractingBlocksArgs.push_back(&numBlocks);
-        findInteractingBlocksArgs.push_back(&sortedBlocks->getDevicePointer());
-        findInteractingBlocksArgs.push_back(&sortedBlockCenter->getDevicePointer());
-        findInteractingBlocksArgs.push_back(&sortedBlockBoundingBox->getDevicePointer());
-        findInteractingBlocksArgs.push_back(&exclusionIndices->getDevicePointer());
-        findInteractingBlocksArgs.push_back(&exclusionRowIndices->getDevicePointer());
-        findInteractingBlocksArgs.push_back(&oldPositions->getDevicePointer());
-        findInteractingBlocksArgs.push_back(&rebuildNeighborList->getDevicePointer());
+        findInteractingBlocksArgs.push_back(&sortedBlocks.getDevicePointer());
+        findInteractingBlocksArgs.push_back(&sortedBlockCenter.getDevicePointer());
+        findInteractingBlocksArgs.push_back(&sortedBlockBoundingBox.getDevicePointer());
+        findInteractingBlocksArgs.push_back(&exclusionIndices.getDevicePointer());
+        findInteractingBlocksArgs.push_back(&exclusionRowIndices.getDevicePointer());
+        findInteractingBlocksArgs.push_back(&oldPositions.getDevicePointer());
+        findInteractingBlocksArgs.push_back(&rebuildNeighborList.getDevicePointer());
     }
 }
 
@@ -406,12 +373,12 @@ void CudaNonbondedUtilities::prepareInteractions(int forceGroups) {
     if (lastCutoff != kernels.cutoffDistance)
         forceRebuildNeighborList = true;
     context.executeKernel(kernels.findBlockBoundsKernel, &findBlockBoundsArgs[0], context.getNumAtoms());
-    blockSorter->sort(*sortedBlocks);
+    blockSorter->sort(sortedBlocks);
     context.executeKernel(kernels.sortBoxDataKernel, &sortBoxDataArgs[0], context.getNumAtoms());
     context.executeKernel(kernels.findInteractingBlocksKernel, &findInteractingBlocksArgs[0], context.getNumAtoms(), 256);
     forceRebuildNeighborList = false;
     lastCutoff = kernels.cutoffDistance;
-    interactionCount->download(pinnedCountBuffer, false);
+    interactionCount.download(pinnedCountBuffer, false);
     cuEventRecord(downloadCountEvent, context.getCurrentStream());
 }
 
@@ -445,27 +412,21 @@ bool CudaNonbondedUtilities::updateNeighborListSize() {
         int totalTiles = context.getNumAtomBlocks()*(context.getNumAtomBlocks()+1)/2;
         if (maxTiles > totalTiles)
             maxTiles = totalTiles;
-        delete interactingTiles;
-        delete interactingAtoms;
-        interactingTiles = NULL; // Avoid an error in the destructor if the following allocation fails
-        interactingAtoms = NULL;
-        interactingTiles = CudaArray::create<int>(context, maxTiles, "interactingTiles");
-        interactingAtoms = CudaArray::create<int>(context, CudaContext::TileSize*maxTiles, "interactingAtoms");
+        interactingTiles.resize(maxTiles);
+        interactingAtoms.resize(CudaContext::TileSize*maxTiles);
         if (forceArgs.size() > 0)
-            forceArgs[7] = &interactingTiles->getDevicePointer();
-        findInteractingBlocksArgs[6] = &interactingTiles->getDevicePointer();
+            forceArgs[7] = &interactingTiles.getDevicePointer();
+        findInteractingBlocksArgs[6] = &interactingTiles.getDevicePointer();
         if (forceArgs.size() > 0)
-            forceArgs[17] = &interactingAtoms->getDevicePointer();
-        findInteractingBlocksArgs[7] = &interactingAtoms->getDevicePointer();
+            forceArgs[17] = &interactingAtoms.getDevicePointer();
+        findInteractingBlocksArgs[7] = &interactingAtoms.getDevicePointer();
     }
     if (pinnedCountBuffer[1] > maxSinglePairs) {
         maxSinglePairs = (int) (1.2*pinnedCountBuffer[1]);
-        delete singlePairs;
-        singlePairs = NULL; // Avoid an error in the destructor if the following allocation fails
-        singlePairs = CudaArray::create<int2>(context, maxSinglePairs, "singlePairs");
+        singlePairs.resize(maxSinglePairs);
         if (forceArgs.size() > 0)
-            forceArgs[19] = &singlePairs->getDevicePointer();
-        findInteractingBlocksArgs[8] = &singlePairs->getDevicePointer();
+            forceArgs[19] = &singlePairs.getDevicePointer();
+        findInteractingBlocksArgs[8] = &singlePairs.getDevicePointer();
     }
     forceRebuildNeighborList = true;
     context.setForcesValid(false);
@@ -510,7 +471,7 @@ void CudaNonbondedUtilities::createKernelsForGroups(int groups) {
         defines["PADDING"] = context.doubleToString(padding);
         defines["PADDED_CUTOFF"] = context.doubleToString(paddedCutoff);
         defines["PADDED_CUTOFF_SQUARED"] = context.doubleToString(paddedCutoff*paddedCutoff);
-        defines["NUM_TILES_WITH_EXCLUSIONS"] = context.intToString(exclusionTiles->getSize());
+        defines["NUM_TILES_WITH_EXCLUSIONS"] = context.intToString(exclusionTiles.getSize());
         if (usePeriodic)
             defines["USE_PERIODIC"] = "1";
         if (context.getBoxIsTriclinic())
@@ -735,7 +696,7 @@ CUfunction CudaNonbondedUtilities::createInteractionKernel(const string& source,
     defines["PADDED_NUM_ATOMS"] = context.intToString(context.getPaddedNumAtoms());
     defines["NUM_BLOCKS"] = context.intToString(context.getNumAtomBlocks());
     defines["TILE_SIZE"] = context.intToString(CudaContext::TileSize);
-    int numExclusionTiles = exclusionTiles->getSize();
+    int numExclusionTiles = exclusionTiles.getSize();
     defines["NUM_TILES_WITH_EXCLUSIONS"] = context.intToString(numExclusionTiles);
     int numContexts = context.getPlatformData().contexts.size();
     int startExclusionIndex = context.getContextIndex()*numExclusionTiles/numContexts;

--- a/platforms/opencl/include/OpenCLArray.h
+++ b/platforms/opencl/include/OpenCLArray.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2009-2012 Stanford University and the Authors.      *
+ * Portions copyright (c) 2009-2018 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -27,14 +27,18 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.      *
  * -------------------------------------------------------------------------- */
 
-#include "OpenCLContext.h"
+#define __CL_ENABLE_EXCEPTIONS
+#define CL_USE_DEPRECATED_OPENCL_1_1_APIS
 #include "openmm/OpenMMException.h"
 #include "windowsExportOpenCL.h"
+#include <cl.hpp>
 #include <iostream>
 #include <sstream>
 #include <vector>
 
 namespace OpenMM {
+
+class OpenCLContext;
 
 /**
  * This class encapsulates an OpenCL Buffer.  It provides a simplified API for working with it,
@@ -70,6 +74,11 @@ public:
         return new OpenCLArray(context, buffer, size, sizeof(T), name);
     }
     /**
+     * Create an uninitialized OpenCLArray object.  It does not point to any OpenCL Buffer,
+     * and cannot be used until initialize() is called on it.
+     */
+    OpenCLArray();
+    /**
      * Create an OpenCLArray object.
      *
      * @param context           the context for which to create the array
@@ -90,6 +99,61 @@ public:
      */
     OpenCLArray(OpenCLContext& context, cl::Buffer* buffer, int size, int elementSize, const std::string& name);
     ~OpenCLArray();
+    /**
+     * Initialize this object.
+     *
+     * @param context           the context for which to create the array
+     * @param size              the number of elements in the array
+     * @param elementSize       the size of each element in bytes
+     * @param name              the name of the array
+     * @param flags             the set of flags to specify when creating the OpenCL Buffer
+     */
+    void initialize(OpenCLContext& context, int size, int elementSize, const std::string& name, cl_int flags = CL_MEM_READ_WRITE);
+    /**
+     * Initialize this object to use a preexisting Buffer.
+     *
+     * @param context           the context for which to create the array
+     * @param buffer            the OpenCL Buffer this object encapsulates
+     * @param size              the number of elements in the array
+     * @param elementSize       the size of each element in bytes
+     * @param name              the name of the array
+     */
+    void initialize(OpenCLContext& context, cl::Buffer* buffer, int size, int elementSize, const std::string& name);
+    /**
+     * Initialize this object.  The template argument is the data type of each array element.
+     *
+     * @param context           the context for which to create the array
+     * @param size              the number of elements in the array
+     * @param name              the name of the array
+     * @param flags             the set of flags to specify when creating the OpenCL Buffer
+     */
+    template <class T>
+    void initialize(OpenCLContext& context, int size, const std::string& name, cl_int flags = CL_MEM_READ_WRITE) {
+        initialize(context, size, sizeof(T), name, flags);
+    }
+    /**
+     * Initialize this object to use a preexisting Buffer.  The template argument
+     * is the data type of each array element.
+     *
+     * @param context           the context for which to create the array
+     * @param buffer            the OpenCL Buffer this object encapsulates
+     * @param size              the number of elements in the array
+     * @param name              the name of the array
+     */
+    template <class T>
+    void initialize(OpenCLContext& context, cl::Buffer* buffer, int size, const std::string& name) {
+        initialize(context, buffer, size, sizeof(T), name);
+    }
+    /**
+     * Recreate the internal storage to have a different size.
+     */
+    void resize(int size);
+    /**
+     * Get whether this array has been initialized.
+     */
+    bool isInitialized() const {
+        return (buffer != NULL);
+    }
     /**
      * Get the size of the array.
      */
@@ -155,9 +219,10 @@ public:
      */
     void copyTo(OpenCLArray& dest) const;
 private:
-    OpenCLContext& context;
+    OpenCLContext* context;
     cl::Buffer* buffer;
     int size, elementSize;
+    cl_int flags;
     bool ownsBuffer;
     std::string name;
 };

--- a/platforms/opencl/include/OpenCLBondedUtilities.h
+++ b/platforms/opencl/include/OpenCLBondedUtilities.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2011-2016 Stanford University and the Authors.      *
+ * Portions copyright (c) 2011-2018 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -81,7 +81,6 @@ namespace OpenMM {
 class OPENMM_EXPORT_OPENCL OpenCLBondedUtilities {
 public:
     OpenCLBondedUtilities(OpenCLContext& context);
-    ~OpenCLBondedUtilities();
     /**
      * Add a bonded interaction.
      *
@@ -143,8 +142,8 @@ private:
     std::vector<std::vector<int> > forceSets;
     std::vector<cl::Memory*> arguments;
     std::vector<std::string> argTypes;
-    std::vector<OpenCLArray*> atomIndices;
-    std::vector<OpenCLArray*> bufferIndices;
+    std::vector<OpenCLArray> atomIndices;
+    std::vector<OpenCLArray> bufferIndices;
     std::vector<std::string> prefixCode;
     std::vector<std::string> energyParameterDerivatives;
     int numForceBuffers, maxBonds, allGroups;

--- a/platforms/opencl/include/OpenCLCompact.h
+++ b/platforms/opencl/include/OpenCLCompact.h
@@ -33,11 +33,10 @@ namespace OpenMM {
 class OPENMM_EXPORT_OPENCL OpenCLCompact {
 public:
     OpenCLCompact(OpenCLContext& context);
-    ~OpenCLCompact();
     void compactStream(OpenCLArray& dOut, OpenCLArray& dIn, OpenCLArray& dValid, OpenCLArray& numValid);
 private:
     OpenCLContext& context;
-    OpenCLArray* dgBlockCounts;
+    OpenCLArray dgBlockCounts;
     cl::Kernel countKernel;
     cl::Kernel moveValidKernel;
 };

--- a/platforms/opencl/include/OpenCLCompact.h
+++ b/platforms/opencl/include/OpenCLCompact.h
@@ -26,6 +26,7 @@
 */
 
 #include "OpenCLArray.h"
+#include "OpenCLContext.h"
 
 namespace OpenMM {
 

--- a/platforms/opencl/include/OpenCLContext.h
+++ b/platforms/opencl/include/OpenCLContext.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2009-2016 Stanford University and the Authors.      *
+ * Portions copyright (c) 2009-2018 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -39,11 +39,11 @@
 #include <pthread.h>
 #include <cl.hpp>
 #include "windowsExportOpenCL.h"
+#include "OpenCLArray.h"
 #include "OpenCLPlatform.h"
 
 namespace OpenMM {
 
-class OpenCLArray;
 class OpenCLForceInfo;
 class OpenCLIntegrationUtilities;
 class OpenCLExpressionUtilities;
@@ -227,49 +227,49 @@ public:
      * Get the array which contains the position (the xyz components) and charge (the w component) of each atom.
      */
     OpenCLArray& getPosq() {
-        return *posq;
+        return posq;
     }
     /**
      * Get the array which contains a correction to the position of each atom.  This only exists if getUseMixedPrecision() returns true.
      */
     OpenCLArray& getPosqCorrection() {
-        return *posqCorrection;
+        return posqCorrection;
     }
     /**
      * Get the array which contains the velocity (the xyz components) and inverse mass (the w component) of each atom.
      */
     OpenCLArray& getVelm() {
-        return *velm;
+        return velm;
     }
     /**
      * Get the array which contains the force on each atom.
      */
     OpenCLArray& getForce() {
-        return *force;
+        return force;
     }
     /**
      * Get the array which contains the buffers in which forces are computed.
      */
     OpenCLArray& getForceBuffers() {
-        return *forceBuffers;
+        return forceBuffers;
     }
     /**
      * Get the array which contains a contribution to each force represented as 64 bit fixed point.
      */
     OpenCLArray& getLongForceBuffer() {
-        return *longForceBuffer;
+        return longForceBuffer;
     }
     /**
      * Get the array which contains the buffer in which energy is computed.
      */
     OpenCLArray& getEnergyBuffer() {
-        return *energyBuffer;
+        return energyBuffer;
     }
     /**
      * Get the array which contains the buffer in which derivatives of the energy with respect to parameters are computed.
      */
     OpenCLArray& getEnergyParamDerivBuffer() {
-        return *energyParamDerivBuffer;
+        return energyParamDerivBuffer;
     }
     /**
      * Get a pointer to a block of pinned memory that can be used for efficient transfers between host and device.
@@ -288,7 +288,7 @@ public:
      * Get the array which contains the index of each atom.
      */
     OpenCLArray& getAtomIndexArray() {
-        return *atomIndexDevice;
+        return atomIndexDevice;
     }
     /**
      * Get the number of cells by which the positions are offset.
@@ -762,17 +762,17 @@ private:
     std::vector<mm_int4> posCellOffsets;
     cl::Buffer* pinnedBuffer;
     void* pinnedMemory;
-    OpenCLArray* posq;
-    OpenCLArray* posqCorrection;
-    OpenCLArray* velm;
-    OpenCLArray* force;
-    OpenCLArray* forceBuffers;
-    OpenCLArray* longForceBuffer;
-    OpenCLArray* energyBuffer;
-    OpenCLArray* energySum;
-    OpenCLArray* energyParamDerivBuffer;
-    OpenCLArray* atomIndexDevice;
-    OpenCLArray* chargeBuffer;
+    OpenCLArray posq;
+    OpenCLArray posqCorrection;
+    OpenCLArray velm;
+    OpenCLArray force;
+    OpenCLArray forceBuffers;
+    OpenCLArray longForceBuffer;
+    OpenCLArray energyBuffer;
+    OpenCLArray energySum;
+    OpenCLArray energyParamDerivBuffer;
+    OpenCLArray atomIndexDevice;
+    OpenCLArray chargeBuffer;
     std::vector<std::string> energyParamDerivNames;
     std::map<std::string, double> energyParamDerivWorkspace;
     std::vector<int> atomIndex;

--- a/platforms/opencl/include/OpenCLIntegrationUtilities.h
+++ b/platforms/opencl/include/OpenCLIntegrationUtilities.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2009-2017 Stanford University and the Authors.      *
+ * Portions copyright (c) 2009-2018 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -42,25 +42,24 @@ namespace OpenMM {
 class OPENMM_EXPORT_OPENCL OpenCLIntegrationUtilities {
 public:
     OpenCLIntegrationUtilities(OpenCLContext& context, const System& system);
-    ~OpenCLIntegrationUtilities();
     /**
      * Get the array which contains position deltas.
      */
     OpenCLArray& getPosDelta() {
-        return *posDelta;
+        return posDelta;
     }
     /**
      * Get the array which contains random values.  Each element is a float4, whose components
      * are independent, normally distributed random numbers with mean 0 and variance 1.
      */
     OpenCLArray& getRandom() {
-        return *random;
+        return random;
     }
     /**
      * Get the array which contains the current step size.
      */
     OpenCLArray& getStepSize() {
-        return *stepSize;
+        return stepSize;
     }
     /**
      * Set the size to use for the next step.
@@ -131,36 +130,36 @@ private:
     cl::Kernel ccmaPosUpdateKernel, ccmaVelUpdateKernel;
     cl::Kernel vsitePositionKernel, vsiteForceKernel, vsiteAddForcesKernel;
     cl::Kernel randomKernel, timeShiftKernel;
-    OpenCLArray* posDelta;
-    OpenCLArray* settleAtoms;
-    OpenCLArray* settleParams;
-    OpenCLArray* shakeAtoms;
-    OpenCLArray* shakeParams;
-    OpenCLArray* random;
-    OpenCLArray* randomSeed;
-    OpenCLArray* stepSize;
-    OpenCLArray* ccmaAtoms;
-    OpenCLArray* ccmaDistance;
-    OpenCLArray* ccmaReducedMass;
-    OpenCLArray* ccmaAtomConstraints;
-    OpenCLArray* ccmaNumAtomConstraints;
-    OpenCLArray* ccmaConstraintMatrixColumn;
-    OpenCLArray* ccmaConstraintMatrixValue;
-    OpenCLArray* ccmaDelta1;
-    OpenCLArray* ccmaDelta2;
-    OpenCLArray* ccmaConverged;
-    OpenCLArray* ccmaConvergedHostBuffer;
-    OpenCLArray* vsite2AvgAtoms;
-    OpenCLArray* vsite2AvgWeights;
-    OpenCLArray* vsite3AvgAtoms;
-    OpenCLArray* vsite3AvgWeights;
-    OpenCLArray* vsiteOutOfPlaneAtoms;
-    OpenCLArray* vsiteOutOfPlaneWeights;
-    OpenCLArray* vsiteLocalCoordsIndex;
-    OpenCLArray* vsiteLocalCoordsAtoms;
-    OpenCLArray* vsiteLocalCoordsWeights;
-    OpenCLArray* vsiteLocalCoordsPos;
-    OpenCLArray* vsiteLocalCoordsStartIndex;
+    OpenCLArray posDelta;
+    OpenCLArray settleAtoms;
+    OpenCLArray settleParams;
+    OpenCLArray shakeAtoms;
+    OpenCLArray shakeParams;
+    OpenCLArray random;
+    OpenCLArray randomSeed;
+    OpenCLArray stepSize;
+    OpenCLArray ccmaAtoms;
+    OpenCLArray ccmaDistance;
+    OpenCLArray ccmaReducedMass;
+    OpenCLArray ccmaAtomConstraints;
+    OpenCLArray ccmaNumAtomConstraints;
+    OpenCLArray ccmaConstraintMatrixColumn;
+    OpenCLArray ccmaConstraintMatrixValue;
+    OpenCLArray ccmaDelta1;
+    OpenCLArray ccmaDelta2;
+    OpenCLArray ccmaConverged;
+    OpenCLArray ccmaConvergedHostBuffer;
+    OpenCLArray vsite2AvgAtoms;
+    OpenCLArray vsite2AvgWeights;
+    OpenCLArray vsite3AvgAtoms;
+    OpenCLArray vsite3AvgWeights;
+    OpenCLArray vsiteOutOfPlaneAtoms;
+    OpenCLArray vsiteOutOfPlaneWeights;
+    OpenCLArray vsiteLocalCoordsIndex;
+    OpenCLArray vsiteLocalCoordsAtoms;
+    OpenCLArray vsiteLocalCoordsWeights;
+    OpenCLArray vsiteLocalCoordsPos;
+    OpenCLArray vsiteLocalCoordsStartIndex;
     int randomPos;
     int lastSeed, numVsites;
     bool hasInitializedPosConstraintKernels, hasInitializedVelConstraintKernels, ccmaUseDirectBuffer, hasOverlappingVsites;

--- a/platforms/opencl/include/OpenCLKernels.h
+++ b/platforms/opencl/include/OpenCLKernels.h
@@ -1132,12 +1132,8 @@ private:
 class OpenCLCalcGayBerneForceKernel : public CalcGayBerneForceKernel {
 public:
     OpenCLCalcGayBerneForceKernel(std::string name, const Platform& platform, OpenCLContext& cl) : CalcGayBerneForceKernel(name, platform), cl(cl),
-            hasInitializedKernels(false), sortedParticles(NULL), axisParticleIndices(NULL), sigParams(NULL), epsParams(NULL), scale(NULL), exceptionParticles(NULL),
-            exceptionParams(NULL), aMatrix(NULL),
-            bMatrix(NULL), gMatrix(NULL), exclusions(NULL), exclusionStartIndex(NULL), blockCenter(NULL), blockBoundingBox(NULL), neighbors(NULL),
-            neighborIndex(NULL), neighborBlockCount(NULL), sortedPos(NULL), torque(NULL) {
+            hasInitializedKernels(false) {
     }
-    ~OpenCLCalcGayBerneForceKernel();
     /**
      * Initialize the kernel.
      *
@@ -1169,25 +1165,25 @@ private:
     bool hasInitializedKernels;
     int numRealParticles, maxNeighborBlocks;
     GayBerneForce::NonbondedMethod nonbondedMethod;
-    OpenCLArray* sortedParticles;
-    OpenCLArray* axisParticleIndices;
-    OpenCLArray* sigParams;
-    OpenCLArray* epsParams;
-    OpenCLArray* scale;
-    OpenCLArray* exceptionParticles;
-    OpenCLArray* exceptionParams;
-    OpenCLArray* aMatrix;
-    OpenCLArray* bMatrix;
-    OpenCLArray* gMatrix;
-    OpenCLArray* exclusions;
-    OpenCLArray* exclusionStartIndex;
-    OpenCLArray* blockCenter;
-    OpenCLArray* blockBoundingBox;
-    OpenCLArray* neighbors;
-    OpenCLArray* neighborIndex;
-    OpenCLArray* neighborBlockCount;
-    OpenCLArray* sortedPos;
-    OpenCLArray* torque;
+    OpenCLArray sortedParticles;
+    OpenCLArray axisParticleIndices;
+    OpenCLArray sigParams;
+    OpenCLArray epsParams;
+    OpenCLArray scale;
+    OpenCLArray exceptionParticles;
+    OpenCLArray exceptionParams;
+    OpenCLArray aMatrix;
+    OpenCLArray bMatrix;
+    OpenCLArray gMatrix;
+    OpenCLArray exclusions;
+    OpenCLArray exclusionStartIndex;
+    OpenCLArray blockCenter;
+    OpenCLArray blockBoundingBox;
+    OpenCLArray neighbors;
+    OpenCLArray neighborIndex;
+    OpenCLArray neighborBlockCount;
+    OpenCLArray sortedPos;
+    OpenCLArray torque;
     std::vector<bool> isRealParticle;
     std::vector<std::pair<int, int> > exceptionAtoms;
     std::vector<std::pair<int, int> > excludedPairs;
@@ -1200,9 +1196,8 @@ private:
 class OpenCLCalcCustomCVForceKernel : public CalcCustomCVForceKernel {
 public:
     OpenCLCalcCustomCVForceKernel(std::string name, const Platform& platform, OpenCLContext& cl) : CalcCustomCVForceKernel(name, platform),
-            cl(cl), hasInitializedKernels(false), invAtomOrder(NULL), innerInvAtomOrder(NULL) {
+            cl(cl), hasInitializedKernels(false) {
     }
-    ~OpenCLCalcCustomCVForceKernel();
     /**
      * Initialize the kernel.
      *
@@ -1236,9 +1231,9 @@ private:
     std::vector<std::string> variableNames, paramDerivNames, globalParameterNames;
     std::vector<Lepton::ExpressionProgram> variableDerivExpressions;
     std::vector<Lepton::ExpressionProgram> paramDerivExpressions;
-    std::vector<OpenCLArray*> cvForces;
-    OpenCLArray* invAtomOrder;
-    OpenCLArray* innerInvAtomOrder;
+    std::vector<OpenCLArray> cvForces;
+    OpenCLArray invAtomOrder;
+    OpenCLArray innerInvAtomOrder;
     cl::Kernel copyStateKernel, copyForcesKernel, addForcesKernel;
 };
 
@@ -1247,10 +1242,8 @@ private:
  */
 class OpenCLCalcRMSDForceKernel : public CalcRMSDForceKernel {
 public:
-    OpenCLCalcRMSDForceKernel(std::string name, const Platform& platform, OpenCLContext& cl) : CalcRMSDForceKernel(name, platform),
-            cl(cl), referencePos(NULL), particles(NULL), buffer(NULL) {
+    OpenCLCalcRMSDForceKernel(std::string name, const Platform& platform, OpenCLContext& cl) : CalcRMSDForceKernel(name, platform), cl(cl) {
     }
-    ~OpenCLCalcRMSDForceKernel();
     /**
      * Initialize the kernel.
      *
@@ -1289,9 +1282,9 @@ private:
     OpenCLContext& cl;
     ForceInfo* info;
     double sumNormRef;
-    OpenCLArray* referencePos;
-    OpenCLArray* particles;
-    OpenCLArray* buffer;
+    OpenCLArray referencePos;
+    OpenCLArray particles;
+    OpenCLArray buffer;
     cl::Kernel kernel1, kernel2;
 };
 
@@ -1337,9 +1330,8 @@ private:
 class OpenCLIntegrateLangevinStepKernel : public IntegrateLangevinStepKernel {
 public:
     OpenCLIntegrateLangevinStepKernel(std::string name, const Platform& platform, OpenCLContext& cl) : IntegrateLangevinStepKernel(name, platform), cl(cl),
-            hasInitializedKernels(false), params(NULL) {
+            hasInitializedKernels(false) {
     }
-    ~OpenCLIntegrateLangevinStepKernel();
     /**
      * Initialize the kernel, setting up the particle masses.
      *
@@ -1365,7 +1357,7 @@ private:
     OpenCLContext& cl;
     double prevTemp, prevFriction, prevStepSize;
     bool hasInitializedKernels;
-    OpenCLArray* params;
+    OpenCLArray params;
     cl::Kernel kernel1, kernel2;
 };
 
@@ -1451,9 +1443,8 @@ private:
 class OpenCLIntegrateVariableLangevinStepKernel : public IntegrateVariableLangevinStepKernel {
 public:
     OpenCLIntegrateVariableLangevinStepKernel(std::string name, const Platform& platform, OpenCLContext& cl) : IntegrateVariableLangevinStepKernel(name, platform), cl(cl),
-            hasInitializedKernels(false), params(NULL) {
+            hasInitializedKernels(false) {
     }
-    ~OpenCLIntegrateVariableLangevinStepKernel();
     /**
      * Initialize the kernel, setting up the particle masses.
      *
@@ -1481,7 +1472,7 @@ private:
     OpenCLContext& cl;
     bool hasInitializedKernels;
     int blockSize;
-    OpenCLArray* params;
+    OpenCLArray params;
     cl::Kernel kernel1, kernel2, selectSizeKernel;
     double prevTemp, prevFriction, prevErrorTol;
 };
@@ -1493,8 +1484,7 @@ class OpenCLIntegrateCustomStepKernel : public IntegrateCustomStepKernel {
 public:
     enum GlobalTargetType {DT, VARIABLE, PARAMETER};
     OpenCLIntegrateCustomStepKernel(std::string name, const Platform& platform, OpenCLContext& cl) : IntegrateCustomStepKernel(name, platform), cl(cl),
-            hasInitializedKernels(false), localValuesAreCurrent(false), globalValues(NULL), sumBuffer(NULL), summedValue(NULL), uniformRandoms(NULL),
-            randomSeed(NULL), perDofEnergyParamDerivs(NULL), perDofValues(NULL), needsEnergyParamDerivs(false) {
+            hasInitializedKernels(false), localValuesAreCurrent(false), perDofValues(NULL), needsEnergyParamDerivs(false) {
     }
     ~OpenCLIntegrateCustomStepKernel();
     /**
@@ -1575,15 +1565,15 @@ private:
     int numGlobalVariables, sumWorkGroupSize;
     bool hasInitializedKernels, deviceValuesAreCurrent, deviceGlobalsAreCurrent, modifiesParameters, keNeedsForce, hasAnyConstraints, needsEnergyParamDerivs;
     mutable bool localValuesAreCurrent;
-    OpenCLArray* globalValues;
-    OpenCLArray* sumBuffer;
-    OpenCLArray* summedValue;
-    OpenCLArray* uniformRandoms;
-    OpenCLArray* randomSeed;
-    OpenCLArray* perDofEnergyParamDerivs;
-    std::vector<OpenCLArray*> tabulatedFunctions;
+    OpenCLArray globalValues;
+    OpenCLArray sumBuffer;
+    OpenCLArray summedValue;
+    OpenCLArray uniformRandoms;
+    OpenCLArray randomSeed;
+    OpenCLArray perDofEnergyParamDerivs;
+    std::vector<OpenCLArray> tabulatedFunctions;
     std::map<int, double> savedEnergy;
-    std::map<int, OpenCLArray*> savedForces;
+    std::map<int, OpenCLArray> savedForces;
     std::set<int> validSavedForces;
     OpenCLParameterSet* perDofValues;
     mutable std::vector<std::vector<cl_float> > localPerDofValuesFloat;
@@ -1635,9 +1625,8 @@ public:
 class OpenCLApplyAndersenThermostatKernel : public ApplyAndersenThermostatKernel {
 public:
     OpenCLApplyAndersenThermostatKernel(std::string name, const Platform& platform, OpenCLContext& cl) : ApplyAndersenThermostatKernel(name, platform), cl(cl),
-            hasInitializedKernels(false), atomGroups(NULL) {
+            hasInitializedKernels(false) {
     }
-    ~OpenCLApplyAndersenThermostatKernel();
     /**
      * Initialize the kernel.
      *
@@ -1655,7 +1644,7 @@ private:
     OpenCLContext& cl;
     bool hasInitializedKernels;
     int randomSeed;
-    OpenCLArray* atomGroups;
+    OpenCLArray atomGroups;
     cl::Kernel kernel;
 };
 
@@ -1665,9 +1654,8 @@ private:
 class OpenCLApplyMonteCarloBarostatKernel : public ApplyMonteCarloBarostatKernel {
 public:
     OpenCLApplyMonteCarloBarostatKernel(std::string name, const Platform& platform, OpenCLContext& cl) : ApplyMonteCarloBarostatKernel(name, platform), cl(cl),
-            hasInitializedKernels(false), savedPositions(NULL), savedForces(NULL), moleculeAtoms(NULL), moleculeStartIndex(NULL) {
+            hasInitializedKernels(false) {
     }
-    ~OpenCLApplyMonteCarloBarostatKernel();
     /**
      * Initialize the kernel.
      *
@@ -1699,10 +1687,10 @@ private:
     OpenCLContext& cl;
     bool hasInitializedKernels;
     int numMolecules;
-    OpenCLArray* savedPositions;
-    OpenCLArray* savedForces;
-    OpenCLArray* moleculeAtoms;
-    OpenCLArray* moleculeStartIndex;
+    OpenCLArray savedPositions;
+    OpenCLArray savedForces;
+    OpenCLArray moleculeAtoms;
+    OpenCLArray moleculeStartIndex;
     cl::Kernel kernel;
     std::vector<int> lastAtomOrder;
 };
@@ -1712,9 +1700,8 @@ private:
  */
 class OpenCLRemoveCMMotionKernel : public RemoveCMMotionKernel {
 public:
-    OpenCLRemoveCMMotionKernel(std::string name, const Platform& platform, OpenCLContext& cl) : RemoveCMMotionKernel(name, platform), cl(cl), cmMomentum(NULL) {
+    OpenCLRemoveCMMotionKernel(std::string name, const Platform& platform, OpenCLContext& cl) : RemoveCMMotionKernel(name, platform), cl(cl) {
     }
-    ~OpenCLRemoveCMMotionKernel();
     /**
      * Initialize the kernel, setting up the particle masses.
      *
@@ -1731,7 +1718,7 @@ public:
 private:
     OpenCLContext& cl;
     int frequency;
-    OpenCLArray* cmMomentum;
+    OpenCLArray cmMomentum;
     cl::Kernel kernel1, kernel2;
 };
 

--- a/platforms/opencl/include/OpenCLKernels.h
+++ b/platforms/opencl/include/OpenCLKernels.h
@@ -243,9 +243,8 @@ private:
 class OpenCLCalcHarmonicBondForceKernel : public CalcHarmonicBondForceKernel {
 public:
     OpenCLCalcHarmonicBondForceKernel(std::string name, const Platform& platform, OpenCLContext& cl, const System& system) : CalcHarmonicBondForceKernel(name, platform),
-            hasInitializedKernel(false), cl(cl), system(system), params(NULL) {
+            hasInitializedKernel(false), cl(cl), system(system) {
     }
-    ~OpenCLCalcHarmonicBondForceKernel();
     /**
      * Initialize the kernel.
      *
@@ -276,7 +275,7 @@ private:
     OpenCLContext& cl;
     ForceInfo* info;
     const System& system;
-    OpenCLArray* params;
+    OpenCLArray params;
 };
 
 /**
@@ -285,7 +284,7 @@ private:
 class OpenCLCalcCustomBondForceKernel : public CalcCustomBondForceKernel {
 public:
     OpenCLCalcCustomBondForceKernel(std::string name, const Platform& platform, OpenCLContext& cl, const System& system) : CalcCustomBondForceKernel(name, platform),
-            hasInitializedKernel(false), cl(cl), system(system), params(NULL), globals(NULL) {
+            hasInitializedKernel(false), cl(cl), system(system), params(NULL) {
     }
     ~OpenCLCalcCustomBondForceKernel();
     /**
@@ -319,7 +318,7 @@ private:
     ForceInfo* info;
     const System& system;
     OpenCLParameterSet* params;
-    OpenCLArray* globals;
+    OpenCLArray globals;
     std::vector<std::string> globalParamNames;
     std::vector<cl_float> globalParamValues;
 };
@@ -330,9 +329,8 @@ private:
 class OpenCLCalcHarmonicAngleForceKernel : public CalcHarmonicAngleForceKernel {
 public:
     OpenCLCalcHarmonicAngleForceKernel(std::string name, const Platform& platform, OpenCLContext& cl, const System& system) : CalcHarmonicAngleForceKernel(name, platform),
-            hasInitializedKernel(false), cl(cl), system(system), params(NULL) {
+            hasInitializedKernel(false), cl(cl), system(system) {
     }
-    ~OpenCLCalcHarmonicAngleForceKernel();
     /**
      * Initialize the kernel.
      *
@@ -363,7 +361,7 @@ private:
     OpenCLContext& cl;
     ForceInfo* info;
     const System& system;
-    OpenCLArray* params;
+    OpenCLArray params;
 };
 
 /**
@@ -372,7 +370,7 @@ private:
 class OpenCLCalcCustomAngleForceKernel : public CalcCustomAngleForceKernel {
 public:
     OpenCLCalcCustomAngleForceKernel(std::string name, const Platform& platform, OpenCLContext& cl, const System& system) : CalcCustomAngleForceKernel(name, platform),
-            hasInitializedKernel(false), cl(cl), system(system), params(NULL), globals(NULL) {
+            hasInitializedKernel(false), cl(cl), system(system), params(NULL) {
     }
     ~OpenCLCalcCustomAngleForceKernel();
     /**
@@ -406,7 +404,7 @@ private:
     ForceInfo* info;
     const System& system;
     OpenCLParameterSet* params;
-    OpenCLArray* globals;
+    OpenCLArray globals;
     std::vector<std::string> globalParamNames;
     std::vector<cl_float> globalParamValues;
 };
@@ -417,9 +415,8 @@ private:
 class OpenCLCalcPeriodicTorsionForceKernel : public CalcPeriodicTorsionForceKernel {
 public:
     OpenCLCalcPeriodicTorsionForceKernel(std::string name, const Platform& platform, OpenCLContext& cl, const System& system) : CalcPeriodicTorsionForceKernel(name, platform),
-            hasInitializedKernel(false), cl(cl), system(system), params(NULL) {
+            hasInitializedKernel(false), cl(cl), system(system) {
     }
-    ~OpenCLCalcPeriodicTorsionForceKernel();
     /**
      * Initialize the kernel.
      *
@@ -450,7 +447,7 @@ private:
     OpenCLContext& cl;
     ForceInfo* info;
     const System& system;
-    OpenCLArray* params;
+    OpenCLArray params;
 };
 
 /**
@@ -459,9 +456,8 @@ private:
 class OpenCLCalcRBTorsionForceKernel : public CalcRBTorsionForceKernel {
 public:
     OpenCLCalcRBTorsionForceKernel(std::string name, const Platform& platform, OpenCLContext& cl, const System& system) : CalcRBTorsionForceKernel(name, platform),
-            hasInitializedKernel(false), cl(cl), system(system), params(NULL) {
+            hasInitializedKernel(false), cl(cl), system(system) {
     }
-    ~OpenCLCalcRBTorsionForceKernel();
     /**
      * Initialize the kernel.
      *
@@ -492,7 +488,7 @@ private:
     OpenCLContext& cl;
     ForceInfo* info;
     const System& system;
-    OpenCLArray* params;
+    OpenCLArray params;
 };
 
 /**
@@ -501,9 +497,8 @@ private:
 class OpenCLCalcCMAPTorsionForceKernel : public CalcCMAPTorsionForceKernel {
 public:
     OpenCLCalcCMAPTorsionForceKernel(std::string name, const Platform& platform, OpenCLContext& cl, const System& system) : CalcCMAPTorsionForceKernel(name, platform),
-            hasInitializedKernel(false), cl(cl), system(system), coefficients(NULL), mapPositions(NULL), torsionMaps(NULL) {
+            hasInitializedKernel(false), cl(cl), system(system) {
     }
-    ~OpenCLCalcCMAPTorsionForceKernel();
     /**
      * Initialize the kernel.
      *
@@ -535,9 +530,9 @@ private:
     ForceInfo* info;
     const System& system;
     std::vector<mm_int2> mapPositionsVec;
-    OpenCLArray* coefficients;
-    OpenCLArray* mapPositions;
-    OpenCLArray* torsionMaps;
+    OpenCLArray coefficients;
+    OpenCLArray mapPositions;
+    OpenCLArray torsionMaps;
 };
 
 /**
@@ -546,7 +541,7 @@ private:
 class OpenCLCalcCustomTorsionForceKernel : public CalcCustomTorsionForceKernel {
 public:
     OpenCLCalcCustomTorsionForceKernel(std::string name, const Platform& platform, OpenCLContext& cl, const System& system) : CalcCustomTorsionForceKernel(name, platform),
-            hasInitializedKernel(false), cl(cl), system(system), params(NULL), globals(NULL) {
+            hasInitializedKernel(false), cl(cl), system(system), params(NULL) {
     }
     ~OpenCLCalcCustomTorsionForceKernel();
     /**
@@ -580,7 +575,7 @@ private:
     ForceInfo* info;
     const System& system;
     OpenCLParameterSet* params;
-    OpenCLArray* globals;
+    OpenCLArray globals;
     std::vector<std::string> globalParamNames;
     std::vector<cl_float> globalParamValues;
 };
@@ -591,10 +586,7 @@ private:
 class OpenCLCalcNonbondedForceKernel : public CalcNonbondedForceKernel {
 public:
     OpenCLCalcNonbondedForceKernel(std::string name, const Platform& platform, OpenCLContext& cl, const System& system) : CalcNonbondedForceKernel(name, platform),
-            hasInitializedKernel(false), cl(cl), sigmaEpsilon(NULL), exceptionParams(NULL), cosSinSums(NULL), pmeGrid(NULL),
-            pmeGrid2(NULL), pmeBsplineModuliX(NULL), pmeBsplineModuliY(NULL), pmeBsplineModuliZ(NULL), pmeDispersionBsplineModuliX(NULL),
-            pmeDispersionBsplineModuliY(NULL), pmeDispersionBsplineModuliZ(NULL), pmeBsplineTheta(NULL), pmeAtomRange(NULL),
-            pmeAtomGridIndex(NULL), pmeEnergyBuffer(NULL), sort(NULL), fft(NULL), dispersionFft(NULL), pmeio(NULL) {
+            hasInitializedKernel(false), cl(cl), sort(NULL), fft(NULL), dispersionFft(NULL), pmeio(NULL) {
     }
     ~OpenCLCalcNonbondedForceKernel();
     /**
@@ -660,21 +652,21 @@ private:
     OpenCLContext& cl;
     ForceInfo* info;
     bool hasInitializedKernel;
-    OpenCLArray* sigmaEpsilon;
-    OpenCLArray* exceptionParams;
-    OpenCLArray* cosSinSums;
-    OpenCLArray* pmeGrid;
-    OpenCLArray* pmeGrid2;
-    OpenCLArray* pmeBsplineModuliX;
-    OpenCLArray* pmeBsplineModuliY;
-    OpenCLArray* pmeBsplineModuliZ;
-    OpenCLArray* pmeDispersionBsplineModuliX;
-    OpenCLArray* pmeDispersionBsplineModuliY;
-    OpenCLArray* pmeDispersionBsplineModuliZ;
-    OpenCLArray* pmeBsplineTheta;
-    OpenCLArray* pmeAtomRange;
-    OpenCLArray* pmeAtomGridIndex;
-    OpenCLArray* pmeEnergyBuffer;
+    OpenCLArray sigmaEpsilon;
+    OpenCLArray exceptionParams;
+    OpenCLArray cosSinSums;
+    OpenCLArray pmeGrid;
+    OpenCLArray pmeGrid2;
+    OpenCLArray pmeBsplineModuliX;
+    OpenCLArray pmeBsplineModuliY;
+    OpenCLArray pmeBsplineModuliZ;
+    OpenCLArray pmeDispersionBsplineModuliX;
+    OpenCLArray pmeDispersionBsplineModuliY;
+    OpenCLArray pmeDispersionBsplineModuliZ;
+    OpenCLArray pmeBsplineTheta;
+    OpenCLArray pmeAtomRange;
+    OpenCLArray pmeAtomGridIndex;
+    OpenCLArray pmeEnergyBuffer;
     OpenCLSort* sort;
     cl::CommandQueue pmeQueue;
     cl::Event pmeSyncEvent;
@@ -717,7 +709,7 @@ private:
 class OpenCLCalcCustomNonbondedForceKernel : public CalcCustomNonbondedForceKernel {
 public:
     OpenCLCalcCustomNonbondedForceKernel(std::string name, const Platform& platform, OpenCLContext& cl, const System& system) : CalcCustomNonbondedForceKernel(name, platform),
-            cl(cl), params(NULL), globals(NULL), interactionGroupData(NULL), forceCopy(NULL), system(system), hasInitializedKernel(false) {
+            cl(cl), params(NULL), forceCopy(NULL), system(system), hasInitializedKernel(false) {
     }
     ~OpenCLCalcCustomNonbondedForceKernel();
     /**
@@ -749,13 +741,13 @@ private:
     OpenCLContext& cl;
     ForceInfo* info;
     OpenCLParameterSet* params;
-    OpenCLArray* globals;
-    OpenCLArray* interactionGroupData;
+    OpenCLArray globals;
+    OpenCLArray interactionGroupData;
     cl::Kernel interactionGroupKernel;
     std::vector<void*> interactionGroupArgs;
     std::vector<std::string> globalParamNames;
     std::vector<cl_float> globalParamValues;
-    std::vector<OpenCLArray*> tabulatedFunctions;
+    std::vector<OpenCLArray> tabulatedFunctions;
     double longRangeCoefficient;
     std::vector<double> longRangeCoefficientDerivs;
     bool hasInitializedLongRangeCorrection, hasInitializedKernel, hasParamDerivs;
@@ -770,10 +762,8 @@ private:
 class OpenCLCalcGBSAOBCForceKernel : public CalcGBSAOBCForceKernel {
 public:
     OpenCLCalcGBSAOBCForceKernel(std::string name, const Platform& platform, OpenCLContext& cl) : CalcGBSAOBCForceKernel(name, platform), cl(cl),
-            hasCreatedKernels(false), params(NULL), bornSum(NULL), longBornSum(NULL), bornRadii(NULL), bornForce(NULL),
-            longBornForce(NULL), obcChain(NULL) {
+            hasCreatedKernels(false) {
     }
-    ~OpenCLCalcGBSAOBCForceKernel();
     /**
      * Initialize the kernel.
      *
@@ -804,13 +794,13 @@ private:
     int maxTiles;
     OpenCLContext& cl;
     ForceInfo* info;
-    OpenCLArray* params;
-    OpenCLArray* bornSum;
-    OpenCLArray* longBornSum;
-    OpenCLArray* bornRadii;
-    OpenCLArray* bornForce;
-    OpenCLArray* longBornForce;
-    OpenCLArray* obcChain;
+    OpenCLArray params;
+    OpenCLArray bornSum;
+    OpenCLArray longBornSum;
+    OpenCLArray bornRadii;
+    OpenCLArray bornForce;
+    OpenCLArray longBornForce;
+    OpenCLArray obcChain;
     cl::Kernel computeBornSumKernel;
     cl::Kernel reduceBornSumKernel;
     cl::Kernel force1Kernel;
@@ -823,8 +813,7 @@ private:
 class OpenCLCalcCustomGBForceKernel : public CalcCustomGBForceKernel {
 public:
     OpenCLCalcCustomGBForceKernel(std::string name, const Platform& platform, OpenCLContext& cl, const System& system) : CalcCustomGBForceKernel(name, platform),
-            hasInitializedKernels(false), cl(cl), params(NULL), computedValues(NULL), energyDerivs(NULL), energyDerivChain(NULL), longEnergyDerivs(NULL), globals(NULL),
-            valueBuffers(NULL), longValueBuffers(NULL), system(system) {
+            hasInitializedKernels(false), cl(cl), params(NULL), computedValues(NULL), energyDerivs(NULL), energyDerivChain(NULL), system(system) {
     }
     ~OpenCLCalcCustomGBForceKernel();
     /**
@@ -862,14 +851,14 @@ private:
     OpenCLParameterSet* energyDerivs;
     OpenCLParameterSet* energyDerivChain;
     std::vector<OpenCLParameterSet*> dValuedParam;
-    std::vector<OpenCLArray*> dValue0dParam;
-    OpenCLArray* longEnergyDerivs;
-    OpenCLArray* globals;
-    OpenCLArray* valueBuffers;
-    OpenCLArray* longValueBuffers;
+    std::vector<OpenCLArray> dValue0dParam;
+    OpenCLArray longEnergyDerivs;
+    OpenCLArray globals;
+    OpenCLArray valueBuffers;
+    OpenCLArray longValueBuffers;
     std::vector<std::string> globalParamNames;
     std::vector<cl_float> globalParamValues;
-    std::vector<OpenCLArray*> tabulatedFunctions;
+    std::vector<OpenCLArray> tabulatedFunctions;
     std::vector<bool> pairValueUsesParam, pairEnergyUsesParam, pairEnergyUsesValue;
     const System& system;
     cl::Kernel pairValueKernel, perParticleValueKernel, pairEnergyKernel, perParticleEnergyKernel, gradientChainRuleKernel;
@@ -883,7 +872,7 @@ private:
 class OpenCLCalcCustomExternalForceKernel : public CalcCustomExternalForceKernel {
 public:
     OpenCLCalcCustomExternalForceKernel(std::string name, const Platform& platform, OpenCLContext& cl, const System& system) : CalcCustomExternalForceKernel(name, platform),
-            hasInitializedKernel(false), cl(cl), system(system), params(NULL), globals(NULL) {
+            hasInitializedKernel(false), cl(cl), system(system), params(NULL) {
     }
     ~OpenCLCalcCustomExternalForceKernel();
     /**
@@ -917,7 +906,7 @@ private:
     ForceInfo* info;
     const System& system;
     OpenCLParameterSet* params;
-    OpenCLArray* globals;
+    OpenCLArray globals;
     std::vector<std::string> globalParamNames;
     std::vector<cl_float> globalParamValues;
 };
@@ -928,8 +917,7 @@ private:
 class OpenCLCalcCustomHbondForceKernel : public CalcCustomHbondForceKernel {
 public:
     OpenCLCalcCustomHbondForceKernel(std::string name, const Platform& platform, OpenCLContext& cl, const System& system) : CalcCustomHbondForceKernel(name, platform),
-            hasInitializedKernel(false), cl(cl), donorParams(NULL), acceptorParams(NULL), donors(NULL), acceptors(NULL),
-            donorBufferIndices(NULL), acceptorBufferIndices(NULL), globals(NULL), donorExclusions(NULL), acceptorExclusions(NULL), system(system) {
+            hasInitializedKernel(false), cl(cl), donorParams(NULL), acceptorParams(NULL), system(system) {
     }
     ~OpenCLCalcCustomHbondForceKernel();
     /**
@@ -963,16 +951,16 @@ private:
     ForceInfo* info;
     OpenCLParameterSet* donorParams;
     OpenCLParameterSet* acceptorParams;
-    OpenCLArray* globals;
-    OpenCLArray* donors;
-    OpenCLArray* acceptors;
-    OpenCLArray* donorBufferIndices;
-    OpenCLArray* acceptorBufferIndices;
-    OpenCLArray* donorExclusions;
-    OpenCLArray* acceptorExclusions;
+    OpenCLArray globals;
+    OpenCLArray donors;
+    OpenCLArray acceptors;
+    OpenCLArray donorBufferIndices;
+    OpenCLArray acceptorBufferIndices;
+    OpenCLArray donorExclusions;
+    OpenCLArray acceptorExclusions;
     std::vector<std::string> globalParamNames;
     std::vector<cl_float> globalParamValues;
-    std::vector<OpenCLArray*> tabulatedFunctions;
+    std::vector<OpenCLArray> tabulatedFunctions;
     const System& system;
     cl::Kernel donorKernel, acceptorKernel;
 };
@@ -983,7 +971,7 @@ private:
 class OpenCLCalcCustomCentroidBondForceKernel : public CalcCustomCentroidBondForceKernel {
 public:
     OpenCLCalcCustomCentroidBondForceKernel(std::string name, const Platform& platform, OpenCLContext& cl, const System& system) : CalcCustomCentroidBondForceKernel(name, platform),
-            cl(cl), params(NULL), globals(NULL), groupParticles(NULL), groupWeights(NULL), groupOffsets(NULL), groupForces(NULL), bondGroups(NULL), centerPositions(NULL), system(system) {
+            cl(cl), params(NULL), system(system) {
     }
     ~OpenCLCalcCustomCentroidBondForceKernel();
     /**
@@ -1017,16 +1005,16 @@ private:
     OpenCLContext& cl;
     ForceInfo* info;
     OpenCLParameterSet* params;
-    OpenCLArray* globals;
-    OpenCLArray* groupParticles;
-    OpenCLArray* groupWeights;
-    OpenCLArray* groupOffsets;
-    OpenCLArray* groupForces;
-    OpenCLArray* bondGroups;
-    OpenCLArray* centerPositions;
+    OpenCLArray globals;
+    OpenCLArray groupParticles;
+    OpenCLArray groupWeights;
+    OpenCLArray groupOffsets;
+    OpenCLArray groupForces;
+    OpenCLArray bondGroups;
+    OpenCLArray centerPositions;
     std::vector<std::string> globalParamNames;
     std::vector<cl_float> globalParamValues;
-    std::vector<OpenCLArray*> tabulatedFunctions;
+    std::vector<OpenCLArray> tabulatedFunctions;
     cl::Kernel computeCentersKernel, groupForcesKernel, applyForcesKernel;
     const System& system;
 };
@@ -1037,7 +1025,7 @@ private:
 class OpenCLCalcCustomCompoundBondForceKernel : public CalcCustomCompoundBondForceKernel {
 public:
     OpenCLCalcCustomCompoundBondForceKernel(std::string name, const Platform& platform, OpenCLContext& cl, const System& system) : CalcCustomCompoundBondForceKernel(name, platform),
-            cl(cl), params(NULL), globals(NULL), system(system) {
+            cl(cl), params(NULL), system(system) {
     }
     ~OpenCLCalcCustomCompoundBondForceKernel();
     /**
@@ -1070,10 +1058,10 @@ private:
     OpenCLContext& cl;
     ForceInfo* info;
     OpenCLParameterSet* params;
-    OpenCLArray* globals;
+    OpenCLArray globals;
     std::vector<std::string> globalParamNames;
     std::vector<cl_float> globalParamValues;
-    std::vector<OpenCLArray*> tabulatedFunctions;
+    std::vector<OpenCLArray> tabulatedFunctions;
     const System& system;
 };
 
@@ -1083,9 +1071,7 @@ private:
 class OpenCLCalcCustomManyParticleForceKernel : public CalcCustomManyParticleForceKernel {
 public:
     OpenCLCalcCustomManyParticleForceKernel(std::string name, const Platform& platform, OpenCLContext& cl, const System& system) : CalcCustomManyParticleForceKernel(name, platform),
-            hasInitializedKernel(false), cl(cl), params(NULL), globals(NULL), particleTypes(NULL), orderIndex(NULL), particleOrder(NULL), exclusions(NULL),
-            exclusionStartIndex(NULL), blockCenter(NULL), blockBoundingBox(NULL), neighborPairs(NULL), numNeighborPairs(NULL), neighborStartIndex(NULL),
-            numNeighborsForAtom(NULL), neighbors(NULL), system(system) {
+            hasInitializedKernel(false), cl(cl), params(NULL), system(system) {
     }
     ~OpenCLCalcCustomManyParticleForceKernel();
     /**
@@ -1120,22 +1106,22 @@ private:
     NonbondedMethod nonbondedMethod;
     int maxNeighborPairs, forceWorkgroupSize, findNeighborsWorkgroupSize;
     OpenCLParameterSet* params;
-    OpenCLArray* globals;
-    OpenCLArray* particleTypes;
-    OpenCLArray* orderIndex;
-    OpenCLArray* particleOrder;
-    OpenCLArray* exclusions;
-    OpenCLArray* exclusionStartIndex;
-    OpenCLArray* blockCenter;
-    OpenCLArray* blockBoundingBox;
-    OpenCLArray* neighborPairs;
-    OpenCLArray* numNeighborPairs;
-    OpenCLArray* neighborStartIndex;
-    OpenCLArray* numNeighborsForAtom;
-    OpenCLArray* neighbors;
+    OpenCLArray globals;
+    OpenCLArray particleTypes;
+    OpenCLArray orderIndex;
+    OpenCLArray particleOrder;
+    OpenCLArray exclusions;
+    OpenCLArray exclusionStartIndex;
+    OpenCLArray blockCenter;
+    OpenCLArray blockBoundingBox;
+    OpenCLArray neighborPairs;
+    OpenCLArray numNeighborPairs;
+    OpenCLArray neighborStartIndex;
+    OpenCLArray numNeighborsForAtom;
+    OpenCLArray neighbors;
     std::vector<std::string> globalParamNames;
     std::vector<float> globalParamValues;
-    std::vector<OpenCLArray*> tabulatedFunctions;
+    std::vector<OpenCLArray> tabulatedFunctions;
     const System& system;
     cl::Kernel forceKernel, blockBoundsKernel, neighborsKernel, startIndicesKernel, copyPairsKernel;
 };

--- a/platforms/opencl/include/OpenCLNonbondedUtilities.h
+++ b/platforms/opencl/include/OpenCLNonbondedUtilities.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2009-2016 Stanford University and the Authors.      *
+ * Portions copyright (c) 2009-2018 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -175,55 +175,55 @@ public:
      * Get the array containing the center of each atom block.
      */
     OpenCLArray& getBlockCenters() {
-        return *blockCenter;
+        return blockCenter;
     }
     /**
      * Get the array containing the dimensions of each atom block.
      */
     OpenCLArray& getBlockBoundingBoxes() {
-        return *blockBoundingBox;
+        return blockBoundingBox;
     }
     /**
      * Get the array whose first element contains the number of tiles with interactions.
      */
     OpenCLArray& getInteractionCount() {
-        return *interactionCount;
+        return interactionCount;
     }
     /**
      * Get the array containing tiles with interactions.
      */
     OpenCLArray& getInteractingTiles() {
-        return *interactingTiles;
+        return interactingTiles;
     }
     /**
      * Get the array containing the atoms in each tile with interactions.
      */
     OpenCLArray& getInteractingAtoms() {
-        return *interactingAtoms;
+        return interactingAtoms;
     }
     /**
      * Get the array containing exclusion flags.
      */
     OpenCLArray& getExclusions() {
-        return *exclusions;
+        return exclusions;
     }
     /**
      * Get the array containing tiles with exclusions.
      */
     OpenCLArray& getExclusionTiles() {
-        return *exclusionTiles;
+        return exclusionTiles;
     }
     /**
      * Get the array containing the index into the exclusion array for each tile.
      */
     OpenCLArray& getExclusionIndices() {
-        return *exclusionIndices;
+        return exclusionIndices;
     }
     /**
      * Get the array listing where the exclusion data starts for each row.
      */
     OpenCLArray& getExclusionRowIndices() {
-        return *exclusionRowIndices;
+        return exclusionRowIndices;
     }
     /**
      * Get the index of the first tile this context is responsible for processing.
@@ -275,20 +275,20 @@ private:
     class BlockSortTrait;
     OpenCLContext& context;
     std::map<int, KernelSet> groupKernels;
-    OpenCLArray* exclusionTiles;
-    OpenCLArray* exclusions;
-    OpenCLArray* exclusionIndices;
-    OpenCLArray* exclusionRowIndices;
-    OpenCLArray* interactingTiles;
-    OpenCLArray* interactingAtoms;
-    OpenCLArray* interactionCount;
-    OpenCLArray* blockCenter;
-    OpenCLArray* blockBoundingBox;
-    OpenCLArray* sortedBlocks;
-    OpenCLArray* sortedBlockCenter;
-    OpenCLArray* sortedBlockBoundingBox;
-    OpenCLArray* oldPositions;
-    OpenCLArray* rebuildNeighborList;
+    OpenCLArray exclusionTiles;
+    OpenCLArray exclusions;
+    OpenCLArray exclusionIndices;
+    OpenCLArray exclusionRowIndices;
+    OpenCLArray interactingTiles;
+    OpenCLArray interactingAtoms;
+    OpenCLArray interactionCount;
+    OpenCLArray blockCenter;
+    OpenCLArray blockBoundingBox;
+    OpenCLArray sortedBlocks;
+    OpenCLArray sortedBlockCenter;
+    OpenCLArray sortedBlockBoundingBox;
+    OpenCLArray oldPositions;
+    OpenCLArray rebuildNeighborList;
     OpenCLSort* blockSorter;
     cl::Event downloadCountEvent;
     cl::Buffer* pinnedCountBuffer;

--- a/platforms/opencl/include/OpenCLParallelKernels.h
+++ b/platforms/opencl/include/OpenCLParallelKernels.h
@@ -84,7 +84,7 @@ private:
     std::vector<long long> completionTimes;
     std::vector<double> contextNonbondedFractions;
     std::vector<int> tileCounts;
-    OpenCLArray* contextForces;
+    OpenCLArray contextForces;
     cl::Buffer* pinnedPositionBuffer;
     cl::Buffer* pinnedForceBuffer;
     void* pinnedPositionMemory;

--- a/platforms/opencl/include/OpenCLSort.h
+++ b/platforms/opencl/include/OpenCLSort.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2010-2013 Stanford University and the Authors.      *
+ * Portions copyright (c) 2010-2018 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -87,11 +87,11 @@ public:
 private:
     OpenCLContext& context;
     SortTrait* trait;
-    OpenCLArray* dataRange;
-    OpenCLArray* bucketOfElement;
-    OpenCLArray* offsetInBucket;
-    OpenCLArray* bucketOffset;
-    OpenCLArray* buckets;
+    OpenCLArray dataRange;
+    OpenCLArray bucketOfElement;
+    OpenCLArray offsetInBucket;
+    OpenCLArray bucketOffset;
+    OpenCLArray buckets;
     cl::Kernel shortListKernel, computeRangeKernel, assignElementsKernel, computeBucketPositionsKernel, copyToBucketsKernel, sortBucketsKernel;
     unsigned int dataLength, rangeKernelSize, positionsKernelSize, sortKernelSize;
     bool isShortList;

--- a/platforms/opencl/include/OpenCLSort.h
+++ b/platforms/opencl/include/OpenCLSort.h
@@ -28,6 +28,7 @@
  * -------------------------------------------------------------------------- */
 
 #include "OpenCLArray.h"
+#include "OpenCLContext.h"
 #include "windowsExportOpenCL.h"
 
 namespace OpenMM {

--- a/platforms/opencl/src/OpenCLArray.cpp
+++ b/platforms/opencl/src/OpenCLArray.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2012 Stanford University and the Authors.           *
+ * Portions copyright (c) 2012-2018 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -25,14 +25,38 @@
  * -------------------------------------------------------------------------- */
 
 #include "OpenCLArray.h"
+#include "OpenCLContext.h"
 #include <iostream>
 #include <sstream>
 #include <vector>
 
 using namespace OpenMM;
 
-OpenCLArray::OpenCLArray(OpenCLContext& context, int size, int elementSize, const std::string& name, cl_int flags) :
-        context(context), size(size), elementSize(elementSize), name(name), ownsBuffer(true) {
+OpenCLArray::OpenCLArray() : buffer(NULL), ownsBuffer(false) {
+}
+
+OpenCLArray::OpenCLArray(OpenCLContext& context, int size, int elementSize, const std::string& name, cl_int flags) : buffer(NULL) {
+    initialize(context, size, elementSize, name, flags);
+}
+
+OpenCLArray::OpenCLArray(OpenCLContext& context, cl::Buffer* buffer, int size, int elementSize, const std::string& name) : buffer(NULL) {
+    initialize(context, buffer, size, elementSize, name);
+}
+
+OpenCLArray::~OpenCLArray() {
+    if (buffer != NULL && ownsBuffer)
+        delete buffer;
+}
+
+void OpenCLArray::initialize(OpenCLContext& context, int size, int elementSize, const std::string& name, cl_int flags) {
+    if (buffer != NULL)
+        throw OpenMMException("OpenCLArray has already been initialized");
+    this->context = &context;
+    this->size = size;
+    this->elementSize = elementSize;
+    this->name = name;
+    this->flags = flags;
+    ownsBuffer = true;
     try {
         buffer = new cl::Buffer(context.getContext(), flags, size*elementSize);
     }
@@ -43,18 +67,32 @@ OpenCLArray::OpenCLArray(OpenCLContext& context, int size, int elementSize, cons
     }
 }
 
-OpenCLArray::OpenCLArray(OpenCLContext& context, cl::Buffer* buffer, int size, int elementSize, const std::string& name) :
-        context(context), buffer(buffer), size(size), elementSize(elementSize), name(name), ownsBuffer(false) {
+void OpenCLArray::initialize(OpenCLContext& context, cl::Buffer* buffer, int size, int elementSize, const std::string& name) {
+    if (this->buffer != NULL)
+        throw OpenMMException("OpenCLArray has already been initialized");
+    this->context = &context;
+    this->buffer = buffer;
+    this->size = size;
+    this->elementSize = elementSize;
+    this->name = name;
+    ownsBuffer = false;
 }
 
-OpenCLArray::~OpenCLArray() {
-    if (ownsBuffer)
-        delete buffer;
+void OpenCLArray::resize(int size) {
+    if (buffer == NULL)
+        throw OpenMMException("OpenCLArray has not been initialized");
+    if (!ownsBuffer)
+        throw OpenMMException("Cannot resize an array that does not own its storage");
+    delete buffer;
+    buffer = NULL;
+    initialize(*context, size, elementSize, name, flags);
 }
 
 void OpenCLArray::upload(const void* data, bool blocking) {
+    if (buffer == NULL)
+        throw OpenMMException("OpenCLArray has not been initialized");
     try {
-        context.getQueue().enqueueWriteBuffer(*buffer, blocking ? CL_TRUE : CL_FALSE, 0, size*elementSize, data);
+        context->getQueue().enqueueWriteBuffer(*buffer, blocking ? CL_TRUE : CL_FALSE, 0, size*elementSize, data);
     }
     catch (cl::Error err) {
         std::stringstream str;
@@ -64,8 +102,10 @@ void OpenCLArray::upload(const void* data, bool blocking) {
 }
 
 void OpenCLArray::download(void* data, bool blocking) const {
+    if (buffer == NULL)
+        throw OpenMMException("OpenCLArray has not been initialized");
     try {
-        context.getQueue().enqueueReadBuffer(*buffer, blocking ? CL_TRUE : CL_FALSE, 0, size*elementSize, data);
+        context->getQueue().enqueueReadBuffer(*buffer, blocking ? CL_TRUE : CL_FALSE, 0, size*elementSize, data);
     }
     catch (cl::Error err) {
         std::stringstream str;
@@ -75,10 +115,12 @@ void OpenCLArray::download(void* data, bool blocking) const {
 }
 
 void OpenCLArray::copyTo(OpenCLArray& dest) const {
+    if (buffer == NULL)
+        throw OpenMMException("OpenCLArray has not been initialized");
     if (dest.getSize() != size || dest.getElementSize() != elementSize)
         throw OpenMMException("Error copying array "+name+" to "+dest.getName()+": The destination array does not match the size of the array");
     try {
-        context.getQueue().enqueueCopyBuffer(*buffer, dest.getDeviceBuffer(), 0, 0, size*elementSize);
+        context->getQueue().enqueueCopyBuffer(*buffer, dest.getDeviceBuffer(), 0, 0, size*elementSize);
     }
     catch (cl::Error err) {
         std::stringstream str;

--- a/platforms/opencl/src/OpenCLFFT3D.cpp
+++ b/platforms/opencl/src/OpenCLFFT3D.cpp
@@ -28,6 +28,7 @@
 #include "OpenCLExpressionUtilities.h"
 #include "OpenCLKernelSources.h"
 #include "SimTKOpenMMRealType.h"
+#include <algorithm>
 #include <map>
 #include <sstream>
 #include <string>
@@ -158,7 +159,7 @@ int OpenCLFFT3D::findLegalDimension(int minimum) {
 }
 
 cl::Kernel OpenCLFFT3D::createKernel(int xsize, int ysize, int zsize, int& threads, int axis, bool forward, bool inputIsReal) {
-    int maxThreads = std::min(256, (int) context.getDevice().getInfo<CL_DEVICE_MAX_WORK_GROUP_SIZE>());
+    int maxThreads = min(256, (int) context.getDevice().getInfo<CL_DEVICE_MAX_WORK_GROUP_SIZE>());
     while (maxThreads > 128 && maxThreads-64 >= zsize)
         maxThreads -= 64;
     bool isCPU = context.getDevice().getInfo<CL_DEVICE_TYPE>() == CL_DEVICE_TYPE_CPU;

--- a/platforms/opencl/src/OpenCLNonbondedUtilities.cpp
+++ b/platforms/opencl/src/OpenCLNonbondedUtilities.cpp
@@ -55,9 +55,7 @@ private:
 };
 
 OpenCLNonbondedUtilities::OpenCLNonbondedUtilities(OpenCLContext& context) : context(context), useCutoff(false), usePeriodic(false), anyExclusions(false), usePadding(true),
-        numForceBuffers(0), exclusionIndices(NULL), exclusionRowIndices(NULL), exclusionTiles(NULL), exclusions(NULL), interactingTiles(NULL), interactingAtoms(NULL),
-        interactionCount(NULL), blockCenter(NULL), blockBoundingBox(NULL), sortedBlocks(NULL), sortedBlockCenter(NULL), sortedBlockBoundingBox(NULL),
-        oldPositions(NULL), rebuildNeighborList(NULL), blockSorter(NULL), pinnedCountBuffer(NULL), pinnedCountMemory(NULL), forceRebuildNeighborList(true), lastCutoff(0.0), groupFlags(0) {
+        numForceBuffers(0), blockSorter(NULL), pinnedCountBuffer(NULL), pinnedCountMemory(NULL), forceRebuildNeighborList(true), lastCutoff(0.0), groupFlags(0) {
     // Decide how many thread blocks and force buffers to use.
 
     deviceIsCpu = (context.getDevice().getInfo<CL_DEVICE_TYPE>() == CL_DEVICE_TYPE_CPU);
@@ -95,34 +93,6 @@ OpenCLNonbondedUtilities::OpenCLNonbondedUtilities(OpenCLContext& context) : con
 }
 
 OpenCLNonbondedUtilities::~OpenCLNonbondedUtilities() {
-    if (exclusionIndices != NULL)
-        delete exclusionIndices;
-    if (exclusionRowIndices != NULL)
-        delete exclusionRowIndices;
-    if (exclusionTiles != NULL)
-        delete exclusionTiles;
-    if (exclusions != NULL)
-        delete exclusions;
-    if (interactingTiles != NULL)
-        delete interactingTiles;
-    if (interactingAtoms != NULL)
-        delete interactingAtoms;
-    if (interactionCount != NULL)
-        delete interactionCount;
-    if (blockCenter != NULL)
-        delete blockCenter;
-    if (blockBoundingBox != NULL)
-        delete blockBoundingBox;
-    if (sortedBlocks != NULL)
-        delete sortedBlocks;
-    if (sortedBlockCenter != NULL)
-        delete sortedBlockCenter;
-    if (sortedBlockBoundingBox != NULL)
-        delete sortedBlockBoundingBox;
-    if (oldPositions != NULL)
-        delete oldPositions;
-    if (rebuildNeighborList != NULL)
-        delete rebuildNeighborList;
     if (blockSorter != NULL)
         delete blockSorter;
     if (pinnedCountBuffer != NULL)
@@ -246,8 +216,8 @@ void OpenCLNonbondedUtilities::initialize(const System& system) {
     for (set<pair<int, int> >::const_iterator iter = tilesWithExclusions.begin(); iter != tilesWithExclusions.end(); ++iter)
         exclusionTilesVec.push_back(mm_ushort2((unsigned short) iter->first, (unsigned short) iter->second));
     sort(exclusionTilesVec.begin(), exclusionTilesVec.end(), context.getSIMDWidth() <= 32 ? compareUshort2 : compareUshort2LargeSIMD);
-    exclusionTiles = OpenCLArray::create<mm_ushort2>(context, exclusionTilesVec.size(), "exclusionTiles");
-    exclusionTiles->upload(exclusionTilesVec);
+    exclusionTiles.initialize<mm_ushort2>(context, exclusionTilesVec.size(), "exclusionTiles");
+    exclusionTiles.upload(exclusionTilesVec);
     map<pair<int, int>, int> exclusionTileMap;
     for (int i = 0; i < (int) exclusionTilesVec.size(); i++) {
         mm_ushort2 tile = exclusionTilesVec[i];
@@ -268,17 +238,17 @@ void OpenCLNonbondedUtilities::initialize(const System& system) {
     maxExclusions = 0;
     for (int i = 0; i < (int) exclusionBlocksForBlock.size(); i++)
         maxExclusions = (maxExclusions > exclusionBlocksForBlock[i].size() ? maxExclusions : exclusionBlocksForBlock[i].size());
-    exclusionIndices = OpenCLArray::create<cl_uint>(context, exclusionIndicesVec.size(), "exclusionIndices");
-    exclusionRowIndices = OpenCLArray::create<cl_uint>(context, exclusionRowIndicesVec.size(), "exclusionRowIndices");
-    exclusionIndices->upload(exclusionIndicesVec);
-    exclusionRowIndices->upload(exclusionRowIndicesVec);
+    exclusionIndices.initialize<cl_uint>(context, exclusionIndicesVec.size(), "exclusionIndices");
+    exclusionRowIndices.initialize<cl_uint>(context, exclusionRowIndicesVec.size(), "exclusionRowIndices");
+    exclusionIndices.upload(exclusionIndicesVec);
+    exclusionRowIndices.upload(exclusionRowIndicesVec);
 
     // Record the exclusion data.
 
-    exclusions = OpenCLArray::create<cl_uint>(context, tilesWithExclusions.size()*OpenCLContext::TileSize, "exclusions");
+    exclusions.initialize<cl_uint>(context, tilesWithExclusions.size()*OpenCLContext::TileSize, "exclusions");
     cl_uint allFlags = (cl_uint) -1;
-    vector<cl_uint> exclusionVec(exclusions->getSize(), allFlags);
-    for (int i = 0; i < exclusions->getSize(); ++i)
+    vector<cl_uint> exclusionVec(exclusions.getSize(), allFlags);
+    for (int i = 0; i < exclusions.getSize(); ++i)
         exclusionVec[i] = 0xFFFFFFFF;
     for (int atom1 = 0; atom1 < (int) atomExclusions.size(); ++atom1) {
         int x = atom1/OpenCLContext::TileSize;
@@ -298,7 +268,7 @@ void OpenCLNonbondedUtilities::initialize(const System& system) {
         }
     }
     atomExclusions.clear(); // We won't use this again, so free the memory it used
-    exclusions->upload(exclusionVec);
+    exclusions.upload(exclusionVec);
 
     // Create data structures for the neighbor list.
 
@@ -312,20 +282,20 @@ void OpenCLNonbondedUtilities::initialize(const System& system) {
         if (maxTiles < 1)
             maxTiles = 1;
         int numAtoms = context.getNumAtoms();
-        interactingTiles = OpenCLArray::create<cl_int>(context, maxTiles, "interactingTiles");
-        interactingAtoms = OpenCLArray::create<cl_int>(context, OpenCLContext::TileSize*maxTiles, "interactingAtoms");
-        interactionCount = OpenCLArray::create<cl_uint>(context, 1, "interactionCount");
+        interactingTiles.initialize<cl_int>(context, maxTiles, "interactingTiles");
+        interactingAtoms.initialize<cl_int>(context, OpenCLContext::TileSize*maxTiles, "interactingAtoms");
+        interactionCount.initialize<cl_uint>(context, 1, "interactionCount");
         int elementSize = (context.getUseDoublePrecision() ? sizeof(cl_double) : sizeof(cl_float));
-        blockCenter = new OpenCLArray(context, numAtomBlocks, 4*elementSize, "blockCenter");
-        blockBoundingBox = new OpenCLArray(context, numAtomBlocks, 4*elementSize, "blockBoundingBox");
-        sortedBlocks = new OpenCLArray(context, numAtomBlocks, 2*elementSize, "sortedBlocks");
-        sortedBlockCenter = new OpenCLArray(context, numAtomBlocks+1, 4*elementSize, "sortedBlockCenter");
-        sortedBlockBoundingBox = new OpenCLArray(context, numAtomBlocks+1, 4*elementSize, "sortedBlockBoundingBox");
-        oldPositions = new OpenCLArray(context, numAtoms, 4*elementSize, "oldPositions");
-        rebuildNeighborList = OpenCLArray::create<int>(context, 1, "rebuildNeighborList");
+        blockCenter.initialize(context, numAtomBlocks, 4*elementSize, "blockCenter");
+        blockBoundingBox.initialize(context, numAtomBlocks, 4*elementSize, "blockBoundingBox");
+        sortedBlocks.initialize(context, numAtomBlocks, 2*elementSize, "sortedBlocks");
+        sortedBlockCenter.initialize(context, numAtomBlocks+1, 4*elementSize, "sortedBlockCenter");
+        sortedBlockBoundingBox.initialize(context, numAtomBlocks+1, 4*elementSize, "sortedBlockBoundingBox");
+        oldPositions.initialize(context, numAtoms, 4*elementSize, "oldPositions");
+        rebuildNeighborList.initialize<int>(context, 1, "rebuildNeighborList");
         blockSorter = new OpenCLSort(context, new BlockSortTrait(context.getUseDoublePrecision()), numAtomBlocks);
         vector<cl_uint> count(1, 0);
-        interactionCount->upload(count);
+        interactionCount.upload(count);
     }
 }
 
@@ -376,14 +346,14 @@ void OpenCLNonbondedUtilities::prepareInteractions(int forceGroups) {
         forceRebuildNeighborList = true;
     setPeriodicBoxArgs(context, kernels.findBlockBoundsKernel, 1);
     context.executeKernel(kernels.findBlockBoundsKernel, context.getNumAtoms());
-    blockSorter->sort(*sortedBlocks);
+    blockSorter->sort(sortedBlocks);
     kernels.sortBoxDataKernel.setArg<cl_int>(9, forceRebuildNeighborList);
     context.executeKernel(kernels.sortBoxDataKernel, context.getNumAtoms());
     setPeriodicBoxArgs(context, kernels.findInteractingBlocksKernel, 0);
     context.executeKernel(kernels.findInteractingBlocksKernel, context.getNumAtoms(), interactingBlocksThreadBlockSize);
     forceRebuildNeighborList = false;
     lastCutoff = kernels.cutoffDistance;
-    context.getQueue().enqueueReadBuffer(interactionCount->getDeviceBuffer(), CL_FALSE, 0, sizeof(int), pinnedCountMemory, NULL, &downloadCountEvent); 
+    context.getQueue().enqueueReadBuffer(interactionCount.getDeviceBuffer(), CL_FALSE, 0, sizeof(int), pinnedCountMemory, NULL, &downloadCountEvent); 
 }
 
 void OpenCLNonbondedUtilities::computeInteractions(int forceGroups, bool includeForces, bool includeEnergy) {
@@ -407,7 +377,7 @@ void OpenCLNonbondedUtilities::computeInteractions(int forceGroups, bool include
 bool OpenCLNonbondedUtilities::updateNeighborListSize() {
     if (!useCutoff)
         return false;
-    if (pinnedCountMemory[0] <= (unsigned int) interactingTiles->getSize())
+    if (pinnedCountMemory[0] <= (unsigned int) interactingTiles.getSize())
         return false;
 
     // The most recent timestep had too many interactions to fit in the arrays.  Make the arrays bigger to prevent
@@ -417,31 +387,27 @@ bool OpenCLNonbondedUtilities::updateNeighborListSize() {
     int totalTiles = context.getNumAtomBlocks()*(context.getNumAtomBlocks()+1)/2;
     if (maxTiles > totalTiles)
         maxTiles = totalTiles;
-    delete interactingTiles;
-    delete interactingAtoms;
-    interactingTiles = NULL; // Avoid an error in the destructor if the following allocation fails
-    interactingAtoms = NULL;
-    interactingTiles = OpenCLArray::create<cl_int>(context, maxTiles, "interactingTiles");
-    interactingAtoms = OpenCLArray::create<cl_int>(context, OpenCLContext::TileSize*maxTiles, "interactingAtoms");
+    interactingTiles.resize(maxTiles);
+    interactingAtoms.resize(OpenCLContext::TileSize*maxTiles);
     for (map<int, KernelSet>::iterator iter = groupKernels.begin(); iter != groupKernels.end(); ++iter) {
         KernelSet& kernels = iter->second;
         if (*reinterpret_cast<cl_kernel*>(&kernels.forceKernel) != NULL) {
-            kernels.forceKernel.setArg<cl::Buffer>(7, interactingTiles->getDeviceBuffer());
+            kernels.forceKernel.setArg<cl::Buffer>(7, interactingTiles.getDeviceBuffer());
             kernels.forceKernel.setArg<cl_uint>(14, maxTiles);
-            kernels.forceKernel.setArg<cl::Buffer>(17, interactingAtoms->getDeviceBuffer());
+            kernels.forceKernel.setArg<cl::Buffer>(17, interactingAtoms.getDeviceBuffer());
         }
         if (*reinterpret_cast<cl_kernel*>(&kernels.energyKernel) != NULL) {
-            kernels.energyKernel.setArg<cl::Buffer>(7, interactingTiles->getDeviceBuffer());
+            kernels.energyKernel.setArg<cl::Buffer>(7, interactingTiles.getDeviceBuffer());
             kernels.energyKernel.setArg<cl_uint>(14, maxTiles);
-            kernels.energyKernel.setArg<cl::Buffer>(17, interactingAtoms->getDeviceBuffer());
+            kernels.energyKernel.setArg<cl::Buffer>(17, interactingAtoms.getDeviceBuffer());
         }
         if (*reinterpret_cast<cl_kernel*>(&kernels.forceEnergyKernel) != NULL) {
-            kernels.forceEnergyKernel.setArg<cl::Buffer>(7, interactingTiles->getDeviceBuffer());
+            kernels.forceEnergyKernel.setArg<cl::Buffer>(7, interactingTiles.getDeviceBuffer());
             kernels.forceEnergyKernel.setArg<cl_uint>(14, maxTiles);
-            kernels.forceEnergyKernel.setArg<cl::Buffer>(17, interactingAtoms->getDeviceBuffer());
+            kernels.forceEnergyKernel.setArg<cl::Buffer>(17, interactingAtoms.getDeviceBuffer());
         }
-        kernels.findInteractingBlocksKernel.setArg<cl::Buffer>(6, interactingTiles->getDeviceBuffer());
-        kernels.findInteractingBlocksKernel.setArg<cl::Buffer>(7, interactingAtoms->getDeviceBuffer());
+        kernels.findInteractingBlocksKernel.setArg<cl::Buffer>(6, interactingTiles.getDeviceBuffer());
+        kernels.findInteractingBlocksKernel.setArg<cl::Buffer>(7, interactingAtoms.getDeviceBuffer());
         kernels.findInteractingBlocksKernel.setArg<cl_uint>(9, maxTiles);
     }
     forceRebuildNeighborList = true;
@@ -506,7 +472,7 @@ void OpenCLNonbondedUtilities::createKernelsForGroups(int groups) {
         defines["PADDING"] = context.doubleToString(padding);
         defines["PADDED_CUTOFF"] = context.doubleToString(paddedCutoff);
         defines["PADDED_CUTOFF_SQUARED"] = context.doubleToString(paddedCutoff*paddedCutoff);
-        defines["NUM_TILES_WITH_EXCLUSIONS"] = context.intToString(exclusionTiles->getSize());
+        defines["NUM_TILES_WITH_EXCLUSIONS"] = context.intToString(exclusionTiles.getSize());
         defines["NUM_BLOCKS"] = context.intToString(context.getNumAtomBlocks());
         defines["SIMD_WIDTH"] = context.intToString(context.getSIMDWidth());
         if (usePeriodic)
@@ -523,36 +489,36 @@ void OpenCLNonbondedUtilities::createKernelsForGroups(int groups) {
             kernels.findBlockBoundsKernel = cl::Kernel(interactingBlocksProgram, "findBlockBounds");
             kernels.findBlockBoundsKernel.setArg<cl_int>(0, context.getNumAtoms());
             kernels.findBlockBoundsKernel.setArg<cl::Buffer>(6, context.getPosq().getDeviceBuffer());
-            kernels.findBlockBoundsKernel.setArg<cl::Buffer>(7, blockCenter->getDeviceBuffer());
-            kernels.findBlockBoundsKernel.setArg<cl::Buffer>(8, blockBoundingBox->getDeviceBuffer());
-            kernels.findBlockBoundsKernel.setArg<cl::Buffer>(9, rebuildNeighborList->getDeviceBuffer());
-            kernels.findBlockBoundsKernel.setArg<cl::Buffer>(10, sortedBlocks->getDeviceBuffer());
+            kernels.findBlockBoundsKernel.setArg<cl::Buffer>(7, blockCenter.getDeviceBuffer());
+            kernels.findBlockBoundsKernel.setArg<cl::Buffer>(8, blockBoundingBox.getDeviceBuffer());
+            kernels.findBlockBoundsKernel.setArg<cl::Buffer>(9, rebuildNeighborList.getDeviceBuffer());
+            kernels.findBlockBoundsKernel.setArg<cl::Buffer>(10, sortedBlocks.getDeviceBuffer());
             kernels.sortBoxDataKernel = cl::Kernel(interactingBlocksProgram, "sortBoxData");
-            kernels.sortBoxDataKernel.setArg<cl::Buffer>(0, sortedBlocks->getDeviceBuffer());
-            kernels.sortBoxDataKernel.setArg<cl::Buffer>(1, blockCenter->getDeviceBuffer());
-            kernels.sortBoxDataKernel.setArg<cl::Buffer>(2, blockBoundingBox->getDeviceBuffer());
-            kernels.sortBoxDataKernel.setArg<cl::Buffer>(3, sortedBlockCenter->getDeviceBuffer());
-            kernels.sortBoxDataKernel.setArg<cl::Buffer>(4, sortedBlockBoundingBox->getDeviceBuffer());
+            kernels.sortBoxDataKernel.setArg<cl::Buffer>(0, sortedBlocks.getDeviceBuffer());
+            kernels.sortBoxDataKernel.setArg<cl::Buffer>(1, blockCenter.getDeviceBuffer());
+            kernels.sortBoxDataKernel.setArg<cl::Buffer>(2, blockBoundingBox.getDeviceBuffer());
+            kernels.sortBoxDataKernel.setArg<cl::Buffer>(3, sortedBlockCenter.getDeviceBuffer());
+            kernels.sortBoxDataKernel.setArg<cl::Buffer>(4, sortedBlockBoundingBox.getDeviceBuffer());
             kernels.sortBoxDataKernel.setArg<cl::Buffer>(5, context.getPosq().getDeviceBuffer());
-            kernels.sortBoxDataKernel.setArg<cl::Buffer>(6, oldPositions->getDeviceBuffer());
-            kernels.sortBoxDataKernel.setArg<cl::Buffer>(7, interactionCount->getDeviceBuffer());
-            kernels.sortBoxDataKernel.setArg<cl::Buffer>(8, rebuildNeighborList->getDeviceBuffer());
+            kernels.sortBoxDataKernel.setArg<cl::Buffer>(6, oldPositions.getDeviceBuffer());
+            kernels.sortBoxDataKernel.setArg<cl::Buffer>(7, interactionCount.getDeviceBuffer());
+            kernels.sortBoxDataKernel.setArg<cl::Buffer>(8, rebuildNeighborList.getDeviceBuffer());
             kernels.sortBoxDataKernel.setArg<cl_int>(9, true);
             kernels.findInteractingBlocksKernel = cl::Kernel(interactingBlocksProgram, "findBlocksWithInteractions");
-            kernels.findInteractingBlocksKernel.setArg<cl::Buffer>(5, interactionCount->getDeviceBuffer());
-            kernels.findInteractingBlocksKernel.setArg<cl::Buffer>(6, interactingTiles->getDeviceBuffer());
-            kernels.findInteractingBlocksKernel.setArg<cl::Buffer>(7, interactingAtoms->getDeviceBuffer());
+            kernels.findInteractingBlocksKernel.setArg<cl::Buffer>(5, interactionCount.getDeviceBuffer());
+            kernels.findInteractingBlocksKernel.setArg<cl::Buffer>(6, interactingTiles.getDeviceBuffer());
+            kernels.findInteractingBlocksKernel.setArg<cl::Buffer>(7, interactingAtoms.getDeviceBuffer());
             kernels.findInteractingBlocksKernel.setArg<cl::Buffer>(8, context.getPosq().getDeviceBuffer());
-            kernels.findInteractingBlocksKernel.setArg<cl_uint>(9, interactingTiles->getSize());
+            kernels.findInteractingBlocksKernel.setArg<cl_uint>(9, interactingTiles.getSize());
             kernels.findInteractingBlocksKernel.setArg<cl_uint>(10, startBlockIndex);
             kernels.findInteractingBlocksKernel.setArg<cl_uint>(11, numBlocks);
-            kernels.findInteractingBlocksKernel.setArg<cl::Buffer>(12, sortedBlocks->getDeviceBuffer());
-            kernels.findInteractingBlocksKernel.setArg<cl::Buffer>(13, sortedBlockCenter->getDeviceBuffer());
-            kernels.findInteractingBlocksKernel.setArg<cl::Buffer>(14, sortedBlockBoundingBox->getDeviceBuffer());
-            kernels.findInteractingBlocksKernel.setArg<cl::Buffer>(15, exclusionIndices->getDeviceBuffer());
-            kernels.findInteractingBlocksKernel.setArg<cl::Buffer>(16, exclusionRowIndices->getDeviceBuffer());
-            kernels.findInteractingBlocksKernel.setArg<cl::Buffer>(17, oldPositions->getDeviceBuffer());
-            kernels.findInteractingBlocksKernel.setArg<cl::Buffer>(18, rebuildNeighborList->getDeviceBuffer());
+            kernels.findInteractingBlocksKernel.setArg<cl::Buffer>(12, sortedBlocks.getDeviceBuffer());
+            kernels.findInteractingBlocksKernel.setArg<cl::Buffer>(13, sortedBlockCenter.getDeviceBuffer());
+            kernels.findInteractingBlocksKernel.setArg<cl::Buffer>(14, sortedBlockBoundingBox.getDeviceBuffer());
+            kernels.findInteractingBlocksKernel.setArg<cl::Buffer>(15, exclusionIndices.getDeviceBuffer());
+            kernels.findInteractingBlocksKernel.setArg<cl::Buffer>(16, exclusionRowIndices.getDeviceBuffer());
+            kernels.findInteractingBlocksKernel.setArg<cl::Buffer>(17, oldPositions.getDeviceBuffer());
+            kernels.findInteractingBlocksKernel.setArg<cl::Buffer>(18, rebuildNeighborList.getDeviceBuffer());
             if (kernels.findInteractingBlocksKernel.getWorkGroupInfo<CL_KERNEL_WORK_GROUP_SIZE>(context.getDevice()) < groupSize) {
                 // The device can't handle this block size, so reduce it.
 
@@ -700,7 +666,7 @@ cl::Kernel OpenCLNonbondedUtilities::createInteractionKernel(const string& sourc
     defines["PADDED_NUM_ATOMS"] = context.intToString(context.getPaddedNumAtoms());
     defines["NUM_BLOCKS"] = context.intToString(context.getNumAtomBlocks());
     defines["TILE_SIZE"] = context.intToString(OpenCLContext::TileSize);
-    int numExclusionTiles = exclusionTiles->getSize();
+    int numExclusionTiles = exclusionTiles.getSize();
     defines["NUM_TILES_WITH_EXCLUSIONS"] = context.intToString(numExclusionTiles);
     int numContexts = context.getPlatformData().contexts.size();
     int startExclusionIndex = context.getContextIndex()*numExclusionTiles/numContexts;
@@ -726,18 +692,18 @@ cl::Kernel OpenCLNonbondedUtilities::createInteractionKernel(const string& sourc
         kernel.setArg<cl::Buffer>(index++, context.getForceBuffers().getDeviceBuffer());
     kernel.setArg<cl::Buffer>(index++, context.getEnergyBuffer().getDeviceBuffer());
     kernel.setArg<cl::Buffer>(index++, context.getPosq().getDeviceBuffer());
-    kernel.setArg<cl::Buffer>(index++, exclusions->getDeviceBuffer());
-    kernel.setArg<cl::Buffer>(index++, exclusionTiles->getDeviceBuffer());
+    kernel.setArg<cl::Buffer>(index++, exclusions.getDeviceBuffer());
+    kernel.setArg<cl::Buffer>(index++, exclusionTiles.getDeviceBuffer());
     kernel.setArg<cl_uint>(index++, startTileIndex);
     kernel.setArg<cl_uint>(index++, numTiles);
     if (useCutoff) {
-        kernel.setArg<cl::Buffer>(index++, interactingTiles->getDeviceBuffer());
-        kernel.setArg<cl::Buffer>(index++, interactionCount->getDeviceBuffer());
+        kernel.setArg<cl::Buffer>(index++, interactingTiles.getDeviceBuffer());
+        kernel.setArg<cl::Buffer>(index++, interactionCount.getDeviceBuffer());
         index += 5; // The periodic box size arguments are set when the kernel is executed.
-        kernel.setArg<cl_uint>(index++, interactingTiles->getSize());
-        kernel.setArg<cl::Buffer>(index++, blockCenter->getDeviceBuffer());
-        kernel.setArg<cl::Buffer>(index++, blockBoundingBox->getDeviceBuffer());
-        kernel.setArg<cl::Buffer>(index++, interactingAtoms->getDeviceBuffer());
+        kernel.setArg<cl_uint>(index++, interactingTiles.getSize());
+        kernel.setArg<cl::Buffer>(index++, blockCenter.getDeviceBuffer());
+        kernel.setArg<cl::Buffer>(index++, blockBoundingBox.getDeviceBuffer());
+        kernel.setArg<cl::Buffer>(index++, interactingAtoms.getDeviceBuffer());
     }
     for (int i = 0; i < (int) params.size(); i++) {
         kernel.setArg<cl::Memory>(index++, params[i].getMemory());

--- a/platforms/opencl/src/OpenCLSort.cpp
+++ b/platforms/opencl/src/OpenCLSort.cpp
@@ -31,8 +31,7 @@
 using namespace OpenMM;
 using namespace std;
 
-OpenCLSort::OpenCLSort(OpenCLContext& context, SortTrait* trait, unsigned int length) : context(context), trait(trait),
-            dataRange(NULL), bucketOfElement(NULL), offsetInBucket(NULL), bucketOffset(NULL), buckets(NULL), dataLength(length) {
+OpenCLSort::OpenCLSort(OpenCLContext& context, SortTrait* trait, unsigned int length) : context(context), trait(trait), dataLength(length) {
     // Create kernels.
 
     std::map<std::string, std::string> replacements;
@@ -81,26 +80,16 @@ OpenCLSort::OpenCLSort(OpenCLContext& context, SortTrait* trait, unsigned int le
     // Create workspace arrays.
 
     if (!isShortList) {
-        dataRange = new OpenCLArray(context, 2, trait->getKeySize(), "sortDataRange");
-        bucketOffset = OpenCLArray::create<cl_uint>(context, numBuckets, "bucketOffset");
-        bucketOfElement = OpenCLArray::create<cl_uint>(context, length, "bucketOfElement");
-        offsetInBucket = OpenCLArray::create<cl_uint>(context, length, "offsetInBucket");
-        buckets = new OpenCLArray(context, length, trait->getDataSize(), "buckets");
+        dataRange.initialize(context, 2, trait->getKeySize(), "sortDataRange");
+        bucketOffset.initialize<cl_uint>(context, numBuckets, "bucketOffset");
+        bucketOfElement.initialize<cl_uint>(context, length, "bucketOfElement");
+        offsetInBucket.initialize<cl_uint>(context, length, "offsetInBucket");
+        buckets.initialize(context, length, trait->getDataSize(), "buckets");
     }
 }
 
 OpenCLSort::~OpenCLSort() {
     delete trait;
-    if (dataRange != NULL)
-        delete dataRange;
-    if (bucketOfElement != NULL)
-        delete bucketOfElement;
-    if (offsetInBucket != NULL)
-        delete offsetInBucket;
-    if (bucketOffset != NULL)
-        delete bucketOffset;
-    if (buckets != NULL)
-        delete buckets;
 }
 
 void OpenCLSort::sort(OpenCLArray& data) {
@@ -119,14 +108,14 @@ void OpenCLSort::sort(OpenCLArray& data) {
     else {
         // Compute the range of data values.
 
-        unsigned int numBuckets = bucketOffset->getSize();
+        unsigned int numBuckets = bucketOffset.getSize();
         computeRangeKernel.setArg<cl::Buffer>(0, data.getDeviceBuffer());
         computeRangeKernel.setArg<cl_uint>(1, data.getSize());
-        computeRangeKernel.setArg<cl::Buffer>(2, dataRange->getDeviceBuffer());
+        computeRangeKernel.setArg<cl::Buffer>(2, dataRange.getDeviceBuffer());
         computeRangeKernel.setArg(3, rangeKernelSize*trait->getKeySize(), NULL);
         computeRangeKernel.setArg(4, rangeKernelSize*trait->getKeySize(), NULL);
         computeRangeKernel.setArg<cl_int>(5, numBuckets);
-        computeRangeKernel.setArg<cl::Buffer>(6, bucketOffset->getDeviceBuffer());
+        computeRangeKernel.setArg<cl::Buffer>(6, bucketOffset.getDeviceBuffer());
         context.executeKernel(computeRangeKernel, rangeKernelSize, rangeKernelSize);
 
         // Assign array elements to buckets.
@@ -134,35 +123,35 @@ void OpenCLSort::sort(OpenCLArray& data) {
         assignElementsKernel.setArg<cl::Buffer>(0, data.getDeviceBuffer());
         assignElementsKernel.setArg<cl_int>(1, data.getSize());
         assignElementsKernel.setArg<cl_int>(2, numBuckets);
-        assignElementsKernel.setArg<cl::Buffer>(3, dataRange->getDeviceBuffer());
-        assignElementsKernel.setArg<cl::Buffer>(4, bucketOffset->getDeviceBuffer());
-        assignElementsKernel.setArg<cl::Buffer>(5, bucketOfElement->getDeviceBuffer());
-        assignElementsKernel.setArg<cl::Buffer>(6, offsetInBucket->getDeviceBuffer());
+        assignElementsKernel.setArg<cl::Buffer>(3, dataRange.getDeviceBuffer());
+        assignElementsKernel.setArg<cl::Buffer>(4, bucketOffset.getDeviceBuffer());
+        assignElementsKernel.setArg<cl::Buffer>(5, bucketOfElement.getDeviceBuffer());
+        assignElementsKernel.setArg<cl::Buffer>(6, offsetInBucket.getDeviceBuffer());
         context.executeKernel(assignElementsKernel, data.getSize());
 
         // Compute the position of each bucket.
 
         computeBucketPositionsKernel.setArg<cl_int>(0, numBuckets);
-        computeBucketPositionsKernel.setArg<cl::Buffer>(1, bucketOffset->getDeviceBuffer());
+        computeBucketPositionsKernel.setArg<cl::Buffer>(1, bucketOffset.getDeviceBuffer());
         computeBucketPositionsKernel.setArg(2, positionsKernelSize*sizeof(cl_int), NULL);
         context.executeKernel(computeBucketPositionsKernel, positionsKernelSize, positionsKernelSize);
 
         // Copy the data into the buckets.
 
         copyToBucketsKernel.setArg<cl::Buffer>(0, data.getDeviceBuffer());
-        copyToBucketsKernel.setArg<cl::Buffer>(1, buckets->getDeviceBuffer());
+        copyToBucketsKernel.setArg<cl::Buffer>(1, buckets.getDeviceBuffer());
         copyToBucketsKernel.setArg<cl_int>(2, data.getSize());
-        copyToBucketsKernel.setArg<cl::Buffer>(3, bucketOffset->getDeviceBuffer());
-        copyToBucketsKernel.setArg<cl::Buffer>(4, bucketOfElement->getDeviceBuffer());
-        copyToBucketsKernel.setArg<cl::Buffer>(5, offsetInBucket->getDeviceBuffer());
+        copyToBucketsKernel.setArg<cl::Buffer>(3, bucketOffset.getDeviceBuffer());
+        copyToBucketsKernel.setArg<cl::Buffer>(4, bucketOfElement.getDeviceBuffer());
+        copyToBucketsKernel.setArg<cl::Buffer>(5, offsetInBucket.getDeviceBuffer());
         context.executeKernel(copyToBucketsKernel, data.getSize());
 
         // Sort each bucket.
 
         sortBucketsKernel.setArg<cl::Buffer>(0, data.getDeviceBuffer());
-        sortBucketsKernel.setArg<cl::Buffer>(1, buckets->getDeviceBuffer());
+        sortBucketsKernel.setArg<cl::Buffer>(1, buckets.getDeviceBuffer());
         sortBucketsKernel.setArg<cl_int>(2, numBuckets);
-        sortBucketsKernel.setArg<cl::Buffer>(3, bucketOffset->getDeviceBuffer());
+        sortBucketsKernel.setArg<cl::Buffer>(3, bucketOffset.getDeviceBuffer());
         sortBucketsKernel.setArg(4, sortKernelSize*trait->getDataSize(), NULL);
         context.executeKernel(sortBucketsKernel, ((data.getSize()+sortKernelSize-1)/sortKernelSize)*sortKernelSize, sortKernelSize);
     }

--- a/platforms/opencl/src/OpenCLSort.cpp
+++ b/platforms/opencl/src/OpenCLSort.cpp
@@ -26,6 +26,7 @@
 
 #include "OpenCLSort.h"
 #include "OpenCLKernelSources.h"
+#include <algorithm>
 #include <map>
 
 using namespace OpenMM;

--- a/platforms/opencl/src/OpenCLSort.cpp
+++ b/platforms/opencl/src/OpenCLSort.cpp
@@ -24,6 +24,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.      *
  * -------------------------------------------------------------------------- */
 
+#ifdef _MSC_VER
+    // Prevent Windows from defining macros that interfere with other code.
+    #define NOMINMAX
+#endif
 #include "OpenCLSort.h"
 #include "OpenCLKernelSources.h"
 #include <algorithm>

--- a/plugins/amoeba/platforms/cuda/src/AmoebaCudaKernels.h
+++ b/plugins/amoeba/platforms/cuda/src/AmoebaCudaKernels.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2008-2015 Stanford University and the Authors.      *
+ * Portions copyright (c) 2008-2018 Stanford University and the Authors.      *
  * Authors: Mark Friedrichs, Peter Eastman                                    *
  * Contributors:                                                              *
  *                                                                            *
@@ -48,7 +48,6 @@ public:
                                           const Platform& platform,
                                           CudaContext& cu,
                                           const System& system);
-    ~CudaCalcAmoebaBondForceKernel();
     /**
      * Initialize the kernel.
      * 
@@ -77,7 +76,7 @@ private:
     int numBonds;
     CudaContext& cu;
     const System& system;
-    CudaArray* params;
+    CudaArray params;
 };
 
 /**
@@ -86,7 +85,6 @@ private:
 class CudaCalcAmoebaAngleForceKernel : public CalcAmoebaAngleForceKernel {
 public:
     CudaCalcAmoebaAngleForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system);
-    ~CudaCalcAmoebaAngleForceKernel();
     /**
      * Initialize the kernel.
      * 
@@ -115,7 +113,7 @@ private:
     int numAngles;
     CudaContext& cu;
     const System& system;
-    CudaArray* params;
+    CudaArray params;
 };
 
 /**
@@ -124,7 +122,6 @@ private:
 class CudaCalcAmoebaInPlaneAngleForceKernel : public CalcAmoebaInPlaneAngleForceKernel {
 public:
     CudaCalcAmoebaInPlaneAngleForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system);
-    ~CudaCalcAmoebaInPlaneAngleForceKernel();
     /**
      * Initialize the kernel.
      * 
@@ -153,7 +150,7 @@ private:
     int numAngles;
     CudaContext& cu;
     const System& system;
-    CudaArray* params;
+    CudaArray params;
 };
 
 /**
@@ -162,7 +159,6 @@ private:
 class CudaCalcAmoebaPiTorsionForceKernel : public CalcAmoebaPiTorsionForceKernel {
 public:
     CudaCalcAmoebaPiTorsionForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system);
-    ~CudaCalcAmoebaPiTorsionForceKernel();
     /**
      * Initialize the kernel.
      * 
@@ -191,7 +187,7 @@ private:
     int numPiTorsions;
     CudaContext& cu;
     const System& system;
-    CudaArray* params;
+    CudaArray params;
 };
 
 /**
@@ -200,7 +196,6 @@ private:
 class CudaCalcAmoebaStretchBendForceKernel : public CalcAmoebaStretchBendForceKernel {
 public:
     CudaCalcAmoebaStretchBendForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system);
-    ~CudaCalcAmoebaStretchBendForceKernel();
     /**
      * Initialize the kernel.
      * 
@@ -229,8 +224,8 @@ private:
     int numStretchBends;
     CudaContext& cu;
     const System& system;
-    CudaArray* params1; // Equilibrium values
-    CudaArray* params2; // force constants
+    CudaArray params1; // Equilibrium values
+    CudaArray params2; // force constants
 };
 
 /**
@@ -239,7 +234,6 @@ private:
 class CudaCalcAmoebaOutOfPlaneBendForceKernel : public CalcAmoebaOutOfPlaneBendForceKernel {
 public:
     CudaCalcAmoebaOutOfPlaneBendForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system);
-    ~CudaCalcAmoebaOutOfPlaneBendForceKernel();
     /**
      * Initialize the kernel.
      * 
@@ -268,7 +262,7 @@ private:
     int numOutOfPlaneBends;
     CudaContext& cu;
     const System& system;
-    CudaArray* params;
+    CudaArray params;
 };
 
 /**
@@ -277,7 +271,6 @@ private:
 class CudaCalcAmoebaTorsionTorsionForceKernel : public CalcAmoebaTorsionTorsionForceKernel {
 public:
     CudaCalcAmoebaTorsionTorsionForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system);
-    ~CudaCalcAmoebaTorsionTorsionForceKernel();
     /**
      * Initialize the kernel.
      * 
@@ -300,9 +293,9 @@ private:
     int numTorsionTorsionGrids;
     CudaContext& cu;
     const System& system;
-    CudaArray* gridValues;
-    CudaArray* gridParams;
-    CudaArray* torsionParams;
+    CudaArray gridValues;
+    CudaArray gridParams;
+    CudaArray torsionParams;
 };
 
 /**
@@ -414,58 +407,58 @@ private:
     const System& system;
     std::vector<int3> covalentFlagValues;
     std::vector<int2> polarizationFlagValues;
-    CudaArray* multipoleParticles;
-    CudaArray* molecularDipoles;
-    CudaArray* molecularQuadrupoles;
-    CudaArray* labFrameDipoles;
-    CudaArray* labFrameQuadrupoles;
-    CudaArray* sphericalDipoles;
-    CudaArray* sphericalQuadrupoles;
-    CudaArray* fracDipoles;
-    CudaArray* fracQuadrupoles;
-    CudaArray* field;
-    CudaArray* fieldPolar;
-    CudaArray* inducedField;
-    CudaArray* inducedFieldPolar;
-    CudaArray* torque;
-    CudaArray* dampingAndThole;
-    CudaArray* inducedDipole;
-    CudaArray* inducedDipolePolar;
-    CudaArray* inducedDipoleErrors;
-    CudaArray* prevDipoles;
-    CudaArray* prevDipolesPolar;
-    CudaArray* prevDipolesGk;
-    CudaArray* prevDipolesGkPolar;
-    CudaArray* prevErrors;
-    CudaArray* diisMatrix;
-    CudaArray* diisCoefficients;
-    CudaArray* extrapolatedDipole;
-    CudaArray* extrapolatedDipolePolar;
-    CudaArray* extrapolatedDipoleGk;
-    CudaArray* extrapolatedDipoleGkPolar;
-    CudaArray* inducedDipoleFieldGradient;
-    CudaArray* inducedDipoleFieldGradientPolar;
-    CudaArray* inducedDipoleFieldGradientGk;
-    CudaArray* inducedDipoleFieldGradientGkPolar;
-    CudaArray* extrapolatedDipoleFieldGradient;
-    CudaArray* extrapolatedDipoleFieldGradientPolar;
-    CudaArray* extrapolatedDipoleFieldGradientGk;
-    CudaArray* extrapolatedDipoleFieldGradientGkPolar;
-    CudaArray* polarizability;
-    CudaArray* covalentFlags;
-    CudaArray* polarizationGroupFlags;
-    CudaArray* pmeGrid;
-    CudaArray* pmeBsplineModuliX;
-    CudaArray* pmeBsplineModuliY;
-    CudaArray* pmeBsplineModuliZ;
-    CudaArray* pmeIgrid;
-    CudaArray* pmePhi;
-    CudaArray* pmePhid;
-    CudaArray* pmePhip;
-    CudaArray* pmePhidp;
-    CudaArray* pmeCphi;
-    CudaArray* pmeAtomRange;
-    CudaArray* lastPositions;
+    CudaArray multipoleParticles;
+    CudaArray molecularDipoles;
+    CudaArray molecularQuadrupoles;
+    CudaArray labFrameDipoles;
+    CudaArray labFrameQuadrupoles;
+    CudaArray sphericalDipoles;
+    CudaArray sphericalQuadrupoles;
+    CudaArray fracDipoles;
+    CudaArray fracQuadrupoles;
+    CudaArray field;
+    CudaArray fieldPolar;
+    CudaArray inducedField;
+    CudaArray inducedFieldPolar;
+    CudaArray torque;
+    CudaArray dampingAndThole;
+    CudaArray inducedDipole;
+    CudaArray inducedDipolePolar;
+    CudaArray inducedDipoleErrors;
+    CudaArray prevDipoles;
+    CudaArray prevDipolesPolar;
+    CudaArray prevDipolesGk;
+    CudaArray prevDipolesGkPolar;
+    CudaArray prevErrors;
+    CudaArray diisMatrix;
+    CudaArray diisCoefficients;
+    CudaArray extrapolatedDipole;
+    CudaArray extrapolatedDipolePolar;
+    CudaArray extrapolatedDipoleGk;
+    CudaArray extrapolatedDipoleGkPolar;
+    CudaArray inducedDipoleFieldGradient;
+    CudaArray inducedDipoleFieldGradientPolar;
+    CudaArray inducedDipoleFieldGradientGk;
+    CudaArray inducedDipoleFieldGradientGkPolar;
+    CudaArray extrapolatedDipoleFieldGradient;
+    CudaArray extrapolatedDipoleFieldGradientPolar;
+    CudaArray extrapolatedDipoleFieldGradientGk;
+    CudaArray extrapolatedDipoleFieldGradientGkPolar;
+    CudaArray polarizability;
+    CudaArray covalentFlags;
+    CudaArray polarizationGroupFlags;
+    CudaArray pmeGrid;
+    CudaArray pmeBsplineModuliX;
+    CudaArray pmeBsplineModuliY;
+    CudaArray pmeBsplineModuliZ;
+    CudaArray pmeIgrid;
+    CudaArray pmePhi;
+    CudaArray pmePhid;
+    CudaArray pmePhip;
+    CudaArray pmePhidp;
+    CudaArray pmeCphi;
+    CudaArray pmeAtomRange;
+    CudaArray lastPositions;
     CudaSort* sort;
     cufftHandle fft;
     CUfunction computeMomentsKernel, recordInducedDipolesKernel, computeFixedFieldKernel, computeInducedFieldKernel, updateInducedFieldKernel, electrostaticsKernel, mapTorqueKernel;
@@ -486,7 +479,6 @@ private:
 class CudaCalcAmoebaGeneralizedKirkwoodForceKernel : public CalcAmoebaGeneralizedKirkwoodForceKernel {
 public:
     CudaCalcAmoebaGeneralizedKirkwoodForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system);
-    ~CudaCalcAmoebaGeneralizedKirkwoodForceKernel();
     /**
      * Initialize the kernel.
      * 
@@ -511,22 +503,22 @@ public:
      * Perform the final parts of the force/energy computation.
      */
     void finishComputation(CudaArray& torque, CudaArray& labFrameDipoles, CudaArray& labFrameQuadrupoles, CudaArray& inducedDipole, CudaArray& inducedDipolePolar, CudaArray& dampingAndThole, CudaArray& covalentFlags, CudaArray& polarizationGroupFlags);
-    CudaArray* getBornRadii() {
+    CudaArray& getBornRadii() {
         return bornRadii;
     }
-    CudaArray* getField() {
+    CudaArray& getField() {
         return field;
     }
-    CudaArray* getInducedField() {
+    CudaArray& getInducedField() {
         return inducedField;
     }
-    CudaArray* getInducedFieldPolar() {
+    CudaArray& getInducedFieldPolar() {
         return inducedFieldPolar;
     }
-    CudaArray* getInducedDipoles() {
+    CudaArray& getInducedDipoles() {
         return inducedDipoleS;
     }
-    CudaArray* getInducedDipolesPolar() {
+    CudaArray& getInducedDipolesPolar() {
         return inducedDipolePolarS;
     }
     /**
@@ -544,15 +536,15 @@ private:
     int computeBornSumThreads, gkForceThreads, chainRuleThreads, ediffThreads;
     AmoebaMultipoleForce::PolarizationType polarizationType;
     std::map<std::string, std::string> defines;
-    CudaArray* params;
-    CudaArray* bornSum;
-    CudaArray* bornRadii;
-    CudaArray* bornForce;
-    CudaArray* field;
-    CudaArray* inducedField;
-    CudaArray* inducedFieldPolar;
-    CudaArray* inducedDipoleS;
-    CudaArray* inducedDipolePolarS;
+    CudaArray params;
+    CudaArray bornSum;
+    CudaArray bornRadii;
+    CudaArray bornForce;
+    CudaArray field;
+    CudaArray inducedField;
+    CudaArray inducedFieldPolar;
+    CudaArray inducedDipoleS;
+    CudaArray inducedDipolePolarS;
     CUfunction computeBornSumKernel, reduceBornSumKernel, surfaceAreaKernel, gkForceKernel, chainRuleKernel, ediffKernel;
 };
 
@@ -592,11 +584,11 @@ private:
     const System& system;
     bool hasInitializedNonbonded;
     double dispersionCoefficient;
-    CudaArray* sigmaEpsilon;
-    CudaArray* bondReductionAtoms;
-    CudaArray* bondReductionFactors;
-    CudaArray* tempPosq;
-    CudaArray* tempForces;
+    CudaArray sigmaEpsilon;
+    CudaArray bondReductionAtoms;
+    CudaArray bondReductionFactors;
+    CudaArray tempPosq;
+    CudaArray tempForces;
     CudaNonbondedUtilities* nonbonded;
     CUfunction prepareKernel, spreadKernel;
 };
@@ -607,7 +599,6 @@ private:
 class CudaCalcAmoebaWcaDispersionForceKernel : public CalcAmoebaWcaDispersionForceKernel {
 public:
     CudaCalcAmoebaWcaDispersionForceKernel(std::string name, const Platform& platform, CudaContext& cu, const System& system);
-    ~CudaCalcAmoebaWcaDispersionForceKernel();
     /**
      * Initialize the kernel.
      * 
@@ -636,7 +627,7 @@ private:
     CudaContext& cu;
     const System& system;
     double totalMaximumDispersionEnergy;
-    CudaArray* radiusEpsilon;
+    CudaArray radiusEpsilon;
     CUfunction forceKernel;
 };
 

--- a/plugins/drude/platforms/cuda/src/CudaDrudeKernels.h
+++ b/plugins/drude/platforms/cuda/src/CudaDrudeKernels.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2013-2015 Stanford University and the Authors.      *
+ * Portions copyright (c) 2013-2018 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -45,9 +45,8 @@ namespace OpenMM {
 class CudaCalcDrudeForceKernel : public CalcDrudeForceKernel {
 public:
     CudaCalcDrudeForceKernel(std::string name, const Platform& platform, CudaContext& cu) :
-            CalcDrudeForceKernel(name, platform), cu(cu), particleParams(NULL), pairParams(NULL) {
+            CalcDrudeForceKernel(name, platform), cu(cu) {
     }
-    ~CudaCalcDrudeForceKernel();
     /**
      * Initialize the kernel.
      * 
@@ -73,8 +72,8 @@ public:
     void copyParametersToContext(ContextImpl& context, const DrudeForce& force);
 private:
     CudaContext& cu;
-    CudaArray* particleParams;
-    CudaArray* pairParams;
+    CudaArray particleParams;
+    CudaArray pairParams;
 };
 
 /**
@@ -83,9 +82,8 @@ private:
 class CudaIntegrateDrudeLangevinStepKernel : public IntegrateDrudeLangevinStepKernel {
 public:
     CudaIntegrateDrudeLangevinStepKernel(std::string name, const Platform& platform, CudaContext& cu) :
-            IntegrateDrudeLangevinStepKernel(name, platform), cu(cu), normalParticles(NULL), pairParticles(NULL) {
+            IntegrateDrudeLangevinStepKernel(name, platform), cu(cu) {
     }
-    ~CudaIntegrateDrudeLangevinStepKernel();
     /**
      * Initialize the kernel.
      *
@@ -111,8 +109,8 @@ public:
 private:
     CudaContext& cu;
     double prevStepSize;
-    CudaArray* normalParticles;
-    CudaArray* pairParticles;
+    CudaArray normalParticles;
+    CudaArray pairParticles;
     CUfunction kernel1, kernel2, hardwallKernel;
 };
 

--- a/plugins/drude/platforms/opencl/src/OpenCLDrudeKernels.cpp
+++ b/plugins/drude/platforms/opencl/src/OpenCLDrudeKernels.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2013-2015 Stanford University and the Authors.      *
+ * Portions copyright (c) 2013-2018 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -107,13 +107,6 @@ private:
     const DrudeForce& force;
 };
 
-OpenCLCalcDrudeForceKernel::~OpenCLCalcDrudeForceKernel() {
-    if (particleParams != NULL)
-        delete particleParams;
-    if (pairParams != NULL)
-        delete pairParams;
-}
-
 void OpenCLCalcDrudeForceKernel::initialize(const System& system, const DrudeForce& force) {
     int numContexts = cl.getPlatformData().contexts.size();
     int startParticleIndex = cl.getContextIndex()*force.getNumParticles()/numContexts;
@@ -123,7 +116,7 @@ void OpenCLCalcDrudeForceKernel::initialize(const System& system, const DrudeFor
         // Create the harmonic interaction .
         
         vector<vector<int> > atoms(numParticles, vector<int>(5));
-        particleParams = OpenCLArray::create<mm_float4>(cl, numParticles, "drudeParticleParams");
+        particleParams.initialize<mm_float4>(cl, numParticles, "drudeParticleParams");
         vector<mm_float4> paramVector(numParticles);
         for (int i = 0; i < numParticles; i++) {
             double charge, polarizability, aniso12, aniso34;
@@ -145,9 +138,9 @@ void OpenCLCalcDrudeForceKernel::initialize(const System& system, const DrudeFor
             }
             paramVector[i] = mm_float4((float) k1, (float) k2, (float) k3, 0.0f);
         }
-        particleParams->upload(paramVector);
+        particleParams.upload(paramVector);
         map<string, string> replacements;
-        replacements["PARAMS"] = cl.getBondedUtilities().addArgument(particleParams->getDeviceBuffer(), "float4");
+        replacements["PARAMS"] = cl.getBondedUtilities().addArgument(particleParams.getDeviceBuffer(), "float4");
         cl.getBondedUtilities().addInteraction(atoms, cl.replaceStrings(OpenCLDrudeKernelSources::drudeParticleForce, replacements), force.getForceGroup());
     }
     int startPairIndex = cl.getContextIndex()*force.getNumScreenedPairs()/numContexts;
@@ -157,7 +150,7 @@ void OpenCLCalcDrudeForceKernel::initialize(const System& system, const DrudeFor
         // Create the screened interaction between dipole pairs.
         
         vector<vector<int> > atoms(numPairs, vector<int>(4));
-        pairParams = OpenCLArray::create<mm_float2>(cl, numPairs, "drudePairParams");
+        pairParams.initialize<mm_float2>(cl, numPairs, "drudePairParams");
         vector<mm_float2> paramVector(numPairs);
         for (int i = 0; i < numPairs; i++) {
             int drude1, drude2;
@@ -171,9 +164,9 @@ void OpenCLCalcDrudeForceKernel::initialize(const System& system, const DrudeFor
             double energyScale = ONE_4PI_EPS0*charge1*charge2;
             paramVector[i] = mm_float2((float) screeningScale, (float) energyScale);
         }
-        pairParams->upload(paramVector);
+        pairParams.upload(paramVector);
         map<string, string> replacements;
-        replacements["PARAMS"] = cl.getBondedUtilities().addArgument(pairParams->getDeviceBuffer(), "float2");
+        replacements["PARAMS"] = cl.getBondedUtilities().addArgument(pairParams.getDeviceBuffer(), "float2");
         cl.getBondedUtilities().addInteraction(atoms, cl.replaceStrings(OpenCLDrudeKernelSources::drudePairForce, replacements), force.getForceGroup());
     }
     cl.addForce(new OpenCLDrudeForceInfo(force));
@@ -192,7 +185,7 @@ void OpenCLCalcDrudeForceKernel::copyParametersToContext(ContextImpl& context, c
     int endParticleIndex = (cl.getContextIndex()+1)*force.getNumParticles()/numContexts;
     int numParticles = endParticleIndex-startParticleIndex;
     if (numParticles > 0) {
-        if (particleParams == NULL || numParticles != particleParams->getSize())
+        if (!particleParams.isInitialized() || numParticles != particleParams.getSize())
             throw OpenMMException("updateParametersInContext: The number of Drude particles has changed");
         vector<mm_float4> paramVector(numParticles);
         for (int i = 0; i < numParticles; i++) {
@@ -211,7 +204,7 @@ void OpenCLCalcDrudeForceKernel::copyParametersToContext(ContextImpl& context, c
                 k2 = 0;
             paramVector[i] = mm_float4((float) k1, (float) k2, (float) k3, 0.0f);
         }
-        particleParams->upload(paramVector);
+        particleParams.upload(paramVector);
     }
     
     // Set the pair parameters.
@@ -220,7 +213,7 @@ void OpenCLCalcDrudeForceKernel::copyParametersToContext(ContextImpl& context, c
     int endPairIndex = (cl.getContextIndex()+1)*force.getNumScreenedPairs()/numContexts;
     int numPairs = endPairIndex-startPairIndex;
     if (numPairs > 0) {
-        if (pairParams == NULL || numPairs != pairParams->getSize())
+        if (!pairParams.isInitialized() || numPairs != pairParams.getSize())
             throw OpenMMException("updateParametersInContext: The number of screened pairs has changed");
         vector<mm_float2> paramVector(numPairs);
         for (int i = 0; i < numPairs; i++) {
@@ -235,15 +228,8 @@ void OpenCLCalcDrudeForceKernel::copyParametersToContext(ContextImpl& context, c
             double energyScale = ONE_4PI_EPS0*charge1*charge2;
             paramVector[i] = mm_float2((float) screeningScale, (float) energyScale);
         }
-        pairParams->upload(paramVector);
+        pairParams.upload(paramVector);
     }
-}
-
-OpenCLIntegrateDrudeLangevinStepKernel::~OpenCLIntegrateDrudeLangevinStepKernel() {
-    if (normalParticles != NULL)
-        delete normalParticles;
-    if (pairParticles != NULL)
-        delete pairParticles;
 }
 
 void OpenCLIntegrateDrudeLangevinStepKernel::initialize(const System& system, const DrudeLangevinIntegrator& integrator, const DrudeForce& force) {
@@ -266,12 +252,12 @@ void OpenCLIntegrateDrudeLangevinStepKernel::initialize(const System& system, co
         pairParticleVec.push_back(mm_int2(p, p1));
     }
     normalParticleVec.insert(normalParticleVec.begin(), particles.begin(), particles.end());
-    normalParticles = OpenCLArray::create<int>(cl, max((int) normalParticleVec.size(), 1), "drudeNormalParticles");
-    pairParticles = OpenCLArray::create<cl_int2>(cl, max((int) pairParticleVec.size(), 1), "drudePairParticles");
+    normalParticles.initialize<int>(cl, max((int) normalParticleVec.size(), 1), "drudeNormalParticles");
+    pairParticles.initialize<cl_int2>(cl, max((int) pairParticleVec.size(), 1), "drudePairParticles");
     if (normalParticleVec.size() > 0)
-        normalParticles->upload(normalParticleVec);
+        normalParticles.upload(normalParticleVec);
     if (pairParticleVec.size() > 0)
-        pairParticles->upload(pairParticleVec);
+        pairParticles.upload(pairParticleVec);
 
     // Create kernels.
     
@@ -296,8 +282,8 @@ void OpenCLIntegrateDrudeLangevinStepKernel::execute(ContextImpl& context, const
         kernel1.setArg<cl::Buffer>(0, cl.getVelm().getDeviceBuffer());
         kernel1.setArg<cl::Buffer>(1, cl.getForce().getDeviceBuffer());
         kernel1.setArg<cl::Buffer>(2, integration.getPosDelta().getDeviceBuffer());
-        kernel1.setArg<cl::Buffer>(3, normalParticles->getDeviceBuffer());
-        kernel1.setArg<cl::Buffer>(4, pairParticles->getDeviceBuffer());
+        kernel1.setArg<cl::Buffer>(3, normalParticles.getDeviceBuffer());
+        kernel1.setArg<cl::Buffer>(4, pairParticles.getDeviceBuffer());
         kernel1.setArg<cl::Buffer>(5, integration.getStepSize().getDeviceBuffer());
         kernel1.setArg<cl::Buffer>(12, integration.getRandom().getDeviceBuffer());
         kernel2.setArg<cl::Buffer>(0, cl.getPosq().getDeviceBuffer());
@@ -314,7 +300,7 @@ void OpenCLIntegrateDrudeLangevinStepKernel::execute(ContextImpl& context, const
         else
             hardwallKernel.setArg<void*>(1, NULL);
         hardwallKernel.setArg<cl::Buffer>(2, cl.getVelm().getDeviceBuffer());
-        hardwallKernel.setArg<cl::Buffer>(3, pairParticles->getDeviceBuffer());
+        hardwallKernel.setArg<cl::Buffer>(3, pairParticles.getDeviceBuffer());
         hardwallKernel.setArg<cl::Buffer>(4, integration.getStepSize().getDeviceBuffer());
     }
     
@@ -363,7 +349,7 @@ void OpenCLIntegrateDrudeLangevinStepKernel::execute(ContextImpl& context, const
 
     // Call the first integration kernel.
 
-    kernel1.setArg<cl_uint>(13, integration.prepareRandomNumbers(normalParticles->getSize()+2*pairParticles->getSize()));
+    kernel1.setArg<cl_uint>(13, integration.prepareRandomNumbers(normalParticles.getSize()+2*pairParticles.getSize()));
     cl.executeKernel(kernel1, numAtoms);
 
     // Apply constraints.
@@ -377,7 +363,7 @@ void OpenCLIntegrateDrudeLangevinStepKernel::execute(ContextImpl& context, const
     // Apply hard wall constraints.
     
     if (maxDrudeDistance > 0)
-        cl.executeKernel(hardwallKernel, pairParticles->getSize());
+        cl.executeKernel(hardwallKernel, pairParticles.getSize());
     integration.computeVirtualSites();
 
     // Update the time and step count.

--- a/plugins/drude/platforms/opencl/src/OpenCLDrudeKernels.h
+++ b/plugins/drude/platforms/opencl/src/OpenCLDrudeKernels.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2013-2015 Stanford University and the Authors.      *
+ * Portions copyright (c) 2013-2018 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -45,9 +45,8 @@ namespace OpenMM {
 class OpenCLCalcDrudeForceKernel : public CalcDrudeForceKernel {
 public:
     OpenCLCalcDrudeForceKernel(std::string name, const Platform& platform, OpenCLContext& cl) :
-            CalcDrudeForceKernel(name, platform), cl(cl), particleParams(NULL), pairParams(NULL) {
+            CalcDrudeForceKernel(name, platform), cl(cl) {
     }
-    ~OpenCLCalcDrudeForceKernel();
     /**
      * Initialize the kernel.
      * 
@@ -73,8 +72,8 @@ public:
     void copyParametersToContext(ContextImpl& context, const DrudeForce& force);
 private:
     OpenCLContext& cl;
-    OpenCLArray* particleParams;
-    OpenCLArray* pairParams;
+    OpenCLArray particleParams;
+    OpenCLArray pairParams;
 };
 
 /**
@@ -83,9 +82,8 @@ private:
 class OpenCLIntegrateDrudeLangevinStepKernel : public IntegrateDrudeLangevinStepKernel {
 public:
     OpenCLIntegrateDrudeLangevinStepKernel(std::string name, const Platform& platform, OpenCLContext& cl) :
-            IntegrateDrudeLangevinStepKernel(name, platform), cl(cl), hasInitializedKernels(false), normalParticles(NULL), pairParticles(NULL) {
+            IntegrateDrudeLangevinStepKernel(name, platform), cl(cl), hasInitializedKernels(false) {
     }
-    ~OpenCLIntegrateDrudeLangevinStepKernel();
     /**
      * Initialize the kernel.
      *
@@ -112,8 +110,8 @@ private:
     OpenCLContext& cl;
     bool hasInitializedKernels;
     double prevStepSize;
-    OpenCLArray* normalParticles;
-    OpenCLArray* pairParticles;
+    OpenCLArray normalParticles;
+    OpenCLArray pairParticles;
     cl::Kernel kernel1, kernel2, hardwallKernel;
 };
 

--- a/plugins/rpmd/platforms/cuda/src/CudaRpmdKernels.h
+++ b/plugins/rpmd/platforms/cuda/src/CudaRpmdKernels.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2011-2013 Stanford University and the Authors.      *
+ * Portions copyright (c) 2011-2018 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -46,9 +46,8 @@ namespace OpenMM {
 class CudaIntegrateRPMDStepKernel : public IntegrateRPMDStepKernel {
 public:
     CudaIntegrateRPMDStepKernel(std::string name, const Platform& platform, CudaContext& cu) :
-            IntegrateRPMDStepKernel(name, platform), cu(cu), forces(NULL), positions(NULL), velocities(NULL), contractedForces(NULL), contractedPositions(NULL) {
+            IntegrateRPMDStepKernel(name, platform), cu(cu) {
     }
-    ~CudaIntegrateRPMDStepKernel();
     /**
      * Initialize the kernel.
      *
@@ -91,11 +90,11 @@ private:
     int numCopies, numParticles, workgroupSize;
     std::map<int, int> groupsByCopies;
     int groupsNotContracted;
-    CudaArray* forces;
-    CudaArray* positions;
-    CudaArray* velocities;
-    CudaArray* contractedForces;
-    CudaArray* contractedPositions;
+    CudaArray forces;
+    CudaArray positions;
+    CudaArray velocities;
+    CudaArray contractedForces;
+    CudaArray contractedPositions;
     CUfunction pileKernel, stepKernel, velocitiesKernel, copyToContextKernel, copyFromContextKernel, translateKernel;
     std::map<int, CUfunction> positionContractionKernels;
     std::map<int, CUfunction> forceContractionKernels;

--- a/plugins/rpmd/platforms/opencl/src/OpenCLRpmdKernels.h
+++ b/plugins/rpmd/platforms/opencl/src/OpenCLRpmdKernels.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org.               *
  *                                                                            *
- * Portions copyright (c) 2011-2013 Stanford University and the Authors.      *
+ * Portions copyright (c) 2011-2018 Stanford University and the Authors.      *
  * Authors: Peter Eastman                                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -45,9 +45,8 @@ namespace OpenMM {
 class OpenCLIntegrateRPMDStepKernel : public IntegrateRPMDStepKernel {
 public:
     OpenCLIntegrateRPMDStepKernel(std::string name, const Platform& platform, OpenCLContext& cl) :
-            IntegrateRPMDStepKernel(name, platform), cl(cl), hasInitializedKernel(false), forces(NULL), positions(NULL), velocities(NULL), contractedForces(NULL), contractedPositions(NULL) {
+            IntegrateRPMDStepKernel(name, platform), cl(cl), hasInitializedKernel(false) {
     }
-    ~OpenCLIntegrateRPMDStepKernel();
     /**
      * Initialize the kernel.
      *
@@ -92,11 +91,11 @@ private:
     int numCopies, numParticles, workgroupSize;
     std::map<int, int> groupsByCopies;
     int groupsNotContracted;
-    OpenCLArray* forces;
-    OpenCLArray* positions;
-    OpenCLArray* velocities;
-    OpenCLArray* contractedForces;
-    OpenCLArray* contractedPositions;
+    OpenCLArray forces;
+    OpenCLArray positions;
+    OpenCLArray velocities;
+    OpenCLArray contractedForces;
+    OpenCLArray contractedPositions;
     cl::Kernel pileKernel, stepKernel, velocitiesKernel, copyToContextKernel, copyFromContextKernel, translateKernel;
     std::map<int, cl::Kernel> positionContractionKernels;
     std::map<int, cl::Kernel> forceContractionKernels;


### PR DESCRIPTION
This is an internal change that allows a lot of code to be simplified.  The CudaArray and OpenCLArray classes can be created in an uninitialized state then later initialized.  That means a class can just have an ordinary field of type OpenCLArray, and all the memory management is taken care of automatically.  Previously, the field needed to be pointer, which had to be initialized to NULL in the constructor, and then a destructor needed to delete any arrays that had been created.