### PR TITLE
Added switchDistance option to ForceField.createSystem()

### DIFF
--- a/docs-source/usersguide/application.rst
+++ b/docs-source/usersguide/application.rst
@@ -792,6 +792,16 @@ The error tolerance is roughly equal to the fractional error in the forces due
 to truncating the Ewald summation.  If you do not specify it, a default value of
 0.0005 is used.
 
+Another optional parameter when using a cutoff is :code:`switchDistance`.  This
+causes Lennard-Jones interactions to smoothly go to zero over some finite range,
+rather than being sharply truncated at the cutoff distance.  This can improve
+energy conservation.  To use it, specify a distance at which the interactions
+should start being reduced.  For example:
+::
+
+    system = prmtop.createSystem(nonbondedMethod=PME, nonbondedCutoff=1*nanometer,
+            switchDistance=0.9*nanometer)
+
 
 Nonbonded Forces for AMOEBA
 ---------------------------

--- a/wrappers/python/tests/TestForceField.py
+++ b/wrappers/python/tests/TestForceField.py
@@ -76,6 +76,21 @@ class TestForceField(unittest.TestCase):
                     cutoff_distance = force.getCutoffDistance()
             self.assertEqual(cutoff_distance, cutoff_check)
 
+    def test_SwitchingDistance(self):
+        """Test that the switchDistance parameter is processed correctly."""
+
+        for switchDistance in [None, 0.9*nanometers]:
+            system = self.forcefield1.createSystem(self.pdb1.topology,
+                                                   nonbondedMethod=PME,
+                                                   switchDistance=switchDistance)
+            for force in system.getForces():
+                if isinstance(force, NonbondedForce):
+                    if switchDistance is None:
+                        self.assertFalse(force.getUseSwitchingFunction())
+                    else:
+                        self.assertTrue(force.getUseSwitchingFunction())
+                        self.assertEqual(switchDistance, force.getSwitchingDistance())
+
     def test_RemoveCMMotion(self):
         """Test both options (True and False) for the removeCMMotion parameter."""
         for b in [True, False]:


### PR DESCRIPTION
Fixes #1994.

I debated about whether this should apply to `<CustomNonbondedForce>` tags.  It supports a switching function, but we have no way of knowing what kind of interaction it's being used for.  In the end I decided it was safest not to.  Just because you want a switching function on LJ interactions, that doesn't necessarily mean you also want it on all CustomNonbondedForces, no matter what purpose they're being used for.  So I made this option only apply to `<NonbondedForce>` and `<LennardJonesForce>` tags.