### PR TITLE
Regenerated files to fix missing external bonds

### DIFF
--- a/wrappers/python/simtk/openmm/app/data/amber14/protein.ff14SB.xml
+++ b/wrappers/python/simtk/openmm/app/data/amber14/protein.ff14SB.xml
@@ -1,7 +1,7 @@
 <ForceField>
   <Info>
-    <DateGenerated>2017-11-25</DateGenerated>
-    <Source Source="leaprc.protein.ff14SB" md5hash="2fbe80b999846068f2a1b6f3c50fcbb9" sourcePackage="AmberTools" sourcePackageVersion="17">leaprc.protein.ff14SB</Source>
+    <DateGenerated>2018-03-02</DateGenerated>
+    <Source Source="leaprc.protein.ff14SB" md5hash="2fbe80b999846068f2a1b6f3c50fcbb9" sourcePackage="AmberTools" sourcePackageVersion="17.6">leaprc.protein.ff14SB</Source>
     <Reference>Maier, J.A., Martinez, C., Kasavajhala, K., Wickstrom, L., Hauser, K.E., and Simmerling, C. (2015). ff14SB: Improving the Accuracy of Protein Side Chain and Backbone Parameters from ff99SB. J. Chem. Theory Comput. 11, 3696-3713.</Reference>
   </Info>
   <AtomTypes>
@@ -270,9 +270,9 @@
       <Bond atomName1="CB" atomName2="HB3"/>
       <Bond atomName1="CB" atomName2="SG"/>
       <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="SG"/>
       <ExternalBond atomName="N"/>
       <ExternalBond atomName="C"/>
-      <ExternalBond atomName="SG"/>
     </Residue>
     <Residue name="GLH">
       <Atom charge="-0.4157" name="N" type="protein-N"/>
@@ -1207,6 +1207,7 @@
       <Bond atomName1="CB" atomName2="SG"/>
       <Bond atomName1="C" atomName2="O"/>
       <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="SG"/>
       <ExternalBond atomName="N"/>
     </Residue>
     <Residue name="CGLN">
@@ -2128,6 +2129,7 @@
       <Bond atomName1="CB" atomName2="HB3"/>
       <Bond atomName1="CB" atomName2="SG"/>
       <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="SG"/>
       <ExternalBond atomName="C"/>
     </Residue>
     <Residue name="NGLN">

--- a/wrappers/python/simtk/openmm/app/data/amber14/protein.ff15ipq.xml
+++ b/wrappers/python/simtk/openmm/app/data/amber14/protein.ff15ipq.xml
@@ -1,4103 +1,4106 @@
 <ForceField>
- <Info>
-  <DateGenerated>2017-11-29</DateGenerated>
-  <Source md5hash="b7e40247370a8e75ff03a5c9b0c3368a" sourcePackage="AmberTools" sourcePackageVersion="17">leaprc.protein.ff15ipq</Source>
-  <Reference>Debiec, K.T.; Cerutti, D.S.; Baker, L.R.; Gronenborn, A.M.; Case, D.A.; Chong, L.T. Further along the Road Less Traveled: AMBER ff15ipq, an Original Protein Force Field Built on a Self-Consistent Physical Model. J. Chem. Theory Comput., 2016, 12, 3926–3947.</Reference>
- </Info>
- <AtomTypes>
-  <Type name="protein-C" class="C" element="C" mass="12.01"/>
-  <Type name="protein-CA" class="CA" element="C" mass="12.01"/>
-  <Type name="protein-CB" class="CB" element="C" mass="12.01"/>
-  <Type name="protein-CC" class="CC" element="C" mass="12.01"/>
-  <Type name="protein-CN" class="CN" element="C" mass="12.01"/>
-  <Type name="protein-CR" class="CR" element="C" mass="12.01"/>
-  <Type name="protein-CT" class="CT" element="C" mass="12.01"/>
-  <Type name="protein-CV" class="CV" element="C" mass="12.01"/>
-  <Type name="protein-CW" class="CW" element="C" mass="12.01"/>
-  <Type name="protein-C*" class="C*" element="C" mass="12.01"/>
-  <Type name="protein-CX" class="CX" element="C" mass="12.01"/>
-  <Type name="protein-H" class="H" element="H" mass="1.008"/>
-  <Type name="protein-HC" class="HC" element="H" mass="1.008"/>
-  <Type name="protein-H1" class="H1" element="H" mass="1.008"/>
-  <Type name="protein-HA" class="HA" element="H" mass="1.008"/>
-  <Type name="protein-H4" class="H4" element="H" mass="1.008"/>
-  <Type name="protein-H5" class="H5" element="H" mass="1.008"/>
-  <Type name="protein-HO" class="HO" element="H" mass="1.008"/>
-  <Type name="protein-HS" class="HS" element="H" mass="1.008"/>
-  <Type name="protein-HP" class="HP" element="H" mass="1.008"/>
-  <Type name="protein-N" class="N" element="N" mass="14.01"/>
-  <Type name="protein-NA" class="NA" element="N" mass="14.01"/>
-  <Type name="protein-NB" class="NB" element="N" mass="14.01"/>
-  <Type name="protein-N2" class="N2" element="N" mass="14.01"/>
-  <Type name="protein-N3" class="N3" element="N" mass="14.01"/>
-  <Type name="protein-O" class="O" element="O" mass="16.0"/>
-  <Type name="protein-OH" class="OH" element="O" mass="16.0"/>
-  <Type name="protein-S" class="S" element="S" mass="32.06"/>
-  <Type name="protein-SH" class="SH" element="S" mass="32.06"/>
-  <Type name="protein-CO" class="CO" element="C" mass="12.01"/>
-  <Type name="protein-2C" class="2C" element="C" mass="12.01"/>
-  <Type name="protein-3C" class="3C" element="C" mass="12.01"/>
-  <Type name="protein-C8" class="C8" element="C" mass="12.01"/>
-  <Type name="protein-O3" class="O3" element="O" mass="16.0"/>
-  <Type name="protein-OD" class="OD" element="O" mass="16.0"/>
-  <Type name="protein-ND" class="ND" element="N" mass="14.01"/>
-  <Type name="protein-OA" class="OA" element="O" mass="16.0"/>
-  <Type name="protein-NL" class="NL" element="N" mass="14.01"/>
-  <Type name="protein-TN" class="TN" element="N" mass="14.01"/>
-  <Type name="protein-TJ" class="TJ" element="C" mass="12.01"/>
-  <Type name="protein-TG" class="TG" element="C" mass="12.01"/>
-  <Type name="protein-TP" class="TP" element="C" mass="12.01"/>
-  <Type name="protein-TM" class="TM" element="C" mass="12.01"/>
-  <Type name="protein-TH" class="TH" element="H" mass="1.008"/>
-  <Type name="protein-TA" class="TA" element="C" mass="12.01"/>
- </AtomTypes>
- <Residues>
-  <Residue name="ALA">
-   <Atom name="N" type="protein-N" charge="-0.51112"/>
-   <Atom name="H" type="protein-H" charge="0.3201"/>
-   <Atom name="CA" type="protein-CX" charge="0.00527"/>
-   <Atom name="HA" type="protein-H1" charge="0.10041"/>
-   <Atom name="CB" type="protein-CT" charge="-0.18102"/>
-   <Atom name="HB1" type="protein-HC" charge="0.07225"/>
-   <Atom name="HB2" type="protein-HC" charge="0.07225"/>
-   <Atom name="HB3" type="protein-HC" charge="0.07225"/>
-   <Atom name="C" type="protein-C" charge="0.63952"/>
-   <Atom name="O" type="protein-OD" charge="-0.58991"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB1"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="N"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="ARG">
-   <Atom name="N" type="protein-N" charge="-0.3908"/>
-   <Atom name="H" type="protein-H" charge="0.31584"/>
-   <Atom name="CA" type="protein-TP" charge="-0.4513"/>
-   <Atom name="HA" type="protein-H1" charge="0.21173"/>
-   <Atom name="CB" type="protein-C8" charge="-0.01245"/>
-   <Atom name="HB2" type="protein-HC" charge="0.06845"/>
-   <Atom name="HB3" type="protein-HC" charge="0.06845"/>
-   <Atom name="CG" type="protein-C8" charge="-0.02988"/>
-   <Atom name="HG2" type="protein-HC" charge="0.05333"/>
-   <Atom name="HG3" type="protein-HC" charge="0.05333"/>
-   <Atom name="CD" type="protein-C8" charge="0.06705"/>
-   <Atom name="HD2" type="protein-H1" charge="0.08336"/>
-   <Atom name="HD3" type="protein-H1" charge="0.08336"/>
-   <Atom name="NE" type="protein-N2" charge="-0.58061"/>
-   <Atom name="HE" type="protein-TH" charge="0.39559"/>
-   <Atom name="CZ" type="protein-CA" charge="0.74823"/>
-   <Atom name="NH1" type="protein-N2" charge="-0.83745"/>
-   <Atom name="HH11" type="protein-TH" charge="0.4466"/>
-   <Atom name="HH12" type="protein-TH" charge="0.4466"/>
-   <Atom name="NH2" type="protein-N2" charge="-0.83745"/>
-   <Atom name="HH21" type="protein-TH" charge="0.4466"/>
-   <Atom name="HH22" type="protein-TH" charge="0.4466"/>
-   <Atom name="C" type="protein-C" charge="0.8387"/>
-   <Atom name="O" type="protein-OD" charge="-0.63388"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="HG2"/>
-   <Bond atomName1="CG" atomName2="HG3"/>
-   <Bond atomName1="CG" atomName2="CD"/>
-   <Bond atomName1="CD" atomName2="HD2"/>
-   <Bond atomName1="CD" atomName2="HD3"/>
-   <Bond atomName1="CD" atomName2="NE"/>
-   <Bond atomName1="NE" atomName2="HE"/>
-   <Bond atomName1="NE" atomName2="CZ"/>
-   <Bond atomName1="CZ" atomName2="NH1"/>
-   <Bond atomName1="CZ" atomName2="NH2"/>
-   <Bond atomName1="NH1" atomName2="HH11"/>
-   <Bond atomName1="NH1" atomName2="HH12"/>
-   <Bond atomName1="NH2" atomName2="HH21"/>
-   <Bond atomName1="NH2" atomName2="HH22"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="N"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="ASH">
-   <Atom name="N" type="protein-N" charge="-0.51112"/>
-   <Atom name="H" type="protein-H" charge="0.3201"/>
-   <Atom name="CA" type="protein-CX" charge="0.08118"/>
-   <Atom name="HA" type="protein-H1" charge="0.07654"/>
-   <Atom name="CB" type="protein-2C" charge="-0.1463"/>
-   <Atom name="HB2" type="protein-HC" charge="0.07911"/>
-   <Atom name="HB3" type="protein-HC" charge="0.07911"/>
-   <Atom name="CG" type="protein-C" charge="0.60797"/>
-   <Atom name="OD1" type="protein-O" charge="-0.51272"/>
-   <Atom name="OD2" type="protein-OH" charge="-0.53531"/>
-   <Atom name="HD2" type="protein-HO" charge="0.41183"/>
-   <Atom name="C" type="protein-C" charge="0.63952"/>
-   <Atom name="O" type="protein-OD" charge="-0.58991"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="OD1"/>
-   <Bond atomName1="CG" atomName2="OD2"/>
-   <Bond atomName1="OD2" atomName2="HD2"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="N"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="ASN">
-   <Atom name="N" type="protein-N" charge="-0.51112"/>
-   <Atom name="H" type="protein-H" charge="0.3201"/>
-   <Atom name="CA" type="protein-CX" charge="0.02612"/>
-   <Atom name="HA" type="protein-H1" charge="0.10302"/>
-   <Atom name="CB" type="protein-2C" charge="-0.16039"/>
-   <Atom name="HB2" type="protein-HC" charge="0.07474"/>
-   <Atom name="HB3" type="protein-HC" charge="0.07474"/>
-   <Atom name="CG" type="protein-C" charge="0.68612"/>
-   <Atom name="OD1" type="protein-OD" charge="-0.63291"/>
-   <Atom name="ND2" type="protein-ND" charge="-0.88334"/>
-   <Atom name="HD21" type="protein-H" charge="0.44179"/>
-   <Atom name="HD22" type="protein-H" charge="0.41152"/>
-   <Atom name="C" type="protein-C" charge="0.63952"/>
-   <Atom name="O" type="protein-OD" charge="-0.58991"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="OD1"/>
-   <Bond atomName1="CG" atomName2="ND2"/>
-   <Bond atomName1="ND2" atomName2="HD21"/>
-   <Bond atomName1="ND2" atomName2="HD22"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="N"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="ASP">
-   <Atom name="N" type="protein-N" charge="-0.70584"/>
-   <Atom name="H" type="protein-H" charge="0.36907"/>
-   <Atom name="CA" type="protein-TM" charge="0.32215"/>
-   <Atom name="HA" type="protein-H1" charge="0.01602"/>
-   <Atom name="CB" type="protein-2C" charge="-0.15393"/>
-   <Atom name="HB2" type="protein-HC" charge="0.02533"/>
-   <Atom name="HB3" type="protein-HC" charge="0.02533"/>
-   <Atom name="CG" type="protein-CO" charge="0.865"/>
-   <Atom name="OD1" type="protein-O3" charge="-0.85227"/>
-   <Atom name="OD2" type="protein-O3" charge="-0.85227"/>
-   <Atom name="C" type="protein-C" charge="0.57227"/>
-   <Atom name="O" type="protein-OD" charge="-0.63086"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="OD1"/>
-   <Bond atomName1="CG" atomName2="OD2"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="N"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="CYM">
-   <Atom name="N" type="protein-N" charge="-0.70584"/>
-   <Atom name="H" type="protein-H" charge="0.36907"/>
-   <Atom name="CA" type="protein-TM" charge="0.31993"/>
-   <Atom name="HA" type="protein-H1" charge="-0.02358"/>
-   <Atom name="CB" type="protein-2C" charge="0.08286"/>
-   <Atom name="HB3" type="protein-H1" charge="0.04444"/>
-   <Atom name="HB2" type="protein-H1" charge="0.04444"/>
-   <Atom name="SG" type="protein-SH" charge="-1.07273"/>
-   <Atom name="C" type="protein-C" charge="0.57227"/>
-   <Atom name="O" type="protein-OD" charge="-0.63086"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="SG"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="N"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="CYS">
-   <Atom name="N" type="protein-N" charge="-0.51112"/>
-   <Atom name="H" type="protein-H" charge="0.3201"/>
-   <Atom name="CA" type="protein-CX" charge="0.02119"/>
-   <Atom name="HA" type="protein-H1" charge="0.10678"/>
-   <Atom name="CB" type="protein-2C" charge="-0.07934"/>
-   <Atom name="HB2" type="protein-H1" charge="0.0996"/>
-   <Atom name="HB3" type="protein-H1" charge="0.0996"/>
-   <Atom name="SG" type="protein-SH" charge="-0.30684"/>
-   <Atom name="HG" type="protein-HS" charge="0.20042"/>
-   <Atom name="C" type="protein-C" charge="0.63952"/>
-   <Atom name="O" type="protein-OD" charge="-0.58991"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="SG"/>
-   <Bond atomName1="SG" atomName2="HG"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="N"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="CYX">
-   <Atom name="N" type="protein-N" charge="-0.51112"/>
-   <Atom name="H" type="protein-H" charge="0.3201"/>
-   <Atom name="CA" type="protein-CX" charge="0.03547"/>
-   <Atom name="HA" type="protein-H1" charge="0.09786"/>
-   <Atom name="CB" type="protein-2C" charge="-0.06785"/>
-   <Atom name="HB2" type="protein-H1" charge="0.0983"/>
-   <Atom name="HB3" type="protein-H1" charge="0.0983"/>
-   <Atom name="SG" type="protein-S" charge="-0.12067"/>
-   <Atom name="C" type="protein-C" charge="0.63952"/>
-   <Atom name="O" type="protein-OD" charge="-0.58991"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="SG"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="N"/>
-   <ExternalBond atomName="C"/>
-   <ExternalBond atomName="SG"/>
-  </Residue>
-  <Residue name="GLH">
-   <Atom name="N" type="protein-N" charge="-0.51112"/>
-   <Atom name="H" type="protein-H" charge="0.3201"/>
-   <Atom name="CA" type="protein-CX" charge="-0.00092"/>
-   <Atom name="HA" type="protein-H1" charge="0.09432"/>
-   <Atom name="CB" type="protein-2C" charge="-0.00739"/>
-   <Atom name="HB2" type="protein-HC" charge="0.04578"/>
-   <Atom name="HB3" type="protein-HC" charge="0.04578"/>
-   <Atom name="CG" type="protein-2C" charge="-0.12492"/>
-   <Atom name="HG2" type="protein-HC" charge="0.06874"/>
-   <Atom name="HG3" type="protein-HC" charge="0.06874"/>
-   <Atom name="CD" type="protein-C" charge="0.59294"/>
-   <Atom name="OE1" type="protein-O" charge="-0.51536"/>
-   <Atom name="OE2" type="protein-OH" charge="-0.5324"/>
-   <Atom name="HE2" type="protein-HO" charge="0.4061"/>
-   <Atom name="C" type="protein-C" charge="0.63952"/>
-   <Atom name="O" type="protein-OD" charge="-0.58991"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="HG2"/>
-   <Bond atomName1="CG" atomName2="HG3"/>
-   <Bond atomName1="CG" atomName2="CD"/>
-   <Bond atomName1="CD" atomName2="OE1"/>
-   <Bond atomName1="CD" atomName2="OE2"/>
-   <Bond atomName1="OE2" atomName2="HE2"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="N"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="GLN">
-   <Atom name="N" type="protein-N" charge="-0.51112"/>
-   <Atom name="H" type="protein-H" charge="0.3201"/>
-   <Atom name="CA" type="protein-CX" charge="0.00596"/>
-   <Atom name="HA" type="protein-H1" charge="0.09225"/>
-   <Atom name="CB" type="protein-2C" charge="-0.04256"/>
-   <Atom name="HB2" type="protein-HC" charge="0.05021"/>
-   <Atom name="HB3" type="protein-HC" charge="0.05021"/>
-   <Atom name="CG" type="protein-2C" charge="-0.14598"/>
-   <Atom name="HG2" type="protein-HC" charge="0.06512"/>
-   <Atom name="HG3" type="protein-HC" charge="0.06512"/>
-   <Atom name="CD" type="protein-C" charge="0.71341"/>
-   <Atom name="OE1" type="protein-OD" charge="-0.65218"/>
-   <Atom name="NE2" type="protein-ND" charge="-0.93462"/>
-   <Atom name="HE21" type="protein-H" charge="0.45469"/>
-   <Atom name="HE22" type="protein-H" charge="0.41978"/>
-   <Atom name="C" type="protein-C" charge="0.63952"/>
-   <Atom name="O" type="protein-OD" charge="-0.58991"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="HG2"/>
-   <Bond atomName1="CG" atomName2="HG3"/>
-   <Bond atomName1="CG" atomName2="CD"/>
-   <Bond atomName1="CD" atomName2="OE1"/>
-   <Bond atomName1="CD" atomName2="NE2"/>
-   <Bond atomName1="NE2" atomName2="HE21"/>
-   <Bond atomName1="NE2" atomName2="HE22"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="N"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="GLU">
-   <Atom name="N" type="protein-N" charge="-0.70584"/>
-   <Atom name="H" type="protein-H" charge="0.36907"/>
-   <Atom name="CA" type="protein-TM" charge="0.34563"/>
-   <Atom name="HA" type="protein-H1" charge="0.00361"/>
-   <Atom name="CB" type="protein-2C" charge="-0.00837"/>
-   <Atom name="HB2" type="protein-HC" charge="0.00926"/>
-   <Atom name="HB3" type="protein-HC" charge="0.00926"/>
-   <Atom name="CG" type="protein-2C" charge="-0.11758"/>
-   <Atom name="HG2" type="protein-HC" charge="0.01714"/>
-   <Atom name="HG3" type="protein-HC" charge="0.01714"/>
-   <Atom name="CD" type="protein-CO" charge="0.80677"/>
-   <Atom name="OE1" type="protein-O3" charge="-0.84375"/>
-   <Atom name="OE2" type="protein-O3" charge="-0.84375"/>
-   <Atom name="C" type="protein-C" charge="0.57227"/>
-   <Atom name="O" type="protein-OD" charge="-0.63086"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="HG2"/>
-   <Bond atomName1="CG" atomName2="HG3"/>
-   <Bond atomName1="CG" atomName2="CD"/>
-   <Bond atomName1="CD" atomName2="OE1"/>
-   <Bond atomName1="CD" atomName2="OE2"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="N"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="GLY">
-   <Atom name="N" type="protein-N" charge="-0.55472"/>
-   <Atom name="H" type="protein-H" charge="0.35974"/>
-   <Atom name="CA" type="protein-TG" charge="-0.06028"/>
-   <Atom name="HA2" type="protein-H1" charge="0.09472"/>
-   <Atom name="HA3" type="protein-H1" charge="0.09472"/>
-   <Atom name="C" type="protein-C" charge="0.69468"/>
-   <Atom name="O" type="protein-OD" charge="-0.62886"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA2"/>
-   <Bond atomName1="CA" atomName2="HA3"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="N"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="HID">
-   <Atom name="N" type="protein-N" charge="-0.51112"/>
-   <Atom name="H" type="protein-H" charge="0.3201"/>
-   <Atom name="CA" type="protein-CX" charge="0.04495"/>
-   <Atom name="HA" type="protein-H1" charge="0.0898"/>
-   <Atom name="CB" type="protein-TA" charge="-0.11726"/>
-   <Atom name="HB2" type="protein-HC" charge="0.07181"/>
-   <Atom name="HB3" type="protein-HC" charge="0.07181"/>
-   <Atom name="CG" type="protein-CC" charge="0.09844"/>
-   <Atom name="ND1" type="protein-NA" charge="-0.35736"/>
-   <Atom name="HD1" type="protein-H" charge="0.37921"/>
-   <Atom name="CE1" type="protein-CR" charge="0.19168"/>
-   <Atom name="HE1" type="protein-H5" charge="0.13308"/>
-   <Atom name="NE2" type="protein-NB" charge="-0.62533"/>
-   <Atom name="CD2" type="protein-CV" charge="0.0153"/>
-   <Atom name="HD2" type="protein-H4" charge="0.14528"/>
-   <Atom name="C" type="protein-C" charge="0.63952"/>
-   <Atom name="O" type="protein-OD" charge="-0.58991"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="ND1"/>
-   <Bond atomName1="CG" atomName2="CD2"/>
-   <Bond atomName1="ND1" atomName2="HD1"/>
-   <Bond atomName1="ND1" atomName2="CE1"/>
-   <Bond atomName1="CE1" atomName2="HE1"/>
-   <Bond atomName1="CE1" atomName2="NE2"/>
-   <Bond atomName1="NE2" atomName2="CD2"/>
-   <Bond atomName1="CD2" atomName2="HD2"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="N"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="HIE">
-   <Atom name="N" type="protein-N" charge="-0.51112"/>
-   <Atom name="H" type="protein-H" charge="0.3201"/>
-   <Atom name="CA" type="protein-CX" charge="0.01013"/>
-   <Atom name="HA" type="protein-H1" charge="0.08867"/>
-   <Atom name="CB" type="protein-TA" charge="-0.10971"/>
-   <Atom name="HB2" type="protein-HC" charge="0.06614"/>
-   <Atom name="HB3" type="protein-HC" charge="0.06614"/>
-   <Atom name="CG" type="protein-CC" charge="0.32544"/>
-   <Atom name="ND1" type="protein-NB" charge="-0.61168"/>
-   <Atom name="CE1" type="protein-CR" charge="0.10547"/>
-   <Atom name="HE1" type="protein-H5" charge="0.15078"/>
-   <Atom name="NE2" type="protein-NA" charge="-0.24062"/>
-   <Atom name="HE2" type="protein-H" charge="0.36772"/>
-   <Atom name="CD2" type="protein-CW" charge="-0.25349"/>
-   <Atom name="HD2" type="protein-H4" charge="0.17642"/>
-   <Atom name="C" type="protein-C" charge="0.63952"/>
-   <Atom name="O" type="protein-OD" charge="-0.58991"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="ND1"/>
-   <Bond atomName1="CG" atomName2="CD2"/>
-   <Bond atomName1="ND1" atomName2="CE1"/>
-   <Bond atomName1="CE1" atomName2="HE1"/>
-   <Bond atomName1="CE1" atomName2="NE2"/>
-   <Bond atomName1="NE2" atomName2="HE2"/>
-   <Bond atomName1="NE2" atomName2="CD2"/>
-   <Bond atomName1="CD2" atomName2="HD2"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="N"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="HIP">
-   <Atom name="N" type="protein-N" charge="-0.3908"/>
-   <Atom name="H" type="protein-H" charge="0.31584"/>
-   <Atom name="CA" type="protein-TP" charge="-0.33237"/>
-   <Atom name="HA" type="protein-H1" charge="0.19393"/>
-   <Atom name="CB" type="protein-C8" charge="-0.11493"/>
-   <Atom name="HB2" type="protein-HC" charge="0.11792"/>
-   <Atom name="HB3" type="protein-HC" charge="0.11792"/>
-   <Atom name="CG" type="protein-CC" charge="0.11778"/>
-   <Atom name="ND1" type="protein-NA" charge="-0.21073"/>
-   <Atom name="HD1" type="protein-H" charge="0.41031"/>
-   <Atom name="CE1" type="protein-CR" charge="0.01961"/>
-   <Atom name="HE1" type="protein-H5" charge="0.22037"/>
-   <Atom name="NE2" type="protein-NA" charge="-0.18173"/>
-   <Atom name="HE2" type="protein-H" charge="0.41205"/>
-   <Atom name="CD2" type="protein-CW" charge="-0.11723"/>
-   <Atom name="HD2" type="protein-H4" charge="0.21724"/>
-   <Atom name="C" type="protein-C" charge="0.8387"/>
-   <Atom name="O" type="protein-OD" charge="-0.63388"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="ND1"/>
-   <Bond atomName1="CG" atomName2="CD2"/>
-   <Bond atomName1="ND1" atomName2="HD1"/>
-   <Bond atomName1="ND1" atomName2="CE1"/>
-   <Bond atomName1="CE1" atomName2="HE1"/>
-   <Bond atomName1="CE1" atomName2="NE2"/>
-   <Bond atomName1="NE2" atomName2="HE2"/>
-   <Bond atomName1="NE2" atomName2="CD2"/>
-   <Bond atomName1="CD2" atomName2="HD2"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="N"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="ILE">
-   <Atom name="N" type="protein-N" charge="-0.51112"/>
-   <Atom name="H" type="protein-H" charge="0.3201"/>
-   <Atom name="CA" type="protein-CX" charge="-0.10079"/>
-   <Atom name="HA" type="protein-H1" charge="0.11671"/>
-   <Atom name="CB" type="protein-3C" charge="0.12718"/>
-   <Atom name="HB" type="protein-HC" charge="0.02029"/>
-   <Atom name="CG2" type="protein-CT" charge="-0.2374"/>
-   <Atom name="HG21" type="protein-HC" charge="0.06565"/>
-   <Atom name="HG22" type="protein-HC" charge="0.06565"/>
-   <Atom name="HG23" type="protein-HC" charge="0.06565"/>
-   <Atom name="CG1" type="protein-2C" charge="0.01664"/>
-   <Atom name="HG12" type="protein-HC" charge="0.01464"/>
-   <Atom name="HG13" type="protein-HC" charge="0.01464"/>
-   <Atom name="CD1" type="protein-CT" charge="-0.14646"/>
-   <Atom name="HD11" type="protein-HC" charge="0.03967"/>
-   <Atom name="HD12" type="protein-HC" charge="0.03967"/>
-   <Atom name="HD13" type="protein-HC" charge="0.03967"/>
-   <Atom name="C" type="protein-C" charge="0.63952"/>
-   <Atom name="O" type="protein-OD" charge="-0.58991"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB"/>
-   <Bond atomName1="CB" atomName2="CG2"/>
-   <Bond atomName1="CB" atomName2="CG1"/>
-   <Bond atomName1="CG2" atomName2="HG21"/>
-   <Bond atomName1="CG2" atomName2="HG22"/>
-   <Bond atomName1="CG2" atomName2="HG23"/>
-   <Bond atomName1="CG1" atomName2="HG12"/>
-   <Bond atomName1="CG1" atomName2="HG13"/>
-   <Bond atomName1="CG1" atomName2="CD1"/>
-   <Bond atomName1="CD1" atomName2="HD11"/>
-   <Bond atomName1="CD1" atomName2="HD12"/>
-   <Bond atomName1="CD1" atomName2="HD13"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="N"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="LEU">
-   <Atom name="N" type="protein-N" charge="-0.51112"/>
-   <Atom name="H" type="protein-H" charge="0.3201"/>
-   <Atom name="CA" type="protein-CX" charge="-0.03749"/>
-   <Atom name="HA" type="protein-H1" charge="0.09578"/>
-   <Atom name="CB" type="protein-2C" charge="-0.08167"/>
-   <Atom name="HB2" type="protein-HC" charge="0.04459"/>
-   <Atom name="HB3" type="protein-HC" charge="0.04459"/>
-   <Atom name="CG" type="protein-3C" charge="0.2285"/>
-   <Atom name="HG" type="protein-HC" charge="0.00131"/>
-   <Atom name="CD1" type="protein-CT" charge="-0.28977"/>
-   <Atom name="HD11" type="protein-HC" charge="0.07089"/>
-   <Atom name="HD12" type="protein-HC" charge="0.07089"/>
-   <Atom name="HD13" type="protein-HC" charge="0.07089"/>
-   <Atom name="CD2" type="protein-CT" charge="-0.28977"/>
-   <Atom name="HD21" type="protein-HC" charge="0.07089"/>
-   <Atom name="HD22" type="protein-HC" charge="0.07089"/>
-   <Atom name="HD23" type="protein-HC" charge="0.07089"/>
-   <Atom name="C" type="protein-C" charge="0.63952"/>
-   <Atom name="O" type="protein-OD" charge="-0.58991"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="HG"/>
-   <Bond atomName1="CG" atomName2="CD1"/>
-   <Bond atomName1="CG" atomName2="CD2"/>
-   <Bond atomName1="CD1" atomName2="HD11"/>
-   <Bond atomName1="CD1" atomName2="HD12"/>
-   <Bond atomName1="CD1" atomName2="HD13"/>
-   <Bond atomName1="CD2" atomName2="HD21"/>
-   <Bond atomName1="CD2" atomName2="HD22"/>
-   <Bond atomName1="CD2" atomName2="HD23"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="N"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="LYN">
-   <Atom name="N" type="protein-N" charge="-0.51112"/>
-   <Atom name="H" type="protein-H" charge="0.3201"/>
-   <Atom name="CA" type="protein-CX" charge="-0.04468"/>
-   <Atom name="HA" type="protein-H1" charge="0.1021"/>
-   <Atom name="CB" type="protein-2C" charge="-0.02592"/>
-   <Atom name="HB2" type="protein-HC" charge="0.0409"/>
-   <Atom name="HB3" type="protein-HC" charge="0.0409"/>
-   <Atom name="CG" type="protein-2C" charge="-0.04379"/>
-   <Atom name="HG2" type="protein-HC" charge="0.03042"/>
-   <Atom name="HG3" type="protein-HC" charge="0.03042"/>
-   <Atom name="CD" type="protein-2C" charge="-0.08662"/>
-   <Atom name="HD2" type="protein-HC" charge="0.03059"/>
-   <Atom name="HD3" type="protein-HC" charge="0.03059"/>
-   <Atom name="CE" type="protein-2C" charge="0.34331"/>
-   <Atom name="HE2" type="protein-HC" charge="-0.01326"/>
-   <Atom name="HE3" type="protein-HC" charge="-0.01326"/>
-   <Atom name="NZ" type="protein-N3" charge="-1.01071"/>
-   <Atom name="HZ2" type="protein-H" charge="0.36521"/>
-   <Atom name="HZ3" type="protein-H" charge="0.36521"/>
-   <Atom name="C" type="protein-C" charge="0.63952"/>
-   <Atom name="O" type="protein-OD" charge="-0.58991"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="HG2"/>
-   <Bond atomName1="CG" atomName2="HG3"/>
-   <Bond atomName1="CG" atomName2="CD"/>
-   <Bond atomName1="CD" atomName2="HD2"/>
-   <Bond atomName1="CD" atomName2="HD3"/>
-   <Bond atomName1="CD" atomName2="CE"/>
-   <Bond atomName1="CE" atomName2="HE2"/>
-   <Bond atomName1="CE" atomName2="HE3"/>
-   <Bond atomName1="CE" atomName2="NZ"/>
-   <Bond atomName1="NZ" atomName2="HZ2"/>
-   <Bond atomName1="NZ" atomName2="HZ3"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="N"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="LYS">
-   <Atom name="N" type="protein-N" charge="-0.3908"/>
-   <Atom name="H" type="protein-H" charge="0.31584"/>
-   <Atom name="CA" type="protein-TP" charge="-0.42095"/>
-   <Atom name="HA" type="protein-H1" charge="0.20346"/>
-   <Atom name="CB" type="protein-C8" charge="-0.11104"/>
-   <Atom name="HB2" type="protein-HC" charge="0.10105"/>
-   <Atom name="HB3" type="protein-HC" charge="0.10105"/>
-   <Atom name="CG" type="protein-C8" charge="-0.10962"/>
-   <Atom name="HG2" type="protein-HC" charge="0.07462"/>
-   <Atom name="HG3" type="protein-HC" charge="0.07462"/>
-   <Atom name="CD" type="protein-C8" charge="-0.03747"/>
-   <Atom name="HD2" type="protein-HC" charge="0.05631"/>
-   <Atom name="HD3" type="protein-HC" charge="0.05631"/>
-   <Atom name="CE" type="protein-C8" charge="0.07491"/>
-   <Atom name="HE2" type="protein-HP" charge="0.09294"/>
-   <Atom name="HE3" type="protein-HP" charge="0.09294"/>
-   <Atom name="NZ" type="protein-NL" charge="-0.56996"/>
-   <Atom name="HZ1" type="protein-H" charge="0.39699"/>
-   <Atom name="HZ2" type="protein-H" charge="0.39699"/>
-   <Atom name="HZ3" type="protein-H" charge="0.39699"/>
-   <Atom name="C" type="protein-C" charge="0.8387"/>
-   <Atom name="O" type="protein-OD" charge="-0.63388"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="HG2"/>
-   <Bond atomName1="CG" atomName2="HG3"/>
-   <Bond atomName1="CG" atomName2="CD"/>
-   <Bond atomName1="CD" atomName2="HD2"/>
-   <Bond atomName1="CD" atomName2="HD3"/>
-   <Bond atomName1="CD" atomName2="CE"/>
-   <Bond atomName1="CE" atomName2="HE2"/>
-   <Bond atomName1="CE" atomName2="HE3"/>
-   <Bond atomName1="CE" atomName2="NZ"/>
-   <Bond atomName1="NZ" atomName2="HZ1"/>
-   <Bond atomName1="NZ" atomName2="HZ2"/>
-   <Bond atomName1="NZ" atomName2="HZ3"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="N"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="MET">
-   <Atom name="N" type="protein-N" charge="-0.51112"/>
-   <Atom name="H" type="protein-H" charge="0.3201"/>
-   <Atom name="CA" type="protein-CX" charge="-0.03103"/>
-   <Atom name="HA" type="protein-H1" charge="0.10635"/>
-   <Atom name="CB" type="protein-2C" charge="4e-05"/>
-   <Atom name="HB2" type="protein-HC" charge="0.05248"/>
-   <Atom name="HB3" type="protein-HC" charge="0.05248"/>
-   <Atom name="CG" type="protein-2C" charge="-0.15683"/>
-   <Atom name="HG2" type="protein-H1" charge="0.11147"/>
-   <Atom name="HG3" type="protein-H1" charge="0.11147"/>
-   <Atom name="SD" type="protein-S" charge="-0.22249"/>
-   <Atom name="CE" type="protein-CT" charge="-0.21658"/>
-   <Atom name="HE1" type="protein-H1" charge="0.11135"/>
-   <Atom name="HE2" type="protein-H1" charge="0.11135"/>
-   <Atom name="HE3" type="protein-H1" charge="0.11135"/>
-   <Atom name="C" type="protein-C" charge="0.63952"/>
-   <Atom name="O" type="protein-OD" charge="-0.58991"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="HG2"/>
-   <Bond atomName1="CG" atomName2="HG3"/>
-   <Bond atomName1="CG" atomName2="SD"/>
-   <Bond atomName1="SD" atomName2="CE"/>
-   <Bond atomName1="CE" atomName2="HE1"/>
-   <Bond atomName1="CE" atomName2="HE2"/>
-   <Bond atomName1="CE" atomName2="HE3"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="N"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="MTB">
-   <Atom name="SG" type="protein-S" charge="-0.14504"/>
-   <Atom name="CB" type="protein-2C" charge="-0.12613"/>
-   <Atom name="HB1" type="protein-H1" charge="0.09039"/>
-   <Atom name="HB2" type="protein-H1" charge="0.09039"/>
-   <Atom name="HB3" type="protein-H1" charge="0.09039"/>
-   <Bond atomName1="SG" atomName2="CB"/>
-   <Bond atomName1="CB" atomName2="HB1"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-  </Residue>
-  <Residue name="NLE">
-   <Atom name="N" type="protein-N" charge="-0.51112"/>
-   <Atom name="H" type="protein-H" charge="0.3201"/>
-   <Atom name="CA" type="protein-CX" charge="-0.04079"/>
-   <Atom name="HA" type="protein-H1" charge="0.09081"/>
-   <Atom name="CB" type="protein-2C" charge="-0.01837"/>
-   <Atom name="HB2" type="protein-HC" charge="0.03482"/>
-   <Atom name="HB3" type="protein-HC" charge="0.03482"/>
-   <Atom name="CG" type="protein-2C" charge="-0.0275"/>
-   <Atom name="HG2" type="protein-HC" charge="0.02284"/>
-   <Atom name="HG3" type="protein-HC" charge="0.02284"/>
-   <Atom name="CD" type="protein-2C" charge="0.07349"/>
-   <Atom name="HD2" type="protein-HC" charge="-0.00321"/>
-   <Atom name="HD3" type="protein-HC" charge="-0.00321"/>
-   <Atom name="CE" type="protein-CT" charge="-0.1597"/>
-   <Atom name="HE1" type="protein-HC" charge="0.03819"/>
-   <Atom name="HE2" type="protein-HC" charge="0.03819"/>
-   <Atom name="HE3" type="protein-HC" charge="0.03819"/>
-   <Atom name="C" type="protein-C" charge="0.63952"/>
-   <Atom name="O" type="protein-OD" charge="-0.58991"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="HG2"/>
-   <Bond atomName1="CG" atomName2="HG3"/>
-   <Bond atomName1="CG" atomName2="CD"/>
-   <Bond atomName1="CD" atomName2="HD2"/>
-   <Bond atomName1="CD" atomName2="HD3"/>
-   <Bond atomName1="CD" atomName2="CE"/>
-   <Bond atomName1="CE" atomName2="HE1"/>
-   <Bond atomName1="CE" atomName2="HE2"/>
-   <Bond atomName1="CE" atomName2="HE3"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="N"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="PHE">
-   <Atom name="N" type="protein-N" charge="-0.51112"/>
-   <Atom name="H" type="protein-H" charge="0.3201"/>
-   <Atom name="CA" type="protein-CX" charge="0.01752"/>
-   <Atom name="HA" type="protein-H1" charge="0.0931"/>
-   <Atom name="CB" type="protein-TA" charge="-0.09016"/>
-   <Atom name="HB2" type="protein-HC" charge="0.06224"/>
-   <Atom name="HB3" type="protein-HC" charge="0.06224"/>
-   <Atom name="CG" type="protein-CA" charge="0.07328"/>
-   <Atom name="CD1" type="protein-CA" charge="-0.16749"/>
-   <Atom name="HD1" type="protein-HA" charge="0.14146"/>
-   <Atom name="CE1" type="protein-CA" charge="-0.16359"/>
-   <Atom name="HE1" type="protein-HA" charge="0.14752"/>
-   <Atom name="CZ" type="protein-CA" charge="-0.12634"/>
-   <Atom name="HZ" type="protein-HA" charge="0.13373"/>
-   <Atom name="CE2" type="protein-CA" charge="-0.16359"/>
-   <Atom name="HE2" type="protein-HA" charge="0.14752"/>
-   <Atom name="CD2" type="protein-CA" charge="-0.16749"/>
-   <Atom name="HD2" type="protein-HA" charge="0.14146"/>
-   <Atom name="C" type="protein-C" charge="0.63952"/>
-   <Atom name="O" type="protein-OD" charge="-0.58991"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="CD1"/>
-   <Bond atomName1="CG" atomName2="CD2"/>
-   <Bond atomName1="CD1" atomName2="HD1"/>
-   <Bond atomName1="CD1" atomName2="CE1"/>
-   <Bond atomName1="CE1" atomName2="HE1"/>
-   <Bond atomName1="CE1" atomName2="CZ"/>
-   <Bond atomName1="CZ" atomName2="HZ"/>
-   <Bond atomName1="CZ" atomName2="CE2"/>
-   <Bond atomName1="CE2" atomName2="HE2"/>
-   <Bond atomName1="CE2" atomName2="CD2"/>
-   <Bond atomName1="CD2" atomName2="HD2"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="N"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="PRO">
-   <Atom name="N" type="protein-TN" charge="-0.35181"/>
-   <Atom name="CD" type="protein-CT" charge="0.04619"/>
-   <Atom name="HD2" type="protein-H1" charge="0.05638"/>
-   <Atom name="HD3" type="protein-H1" charge="0.05638"/>
-   <Atom name="CG" type="protein-CT" charge="-0.04145"/>
-   <Atom name="HG2" type="protein-HC" charge="0.04628"/>
-   <Atom name="HG3" type="protein-HC" charge="0.04628"/>
-   <Atom name="CB" type="protein-CT" charge="-0.06018"/>
-   <Atom name="HB2" type="protein-HC" charge="0.05925"/>
-   <Atom name="HB3" type="protein-HC" charge="0.05925"/>
-   <Atom name="CA" type="protein-TJ" charge="-0.08538"/>
-   <Atom name="HA" type="protein-H1" charge="0.1044"/>
-   <Atom name="C" type="protein-C" charge="0.67582"/>
-   <Atom name="O" type="protein-OD" charge="-0.61141"/>
-   <Bond atomName1="N" atomName2="CD"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CD" atomName2="HD2"/>
-   <Bond atomName1="CD" atomName2="HD3"/>
-   <Bond atomName1="CD" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="HG2"/>
-   <Bond atomName1="CG" atomName2="HG3"/>
-   <Bond atomName1="CG" atomName2="CB"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="N"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="SER">
-   <Atom name="N" type="protein-N" charge="-0.51112"/>
-   <Atom name="H" type="protein-H" charge="0.3201"/>
-   <Atom name="CA" type="protein-CX" charge="-0.00012"/>
-   <Atom name="HA" type="protein-H1" charge="0.09398"/>
-   <Atom name="CB" type="protein-2C" charge="0.12377"/>
-   <Atom name="HB2" type="protein-H1" charge="0.05373"/>
-   <Atom name="HB3" type="protein-H1" charge="0.05373"/>
-   <Atom name="OG" type="protein-OA" charge="-0.56858"/>
-   <Atom name="HG" type="protein-HO" charge="0.3849"/>
-   <Atom name="C" type="protein-C" charge="0.63952"/>
-   <Atom name="O" type="protein-OD" charge="-0.58991"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="OG"/>
-   <Bond atomName1="OG" atomName2="HG"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="N"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="THR">
-   <Atom name="N" type="protein-N" charge="-0.51112"/>
-   <Atom name="H" type="protein-H" charge="0.3201"/>
-   <Atom name="CA" type="protein-CX" charge="0.01035"/>
-   <Atom name="HA" type="protein-H1" charge="0.08532"/>
-   <Atom name="CB" type="protein-3C" charge="0.20161"/>
-   <Atom name="HB" type="protein-H1" charge="0.05224"/>
-   <Atom name="CG2" type="protein-CT" charge="-0.2416"/>
-   <Atom name="HG21" type="protein-HC" charge="0.07861"/>
-   <Atom name="HG22" type="protein-HC" charge="0.07861"/>
-   <Atom name="HG23" type="protein-HC" charge="0.07861"/>
-   <Atom name="OG1" type="protein-OA" charge="-0.57965"/>
-   <Atom name="HG1" type="protein-HO" charge="0.37731"/>
-   <Atom name="C" type="protein-C" charge="0.63952"/>
-   <Atom name="O" type="protein-OD" charge="-0.58991"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB"/>
-   <Bond atomName1="CB" atomName2="CG2"/>
-   <Bond atomName1="CB" atomName2="OG1"/>
-   <Bond atomName1="CG2" atomName2="HG21"/>
-   <Bond atomName1="CG2" atomName2="HG22"/>
-   <Bond atomName1="CG2" atomName2="HG23"/>
-   <Bond atomName1="OG1" atomName2="HG1"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="N"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="TRP">
-   <Atom name="N" type="protein-N" charge="-0.51112"/>
-   <Atom name="H" type="protein-H" charge="0.3201"/>
-   <Atom name="CA" type="protein-CX" charge="-0.01666"/>
-   <Atom name="HA" type="protein-H1" charge="0.10372"/>
-   <Atom name="CB" type="protein-TA" charge="-0.06181"/>
-   <Atom name="HB2" type="protein-HC" charge="0.07351"/>
-   <Atom name="HB3" type="protein-HC" charge="0.07351"/>
-   <Atom name="CG" type="protein-C*" charge="-0.14967"/>
-   <Atom name="CD1" type="protein-CW" charge="-0.08613"/>
-   <Atom name="HD1" type="protein-H4" charge="0.17345"/>
-   <Atom name="NE1" type="protein-NA" charge="-0.46227"/>
-   <Atom name="HE1" type="protein-H" charge="0.40212"/>
-   <Atom name="CE2" type="protein-CN" charge="0.24827"/>
-   <Atom name="CZ2" type="protein-CA" charge="-0.29494"/>
-   <Atom name="HZ2" type="protein-HA" charge="0.16633"/>
-   <Atom name="CH2" type="protein-CA" charge="-0.16017"/>
-   <Atom name="HH2" type="protein-HA" charge="0.15706"/>
-   <Atom name="CZ3" type="protein-CA" charge="-0.19582"/>
-   <Atom name="HZ3" type="protein-HA" charge="0.15158"/>
-   <Atom name="CE3" type="protein-CA" charge="-0.26689"/>
-   <Atom name="HE3" type="protein-HA" charge="0.172"/>
-   <Atom name="CD2" type="protein-CB" charge="0.11422"/>
-   <Atom name="C" type="protein-C" charge="0.63952"/>
-   <Atom name="O" type="protein-OD" charge="-0.58991"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="CD1"/>
-   <Bond atomName1="CG" atomName2="CD2"/>
-   <Bond atomName1="CD1" atomName2="HD1"/>
-   <Bond atomName1="CD1" atomName2="NE1"/>
-   <Bond atomName1="NE1" atomName2="HE1"/>
-   <Bond atomName1="NE1" atomName2="CE2"/>
-   <Bond atomName1="CE2" atomName2="CZ2"/>
-   <Bond atomName1="CE2" atomName2="CD2"/>
-   <Bond atomName1="CZ2" atomName2="HZ2"/>
-   <Bond atomName1="CZ2" atomName2="CH2"/>
-   <Bond atomName1="CH2" atomName2="HH2"/>
-   <Bond atomName1="CH2" atomName2="CZ3"/>
-   <Bond atomName1="CZ3" atomName2="HZ3"/>
-   <Bond atomName1="CZ3" atomName2="CE3"/>
-   <Bond atomName1="CE3" atomName2="HE3"/>
-   <Bond atomName1="CE3" atomName2="CD2"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="N"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="TYR">
-   <Atom name="N" type="protein-N" charge="-0.51112"/>
-   <Atom name="H" type="protein-H" charge="0.3201"/>
-   <Atom name="CA" type="protein-CX" charge="0.00087"/>
-   <Atom name="HA" type="protein-H1" charge="0.09398"/>
-   <Atom name="CB" type="protein-TA" charge="-0.08145"/>
-   <Atom name="HB2" type="protein-HC" charge="0.06108"/>
-   <Atom name="HB3" type="protein-HC" charge="0.06108"/>
-   <Atom name="CG" type="protein-CA" charge="0.08621"/>
-   <Atom name="CD1" type="protein-CA" charge="-0.21395"/>
-   <Atom name="HD1" type="protein-HA" charge="0.16867"/>
-   <Atom name="CE1" type="protein-CA" charge="-0.29415"/>
-   <Atom name="HE1" type="protein-HA" charge="0.18565"/>
-   <Atom name="CZ" type="protein-C" charge="0.38943"/>
-   <Atom name="OH" type="protein-OA" charge="-0.5524"/>
-   <Atom name="HH" type="protein-HO" charge="0.39017"/>
-   <Atom name="CE2" type="protein-CA" charge="-0.29415"/>
-   <Atom name="HE2" type="protein-HA" charge="0.18565"/>
-   <Atom name="CD2" type="protein-CA" charge="-0.21395"/>
-   <Atom name="HD2" type="protein-HA" charge="0.16867"/>
-   <Atom name="C" type="protein-C" charge="0.63952"/>
-   <Atom name="O" type="protein-OD" charge="-0.58991"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="CD1"/>
-   <Bond atomName1="CG" atomName2="CD2"/>
-   <Bond atomName1="CD1" atomName2="HD1"/>
-   <Bond atomName1="CD1" atomName2="CE1"/>
-   <Bond atomName1="CE1" atomName2="HE1"/>
-   <Bond atomName1="CE1" atomName2="CZ"/>
-   <Bond atomName1="CZ" atomName2="OH"/>
-   <Bond atomName1="CZ" atomName2="CE2"/>
-   <Bond atomName1="OH" atomName2="HH"/>
-   <Bond atomName1="CE2" atomName2="HE2"/>
-   <Bond atomName1="CE2" atomName2="CD2"/>
-   <Bond atomName1="CD2" atomName2="HD2"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="N"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="VAL">
-   <Atom name="N" type="protein-N" charge="-0.51112"/>
-   <Atom name="H" type="protein-H" charge="0.3201"/>
-   <Atom name="CA" type="protein-CX" charge="-0.0939"/>
-   <Atom name="HA" type="protein-H1" charge="0.1119"/>
-   <Atom name="CB" type="protein-3C" charge="0.20616"/>
-   <Atom name="HB" type="protein-HC" charge="0.02749"/>
-   <Atom name="CG1" type="protein-CT" charge="-0.3055"/>
-   <Atom name="HG11" type="protein-HC" charge="0.08346"/>
-   <Atom name="HG12" type="protein-HC" charge="0.08346"/>
-   <Atom name="HG13" type="protein-HC" charge="0.08346"/>
-   <Atom name="CG2" type="protein-CT" charge="-0.3055"/>
-   <Atom name="HG21" type="protein-HC" charge="0.08346"/>
-   <Atom name="HG22" type="protein-HC" charge="0.08346"/>
-   <Atom name="HG23" type="protein-HC" charge="0.08346"/>
-   <Atom name="C" type="protein-C" charge="0.63952"/>
-   <Atom name="O" type="protein-OD" charge="-0.58991"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB"/>
-   <Bond atomName1="CB" atomName2="CG1"/>
-   <Bond atomName1="CB" atomName2="CG2"/>
-   <Bond atomName1="CG1" atomName2="HG11"/>
-   <Bond atomName1="CG1" atomName2="HG12"/>
-   <Bond atomName1="CG1" atomName2="HG13"/>
-   <Bond atomName1="CG2" atomName2="HG21"/>
-   <Bond atomName1="CG2" atomName2="HG22"/>
-   <Bond atomName1="CG2" atomName2="HG23"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="N"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="CALA">
-   <Atom name="N" type="protein-N" charge="-0.74668"/>
-   <Atom name="H" type="protein-H" charge="0.37486"/>
-   <Atom name="CA" type="protein-CX" charge="0.29792"/>
-   <Atom name="HA" type="protein-H1" charge="-0.01563"/>
-   <Atom name="CB" type="protein-CT" charge="-0.18128"/>
-   <Atom name="HB1" type="protein-HC" charge="0.04532"/>
-   <Atom name="HB2" type="protein-HC" charge="0.04532"/>
-   <Atom name="HB3" type="protein-HC" charge="0.04532"/>
-   <Atom name="C" type="protein-CO" charge="0.75823"/>
-   <Atom name="O" type="protein-O3" charge="-0.81169"/>
-   <Atom name="OXT" type="protein-O3" charge="-0.81169"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB1"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <Bond atomName1="C" atomName2="OXT"/>
-   <ExternalBond atomName="N"/>
-  </Residue>
-  <Residue name="CARG">
-   <Atom name="N" type="protein-N" charge="-0.64105"/>
-   <Atom name="H" type="protein-H" charge="0.35488"/>
-   <Atom name="CA" type="protein-TP" charge="0.06866"/>
-   <Atom name="HA" type="protein-H1" charge="0.07475"/>
-   <Atom name="CB" type="protein-C8" charge="-0.08607"/>
-   <Atom name="HB2" type="protein-HC" charge="0.03747"/>
-   <Atom name="HB3" type="protein-HC" charge="0.03747"/>
-   <Atom name="CG" type="protein-C8" charge="-0.01181"/>
-   <Atom name="HG2" type="protein-HC" charge="0.02632"/>
-   <Atom name="HG3" type="protein-HC" charge="0.02632"/>
-   <Atom name="CD" type="protein-C8" charge="0.19254"/>
-   <Atom name="HD2" type="protein-H1" charge="0.04767"/>
-   <Atom name="HD3" type="protein-H1" charge="0.04767"/>
-   <Atom name="NE" type="protein-N2" charge="-0.63781"/>
-   <Atom name="HE" type="protein-TH" charge="0.39629"/>
-   <Atom name="CZ" type="protein-CA" charge="0.7736"/>
-   <Atom name="NH1" type="protein-N2" charge="-0.84909"/>
-   <Atom name="HH11" type="protein-TH" charge="0.44406"/>
-   <Atom name="HH12" type="protein-TH" charge="0.44406"/>
-   <Atom name="NH2" type="protein-N2" charge="-0.84909"/>
-   <Atom name="HH21" type="protein-TH" charge="0.44406"/>
-   <Atom name="HH22" type="protein-TH" charge="0.44406"/>
-   <Atom name="C" type="protein-CO" charge="0.85422"/>
-   <Atom name="O" type="protein-O3" charge="-0.81959"/>
-   <Atom name="OXT" type="protein-O3" charge="-0.81959"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="HG2"/>
-   <Bond atomName1="CG" atomName2="HG3"/>
-   <Bond atomName1="CG" atomName2="CD"/>
-   <Bond atomName1="CD" atomName2="HD2"/>
-   <Bond atomName1="CD" atomName2="HD3"/>
-   <Bond atomName1="CD" atomName2="NE"/>
-   <Bond atomName1="NE" atomName2="HE"/>
-   <Bond atomName1="NE" atomName2="CZ"/>
-   <Bond atomName1="CZ" atomName2="NH1"/>
-   <Bond atomName1="CZ" atomName2="NH2"/>
-   <Bond atomName1="NH1" atomName2="HH11"/>
-   <Bond atomName1="NH1" atomName2="HH12"/>
-   <Bond atomName1="NH2" atomName2="HH21"/>
-   <Bond atomName1="NH2" atomName2="HH22"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <Bond atomName1="C" atomName2="OXT"/>
-   <ExternalBond atomName="N"/>
-  </Residue>
-  <Residue name="CASH">
-   <Atom name="N" type="protein-N" charge="-0.74668"/>
-   <Atom name="H" type="protein-H" charge="0.37486"/>
-   <Atom name="CA" type="protein-CX" charge="0.36397"/>
-   <Atom name="HA" type="protein-H1" charge="-0.0108"/>
-   <Atom name="CB" type="protein-2C" charge="-0.16493"/>
-   <Atom name="HB2" type="protein-HC" charge="0.06085"/>
-   <Atom name="HB3" type="protein-HC" charge="0.06085"/>
-   <Atom name="CG" type="protein-C" charge="0.61304"/>
-   <Atom name="OD1" type="protein-O" charge="-0.55431"/>
-   <Atom name="OD2" type="protein-OH" charge="-0.5455"/>
-   <Atom name="HD1" type="protein-HO" charge="0.4138"/>
-   <Atom name="C" type="protein-CO" charge="0.75823"/>
-   <Atom name="O" type="protein-O3" charge="-0.81169"/>
-   <Atom name="OXT" type="protein-O3" charge="-0.81169"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="OD1"/>
-   <Bond atomName1="CG" atomName2="OD2"/>
-   <Bond atomName1="OD2" atomName2="HD1"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <Bond atomName1="C" atomName2="OXT"/>
-   <ExternalBond atomName="N"/>
-  </Residue>
-  <Residue name="CASN">
-   <Atom name="N" type="protein-N" charge="-0.74668"/>
-   <Atom name="H" type="protein-H" charge="0.37486"/>
-   <Atom name="CA" type="protein-CX" charge="0.32941"/>
-   <Atom name="HA" type="protein-H1" charge="0.01485"/>
-   <Atom name="CB" type="protein-2C" charge="-0.16997"/>
-   <Atom name="HB2" type="protein-HC" charge="0.04656"/>
-   <Atom name="HB3" type="protein-HC" charge="0.04656"/>
-   <Atom name="CG" type="protein-C" charge="0.66875"/>
-   <Atom name="OD1" type="protein-OD" charge="-0.61807"/>
-   <Atom name="ND2" type="protein-ND" charge="-0.93688"/>
-   <Atom name="HD21" type="protein-H" charge="0.44446"/>
-   <Atom name="HD22" type="protein-H" charge="0.4113"/>
-   <Atom name="C" type="protein-CO" charge="0.75823"/>
-   <Atom name="O" type="protein-O3" charge="-0.81169"/>
-   <Atom name="OXT" type="protein-O3" charge="-0.81169"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="OD1"/>
-   <Bond atomName1="CG" atomName2="ND2"/>
-   <Bond atomName1="ND2" atomName2="HD21"/>
-   <Bond atomName1="ND2" atomName2="HD22"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <Bond atomName1="C" atomName2="OXT"/>
-   <ExternalBond atomName="N"/>
-  </Residue>
-  <Residue name="CASP">
-   <Atom name="N" type="protein-N" charge="-0.88855"/>
-   <Atom name="H" type="protein-H" charge="0.38566"/>
-   <Atom name="CA" type="protein-TM" charge="0.57052"/>
-   <Atom name="HA" type="protein-H1" charge="-0.05917"/>
-   <Atom name="CB" type="protein-2C" charge="-0.20865"/>
-   <Atom name="HB2" type="protein-HC" charge="0.01254"/>
-   <Atom name="HB3" type="protein-HC" charge="0.01254"/>
-   <Atom name="CG" type="protein-CO" charge="0.77865"/>
-   <Atom name="OD1" type="protein-O3" charge="-0.83313"/>
-   <Atom name="OD2" type="protein-O3" charge="-0.83313"/>
-   <Atom name="C" type="protein-CO" charge="0.69002"/>
-   <Atom name="O" type="protein-O3" charge="-0.81365"/>
-   <Atom name="OXT" type="protein-O3" charge="-0.81365"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="OD1"/>
-   <Bond atomName1="CG" atomName2="OD2"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <Bond atomName1="C" atomName2="OXT"/>
-   <ExternalBond atomName="N"/>
-  </Residue>
-  <Residue name="CCYM">
-   <Atom name="N" type="protein-N" charge="-0.88855"/>
-   <Atom name="H" type="protein-H" charge="0.38566"/>
-   <Atom name="CA" type="protein-TM" charge="0.49737"/>
-   <Atom name="HA" type="protein-H1" charge="-0.09211"/>
-   <Atom name="CB" type="protein-2C" charge="0.32515"/>
-   <Atom name="HB2" type="protein-H1" charge="-0.06626"/>
-   <Atom name="HB3" type="protein-H1" charge="-0.06626"/>
-   <Atom name="SG" type="protein-SH" charge="-1.15772"/>
-   <Atom name="C" type="protein-CO" charge="0.69002"/>
-   <Atom name="O" type="protein-O3" charge="-0.81365"/>
-   <Atom name="OXT" type="protein-O3" charge="-0.81365"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="SG"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <Bond atomName1="C" atomName2="OXT"/>
-   <ExternalBond atomName="N"/>
-  </Residue>
-  <Residue name="CCYS">
-   <Atom name="N" type="protein-N" charge="-0.74668"/>
-   <Atom name="H" type="protein-H" charge="0.37486"/>
-   <Atom name="CA" type="protein-CX" charge="0.34587"/>
-   <Atom name="HA" type="protein-H1" charge="0.01124"/>
-   <Atom name="CB" type="protein-2C" charge="-0.10495"/>
-   <Atom name="HB2" type="protein-H1" charge="0.08031"/>
-   <Atom name="HB3" type="protein-H1" charge="0.08031"/>
-   <Atom name="SG" type="protein-SH" charge="-0.37231"/>
-   <Atom name="HG" type="protein-HS" charge="0.1965"/>
-   <Atom name="C" type="protein-CO" charge="0.75823"/>
-   <Atom name="O" type="protein-O3" charge="-0.81169"/>
-   <Atom name="OXT" type="protein-O3" charge="-0.81169"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="SG"/>
-   <Bond atomName1="SG" atomName2="HG"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <Bond atomName1="C" atomName2="OXT"/>
-   <ExternalBond atomName="N"/>
-  </Residue>
-  <Residue name="CCYX">
-   <Atom name="N" type="protein-N" charge="-0.74668"/>
-   <Atom name="H" type="protein-H" charge="0.37486"/>
-   <Atom name="CA" type="protein-CX" charge="0.36185"/>
-   <Atom name="HA" type="protein-H1" charge="-0.00831"/>
-   <Atom name="CB" type="protein-2C" charge="-0.09676"/>
-   <Atom name="HB2" type="protein-H1" charge="0.07884"/>
-   <Atom name="HB3" type="protein-H1" charge="0.07884"/>
-   <Atom name="SG" type="protein-S" charge="-0.17749"/>
-   <Atom name="C" type="protein-CO" charge="0.75823"/>
-   <Atom name="O" type="protein-O3" charge="-0.81169"/>
-   <Atom name="OXT" type="protein-O3" charge="-0.81169"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="SG"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <Bond atomName1="C" atomName2="OXT"/>
-   <ExternalBond atomName="N"/>
-  </Residue>
-  <Residue name="CGLH">
-   <Atom name="N" type="protein-N" charge="-0.74668"/>
-   <Atom name="H" type="protein-H" charge="0.37486"/>
-   <Atom name="CA" type="protein-CX" charge="0.3131"/>
-   <Atom name="HA" type="protein-H1" charge="-0.00019"/>
-   <Atom name="CB" type="protein-2C" charge="-0.0685"/>
-   <Atom name="HB2" type="protein-HC" charge="0.02808"/>
-   <Atom name="HB3" type="protein-HC" charge="0.02808"/>
-   <Atom name="CG" type="protein-2C" charge="-0.11145"/>
-   <Atom name="HG2" type="protein-HC" charge="0.06094"/>
-   <Atom name="HG3" type="protein-HC" charge="0.06094"/>
-   <Atom name="CD" type="protein-C" charge="0.6033"/>
-   <Atom name="OE1" type="protein-O" charge="-0.54267"/>
-   <Atom name="OE2" type="protein-OH" charge="-0.5401"/>
-   <Atom name="HE2" type="protein-HO" charge="0.40544"/>
-   <Atom name="C" type="protein-CO" charge="0.75823"/>
-   <Atom name="O" type="protein-O3" charge="-0.81169"/>
-   <Atom name="OXT" type="protein-O3" charge="-0.81169"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="HG2"/>
-   <Bond atomName1="CG" atomName2="HG3"/>
-   <Bond atomName1="CG" atomName2="CD"/>
-   <Bond atomName1="CD" atomName2="OE1"/>
-   <Bond atomName1="CD" atomName2="OE2"/>
-   <Bond atomName1="OE2" atomName2="HE2"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <Bond atomName1="C" atomName2="OXT"/>
-   <ExternalBond atomName="N"/>
-  </Residue>
-  <Residue name="CGLN">
-   <Atom name="N" type="protein-N" charge="-0.74668"/>
-   <Atom name="H" type="protein-H" charge="0.37486"/>
-   <Atom name="CA" type="protein-CX" charge="0.27269"/>
-   <Atom name="HA" type="protein-H1" charge="0.02646"/>
-   <Atom name="CB" type="protein-2C" charge="-0.07248"/>
-   <Atom name="HB2" type="protein-HC" charge="0.04016"/>
-   <Atom name="HB3" type="protein-HC" charge="0.04016"/>
-   <Atom name="CG" type="protein-2C" charge="-0.12201"/>
-   <Atom name="HG2" type="protein-HC" charge="0.04893"/>
-   <Atom name="HG3" type="protein-HC" charge="0.04893"/>
-   <Atom name="CD" type="protein-C" charge="0.6567"/>
-   <Atom name="OE1" type="protein-OD" charge="-0.63641"/>
-   <Atom name="NE2" type="protein-ND" charge="-0.88906"/>
-   <Atom name="HE21" type="protein-H" charge="0.42983"/>
-   <Atom name="HE22" type="protein-H" charge="0.39307"/>
-   <Atom name="C" type="protein-CO" charge="0.75823"/>
-   <Atom name="O" type="protein-O3" charge="-0.81169"/>
-   <Atom name="OXT" type="protein-O3" charge="-0.81169"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="HG2"/>
-   <Bond atomName1="CG" atomName2="HG3"/>
-   <Bond atomName1="CG" atomName2="CD"/>
-   <Bond atomName1="CD" atomName2="OE1"/>
-   <Bond atomName1="CD" atomName2="NE2"/>
-   <Bond atomName1="NE2" atomName2="HE21"/>
-   <Bond atomName1="NE2" atomName2="HE22"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <Bond atomName1="C" atomName2="OXT"/>
-   <ExternalBond atomName="N"/>
-  </Residue>
-  <Residue name="CGLU">
-   <Atom name="N" type="protein-N" charge="-0.88855"/>
-   <Atom name="H" type="protein-H" charge="0.38566"/>
-   <Atom name="CA" type="protein-TM" charge="0.53062"/>
-   <Atom name="HA" type="protein-H1" charge="-0.0591"/>
-   <Atom name="CB" type="protein-2C" charge="0.01319"/>
-   <Atom name="HB2" type="protein-HC" charge="-0.01557"/>
-   <Atom name="HB3" type="protein-HC" charge="-0.01557"/>
-   <Atom name="CG" type="protein-2C" charge="-0.144"/>
-   <Atom name="HG2" type="protein-HC" charge="4e-05"/>
-   <Atom name="HG3" type="protein-HC" charge="4e-05"/>
-   <Atom name="CD" type="protein-CO" charge="0.9041"/>
-   <Atom name="OE1" type="protein-O3" charge="-0.88679"/>
-   <Atom name="OE2" type="protein-O3" charge="-0.88679"/>
-   <Atom name="C" type="protein-CO" charge="0.69002"/>
-   <Atom name="O" type="protein-O3" charge="-0.81365"/>
-   <Atom name="OXT" type="protein-O3" charge="-0.81365"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="HG2"/>
-   <Bond atomName1="CG" atomName2="HG3"/>
-   <Bond atomName1="CG" atomName2="CD"/>
-   <Bond atomName1="CD" atomName2="OE1"/>
-   <Bond atomName1="CD" atomName2="OE2"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <Bond atomName1="C" atomName2="OXT"/>
-   <ExternalBond atomName="N"/>
-  </Residue>
-  <Residue name="CGLY">
-   <Atom name="N" type="protein-N" charge="-0.68544"/>
-   <Atom name="H" type="protein-H" charge="0.36253"/>
-   <Atom name="CA" type="protein-TG" charge="0.09536"/>
-   <Atom name="HA2" type="protein-H1" charge="0.03088"/>
-   <Atom name="HA3" type="protein-H1" charge="0.03088"/>
-   <Atom name="C" type="protein-CO" charge="0.84935"/>
-   <Atom name="O" type="protein-O3" charge="-0.84178"/>
-   <Atom name="OXT" type="protein-O3" charge="-0.84178"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA2"/>
-   <Bond atomName1="CA" atomName2="HA3"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <Bond atomName1="C" atomName2="OXT"/>
-   <ExternalBond atomName="N"/>
-  </Residue>
-  <Residue name="CHID">
-   <Atom name="N" type="protein-N" charge="-0.74668"/>
-   <Atom name="H" type="protein-H" charge="0.37486"/>
-   <Atom name="CA" type="protein-CX" charge="0.34684"/>
-   <Atom name="HA" type="protein-H1" charge="0.00586"/>
-   <Atom name="CB" type="protein-TA" charge="-0.15541"/>
-   <Atom name="HB2" type="protein-HC" charge="0.0436"/>
-   <Atom name="HB3" type="protein-HC" charge="0.0436"/>
-   <Atom name="CG" type="protein-CC" charge="0.11292"/>
-   <Atom name="ND1" type="protein-NA" charge="-0.3423"/>
-   <Atom name="HD1" type="protein-H" charge="0.36875"/>
-   <Atom name="CE1" type="protein-CR" charge="0.16555"/>
-   <Atom name="HE1" type="protein-H5" charge="0.12674"/>
-   <Atom name="NE2" type="protein-NB" charge="-0.63855"/>
-   <Atom name="CD2" type="protein-CV" charge="0.02318"/>
-   <Atom name="HD2" type="protein-H4" charge="0.13619"/>
-   <Atom name="C" type="protein-CO" charge="0.75823"/>
-   <Atom name="O" type="protein-O3" charge="-0.81169"/>
-   <Atom name="OXT" type="protein-O3" charge="-0.81169"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="ND1"/>
-   <Bond atomName1="CG" atomName2="CD2"/>
-   <Bond atomName1="ND1" atomName2="HD1"/>
-   <Bond atomName1="ND1" atomName2="CE1"/>
-   <Bond atomName1="CE1" atomName2="HE1"/>
-   <Bond atomName1="CE1" atomName2="NE2"/>
-   <Bond atomName1="NE2" atomName2="CD2"/>
-   <Bond atomName1="CD2" atomName2="HD2"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <Bond atomName1="C" atomName2="OXT"/>
-   <ExternalBond atomName="N"/>
-  </Residue>
-  <Residue name="CHIE">
-   <Atom name="N" type="protein-N" charge="-0.74668"/>
-   <Atom name="H" type="protein-H" charge="0.37486"/>
-   <Atom name="CA" type="protein-CX" charge="0.31047"/>
-   <Atom name="HA" type="protein-H1" charge="0.01525"/>
-   <Atom name="CB" type="protein-TA" charge="-0.17163"/>
-   <Atom name="HB2" type="protein-HC" charge="0.04436"/>
-   <Atom name="HB3" type="protein-HC" charge="0.04436"/>
-   <Atom name="CG" type="protein-CC" charge="0.38429"/>
-   <Atom name="ND1" type="protein-NB" charge="-0.60136"/>
-   <Atom name="CE1" type="protein-CR" charge="0.08553"/>
-   <Atom name="HE1" type="protein-H5" charge="0.13624"/>
-   <Atom name="NE2" type="protein-NA" charge="-0.22972"/>
-   <Atom name="HE2" type="protein-H" charge="0.3472"/>
-   <Atom name="CD2" type="protein-CW" charge="-0.31378"/>
-   <Atom name="HD2" type="protein-H4" charge="0.18576"/>
-   <Atom name="C" type="protein-CO" charge="0.75823"/>
-   <Atom name="O" type="protein-O3" charge="-0.81169"/>
-   <Atom name="OXT" type="protein-O3" charge="-0.81169"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="ND1"/>
-   <Bond atomName1="CG" atomName2="CD2"/>
-   <Bond atomName1="ND1" atomName2="CE1"/>
-   <Bond atomName1="CE1" atomName2="HE1"/>
-   <Bond atomName1="CE1" atomName2="NE2"/>
-   <Bond atomName1="NE2" atomName2="HE2"/>
-   <Bond atomName1="NE2" atomName2="CD2"/>
-   <Bond atomName1="CD2" atomName2="HD2"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <Bond atomName1="C" atomName2="OXT"/>
-   <ExternalBond atomName="N"/>
-  </Residue>
-  <Residue name="CHIP">
-   <Atom name="N" type="protein-N" charge="-0.64105"/>
-   <Atom name="H" type="protein-H" charge="0.35488"/>
-   <Atom name="CA" type="protein-TP" charge="0.17779"/>
-   <Atom name="HA" type="protein-H1" charge="0.05782"/>
-   <Atom name="CB" type="protein-C8" charge="-0.18367"/>
-   <Atom name="HB2" type="protein-HC" charge="0.10205"/>
-   <Atom name="HB3" type="protein-HC" charge="0.10205"/>
-   <Atom name="CG" type="protein-CC" charge="0.09697"/>
-   <Atom name="ND1" type="protein-NA" charge="-0.20953"/>
-   <Atom name="HD1" type="protein-H" charge="0.40107"/>
-   <Atom name="CE1" type="protein-CR" charge="0.02601"/>
-   <Atom name="HE1" type="protein-H5" charge="0.20803"/>
-   <Atom name="NE2" type="protein-NA" charge="-0.21692"/>
-   <Atom name="HE2" type="protein-H" charge="0.40807"/>
-   <Atom name="CD2" type="protein-CW" charge="-0.10478"/>
-   <Atom name="HD2" type="protein-H4" charge="0.20617"/>
-   <Atom name="C" type="protein-CO" charge="0.85422"/>
-   <Atom name="O" type="protein-O3" charge="-0.81959"/>
-   <Atom name="OXT" type="protein-O3" charge="-0.81959"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="ND1"/>
-   <Bond atomName1="CG" atomName2="CD2"/>
-   <Bond atomName1="ND1" atomName2="HD1"/>
-   <Bond atomName1="ND1" atomName2="CE1"/>
-   <Bond atomName1="CE1" atomName2="HE1"/>
-   <Bond atomName1="CE1" atomName2="NE2"/>
-   <Bond atomName1="NE2" atomName2="HE2"/>
-   <Bond atomName1="NE2" atomName2="CD2"/>
-   <Bond atomName1="CD2" atomName2="HD2"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <Bond atomName1="C" atomName2="OXT"/>
-   <ExternalBond atomName="N"/>
-  </Residue>
-  <Residue name="CILE">
-   <Atom name="N" type="protein-N" charge="-0.74668"/>
-   <Atom name="H" type="protein-H" charge="0.37486"/>
-   <Atom name="CA" type="protein-CX" charge="0.23853"/>
-   <Atom name="HA" type="protein-H1" charge="0.02293"/>
-   <Atom name="CB" type="protein-3C" charge="0.03868"/>
-   <Atom name="HB" type="protein-HC" charge="0.0195"/>
-   <Atom name="CG2" type="protein-CT" charge="-0.29405"/>
-   <Atom name="HG21" type="protein-HC" charge="0.07297"/>
-   <Atom name="HG22" type="protein-HC" charge="0.07297"/>
-   <Atom name="HG23" type="protein-HC" charge="0.07297"/>
-   <Atom name="CG1" type="protein-2C" charge="0.05173"/>
-   <Atom name="HG12" type="protein-HC" charge="-0.00325"/>
-   <Atom name="HG13" type="protein-HC" charge="-0.00325"/>
-   <Atom name="CD1" type="protein-CT" charge="-0.12542"/>
-   <Atom name="HD11" type="protein-HC" charge="0.02422"/>
-   <Atom name="HD12" type="protein-HC" charge="0.02422"/>
-   <Atom name="HD13" type="protein-HC" charge="0.02422"/>
-   <Atom name="C" type="protein-CO" charge="0.75823"/>
-   <Atom name="O" type="protein-O3" charge="-0.81169"/>
-   <Atom name="OXT" type="protein-O3" charge="-0.81169"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB"/>
-   <Bond atomName1="CB" atomName2="CG2"/>
-   <Bond atomName1="CB" atomName2="CG1"/>
-   <Bond atomName1="CG2" atomName2="HG21"/>
-   <Bond atomName1="CG2" atomName2="HG22"/>
-   <Bond atomName1="CG2" atomName2="HG23"/>
-   <Bond atomName1="CG1" atomName2="HG12"/>
-   <Bond atomName1="CG1" atomName2="HG13"/>
-   <Bond atomName1="CG1" atomName2="CD1"/>
-   <Bond atomName1="CD1" atomName2="HD11"/>
-   <Bond atomName1="CD1" atomName2="HD12"/>
-   <Bond atomName1="CD1" atomName2="HD13"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <Bond atomName1="C" atomName2="OXT"/>
-   <ExternalBond atomName="N"/>
-  </Residue>
-  <Residue name="CLEU">
-   <Atom name="N" type="protein-N" charge="-0.74668"/>
-   <Atom name="H" type="protein-H" charge="0.37486"/>
-   <Atom name="CA" type="protein-CX" charge="0.25731"/>
-   <Atom name="HA" type="protein-H1" charge="0.0213"/>
-   <Atom name="CB" type="protein-2C" charge="-0.12052"/>
-   <Atom name="HB2" type="protein-HC" charge="0.02334"/>
-   <Atom name="HB3" type="protein-HC" charge="0.02334"/>
-   <Atom name="CG" type="protein-3C" charge="0.25569"/>
-   <Atom name="HG" type="protein-HC" charge="-0.01341"/>
-   <Atom name="CD1" type="protein-CT" charge="-0.26758"/>
-   <Atom name="HD11" type="protein-HC" charge="0.05418"/>
-   <Atom name="HD12" type="protein-HC" charge="0.05418"/>
-   <Atom name="HD13" type="protein-HC" charge="0.05418"/>
-   <Atom name="CD2" type="protein-CT" charge="-0.26758"/>
-   <Atom name="HD21" type="protein-HC" charge="0.05418"/>
-   <Atom name="HD22" type="protein-HC" charge="0.05418"/>
-   <Atom name="HD23" type="protein-HC" charge="0.05418"/>
-   <Atom name="C" type="protein-CO" charge="0.75823"/>
-   <Atom name="O" type="protein-O3" charge="-0.81169"/>
-   <Atom name="OXT" type="protein-O3" charge="-0.81169"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="HG"/>
-   <Bond atomName1="CG" atomName2="CD1"/>
-   <Bond atomName1="CG" atomName2="CD2"/>
-   <Bond atomName1="CD1" atomName2="HD11"/>
-   <Bond atomName1="CD1" atomName2="HD12"/>
-   <Bond atomName1="CD1" atomName2="HD13"/>
-   <Bond atomName1="CD2" atomName2="HD21"/>
-   <Bond atomName1="CD2" atomName2="HD22"/>
-   <Bond atomName1="CD2" atomName2="HD23"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <Bond atomName1="C" atomName2="OXT"/>
-   <ExternalBond atomName="N"/>
-  </Residue>
-  <Residue name="CLYN">
-   <Atom name="N" type="protein-N" charge="-0.74668"/>
-   <Atom name="H" type="protein-H" charge="0.37486"/>
-   <Atom name="CA" type="protein-CX" charge="0.28573"/>
-   <Atom name="HA" type="protein-H1" charge="-0.00064"/>
-   <Atom name="CB" type="protein-2C" charge="-0.14981"/>
-   <Atom name="HB2" type="protein-HC" charge="0.04224"/>
-   <Atom name="HB3" type="protein-HC" charge="0.04224"/>
-   <Atom name="CG" type="protein-2C" charge="0.0431"/>
-   <Atom name="HG2" type="protein-HC" charge="0.00501"/>
-   <Atom name="HG3" type="protein-HC" charge="0.00501"/>
-   <Atom name="CD" type="protein-2C" charge="-0.0935"/>
-   <Atom name="HD2" type="protein-HC" charge="0.02565"/>
-   <Atom name="HD3" type="protein-HC" charge="0.02565"/>
-   <Atom name="CE" type="protein-2C" charge="0.31815"/>
-   <Atom name="HE2" type="protein-HC" charge="-0.01422"/>
-   <Atom name="HE3" type="protein-HC" charge="-0.01422"/>
-   <Atom name="NZ" type="protein-N3" charge="-1.01418"/>
-   <Atom name="HZ2" type="protein-H" charge="0.36538"/>
-   <Atom name="HZ3" type="protein-H" charge="0.36538"/>
-   <Atom name="C" type="protein-CO" charge="0.75823"/>
-   <Atom name="O" type="protein-O3" charge="-0.81169"/>
-   <Atom name="OXT" type="protein-O3" charge="-0.81169"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="HG2"/>
-   <Bond atomName1="CG" atomName2="HG3"/>
-   <Bond atomName1="CG" atomName2="CD"/>
-   <Bond atomName1="CD" atomName2="HD2"/>
-   <Bond atomName1="CD" atomName2="HD3"/>
-   <Bond atomName1="CD" atomName2="CE"/>
-   <Bond atomName1="CE" atomName2="HE2"/>
-   <Bond atomName1="CE" atomName2="HE3"/>
-   <Bond atomName1="CE" atomName2="NZ"/>
-   <Bond atomName1="NZ" atomName2="HZ2"/>
-   <Bond atomName1="NZ" atomName2="HZ3"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <Bond atomName1="C" atomName2="OXT"/>
-   <ExternalBond atomName="N"/>
-  </Residue>
-  <Residue name="CLYS">
-   <Atom name="N" type="protein-N" charge="-0.64105"/>
-   <Atom name="H" type="protein-H" charge="0.35488"/>
-   <Atom name="CA" type="protein-TP" charge="0.0548"/>
-   <Atom name="HA" type="protein-H1" charge="0.0733"/>
-   <Atom name="CB" type="protein-C8" charge="-0.12611"/>
-   <Atom name="HB2" type="protein-HC" charge="0.04989"/>
-   <Atom name="HB3" type="protein-HC" charge="0.04989"/>
-   <Atom name="CG" type="protein-C8" charge="0.01562"/>
-   <Atom name="HG2" type="protein-HC" charge="0.02232"/>
-   <Atom name="HG3" type="protein-HC" charge="0.02232"/>
-   <Atom name="CD" type="protein-C8" charge="-0.04107"/>
-   <Atom name="HD2" type="protein-HC" charge="0.04925"/>
-   <Atom name="HD3" type="protein-HC" charge="0.04925"/>
-   <Atom name="CE" type="protein-C8" charge="0.03253"/>
-   <Atom name="HE2" type="protein-HP" charge="0.10238"/>
-   <Atom name="HE3" type="protein-HP" charge="0.10238"/>
-   <Atom name="NZ" type="protein-NL" charge="-0.5999"/>
-   <Atom name="HZ1" type="protein-H" charge="0.40476"/>
-   <Atom name="HZ2" type="protein-H" charge="0.40476"/>
-   <Atom name="HZ3" type="protein-H" charge="0.40476"/>
-   <Atom name="C" type="protein-CO" charge="0.85422"/>
-   <Atom name="O" type="protein-O3" charge="-0.81959"/>
-   <Atom name="OXT" type="protein-O3" charge="-0.81959"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="HG2"/>
-   <Bond atomName1="CG" atomName2="HG3"/>
-   <Bond atomName1="CG" atomName2="CD"/>
-   <Bond atomName1="CD" atomName2="HD2"/>
-   <Bond atomName1="CD" atomName2="HD3"/>
-   <Bond atomName1="CD" atomName2="CE"/>
-   <Bond atomName1="CE" atomName2="HE2"/>
-   <Bond atomName1="CE" atomName2="HE3"/>
-   <Bond atomName1="CE" atomName2="NZ"/>
-   <Bond atomName1="NZ" atomName2="HZ1"/>
-   <Bond atomName1="NZ" atomName2="HZ2"/>
-   <Bond atomName1="NZ" atomName2="HZ3"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <Bond atomName1="C" atomName2="OXT"/>
-   <ExternalBond atomName="N"/>
-  </Residue>
-  <Residue name="CMET">
-   <Atom name="N" type="protein-N" charge="-0.74668"/>
-   <Atom name="H" type="protein-H" charge="0.37486"/>
-   <Atom name="CA" type="protein-CX" charge="0.27366"/>
-   <Atom name="HA" type="protein-H1" charge="0.01571"/>
-   <Atom name="CB" type="protein-2C" charge="-0.02484"/>
-   <Atom name="HB2" type="protein-HC" charge="0.02296"/>
-   <Atom name="HB3" type="protein-HC" charge="0.02296"/>
-   <Atom name="CG" type="protein-2C" charge="-0.06965"/>
-   <Atom name="HG2" type="protein-H1" charge="0.07399"/>
-   <Atom name="HG3" type="protein-H1" charge="0.07399"/>
-   <Atom name="SD" type="protein-S" charge="-0.23587"/>
-   <Atom name="CE" type="protein-CT" charge="-0.27522"/>
-   <Atom name="HE1" type="protein-H1" charge="0.11976"/>
-   <Atom name="HE2" type="protein-H1" charge="0.11976"/>
-   <Atom name="HE3" type="protein-H1" charge="0.11976"/>
-   <Atom name="C" type="protein-CO" charge="0.75823"/>
-   <Atom name="O" type="protein-O3" charge="-0.81169"/>
-   <Atom name="OXT" type="protein-O3" charge="-0.81169"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="HG2"/>
-   <Bond atomName1="CG" atomName2="HG3"/>
-   <Bond atomName1="CG" atomName2="SD"/>
-   <Bond atomName1="SD" atomName2="CE"/>
-   <Bond atomName1="CE" atomName2="HE1"/>
-   <Bond atomName1="CE" atomName2="HE2"/>
-   <Bond atomName1="CE" atomName2="HE3"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <Bond atomName1="C" atomName2="OXT"/>
-   <ExternalBond atomName="N"/>
-  </Residue>
-  <Residue name="CNLE">
-   <Atom name="N" type="protein-N" charge="-0.74668"/>
-   <Atom name="H" type="protein-H" charge="0.37486"/>
-   <Atom name="CA" type="protein-CX" charge="0.27757"/>
-   <Atom name="HA" type="protein-H1" charge="-0.0051"/>
-   <Atom name="CB" type="protein-2C" charge="-0.0709"/>
-   <Atom name="HB2" type="protein-HC" charge="0.0106"/>
-   <Atom name="HB3" type="protein-HC" charge="0.0106"/>
-   <Atom name="CG" type="protein-2C" charge="0.05418"/>
-   <Atom name="HG2" type="protein-HC" charge="-0.01331"/>
-   <Atom name="HG3" type="protein-HC" charge="-0.01331"/>
-   <Atom name="CD" type="protein-2C" charge="0.09953"/>
-   <Atom name="HD2" type="protein-HC" charge="-0.02455"/>
-   <Atom name="HD3" type="protein-HC" charge="-0.02455"/>
-   <Atom name="CE" type="protein-CT" charge="-0.11953"/>
-   <Atom name="HE1" type="protein-HC" charge="0.01858"/>
-   <Atom name="HE2" type="protein-HC" charge="0.01858"/>
-   <Atom name="HE3" type="protein-HC" charge="0.01858"/>
-   <Atom name="C" type="protein-CO" charge="0.75823"/>
-   <Atom name="O" type="protein-O3" charge="-0.81169"/>
-   <Atom name="OXT" type="protein-O3" charge="-0.81169"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="HG2"/>
-   <Bond atomName1="CG" atomName2="HG3"/>
-   <Bond atomName1="CG" atomName2="CD"/>
-   <Bond atomName1="CD" atomName2="HD2"/>
-   <Bond atomName1="CD" atomName2="HD3"/>
-   <Bond atomName1="CD" atomName2="CE"/>
-   <Bond atomName1="CE" atomName2="HE1"/>
-   <Bond atomName1="CE" atomName2="HE2"/>
-   <Bond atomName1="CE" atomName2="HE3"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <Bond atomName1="C" atomName2="OXT"/>
-   <ExternalBond atomName="N"/>
-  </Residue>
-  <Residue name="CPHE">
-   <Atom name="N" type="protein-N" charge="-0.74668"/>
-   <Atom name="H" type="protein-H" charge="0.37486"/>
-   <Atom name="CA" type="protein-CX" charge="0.32"/>
-   <Atom name="HA" type="protein-H1" charge="0.01647"/>
-   <Atom name="CB" type="protein-TA" charge="-0.17986"/>
-   <Atom name="HB2" type="protein-HC" charge="0.05244"/>
-   <Atom name="HB3" type="protein-HC" charge="0.05244"/>
-   <Atom name="CG" type="protein-CA" charge="0.10524"/>
-   <Atom name="CD1" type="protein-CA" charge="-0.16273"/>
-   <Atom name="HD1" type="protein-HA" charge="0.14536"/>
-   <Atom name="CE1" type="protein-CA" charge="-0.18895"/>
-   <Atom name="HE1" type="protein-HA" charge="0.14296"/>
-   <Atom name="CZ" type="protein-CA" charge="-0.12517"/>
-   <Atom name="HZ" type="protein-HA" charge="0.12213"/>
-   <Atom name="CE2" type="protein-CA" charge="-0.18895"/>
-   <Atom name="HE2" type="protein-HA" charge="0.14296"/>
-   <Atom name="CD2" type="protein-CA" charge="-0.16273"/>
-   <Atom name="HD2" type="protein-HA" charge="0.14536"/>
-   <Atom name="C" type="protein-CO" charge="0.75823"/>
-   <Atom name="O" type="protein-O3" charge="-0.81169"/>
-   <Atom name="OXT" type="protein-O3" charge="-0.81169"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="CD1"/>
-   <Bond atomName1="CG" atomName2="CD2"/>
-   <Bond atomName1="CD1" atomName2="HD1"/>
-   <Bond atomName1="CD1" atomName2="CE1"/>
-   <Bond atomName1="CE1" atomName2="HE1"/>
-   <Bond atomName1="CE1" atomName2="CZ"/>
-   <Bond atomName1="CZ" atomName2="HZ"/>
-   <Bond atomName1="CZ" atomName2="CE2"/>
-   <Bond atomName1="CE2" atomName2="HE2"/>
-   <Bond atomName1="CE2" atomName2="CD2"/>
-   <Bond atomName1="CD2" atomName2="HD2"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <Bond atomName1="C" atomName2="OXT"/>
-   <ExternalBond atomName="N"/>
-  </Residue>
-  <Residue name="CPRO">
-   <Atom name="N" type="protein-TN" charge="-0.51659"/>
-   <Atom name="CD" type="protein-CT" charge="0.12764"/>
-   <Atom name="HD2" type="protein-H1" charge="0.00676"/>
-   <Atom name="HD3" type="protein-H1" charge="0.00676"/>
-   <Atom name="CG" type="protein-CT" charge="0.01993"/>
-   <Atom name="HG2" type="protein-HC" charge="0.00443"/>
-   <Atom name="HG3" type="protein-HC" charge="0.00443"/>
-   <Atom name="CB" type="protein-CT" charge="-0.00483"/>
-   <Atom name="HB2" type="protein-HC" charge="-0.00183"/>
-   <Atom name="HB3" type="protein-HC" charge="-0.00183"/>
-   <Atom name="CA" type="protein-TJ" charge="0.29691"/>
-   <Atom name="HA" type="protein-H1" charge="-0.04305"/>
-   <Atom name="C" type="protein-CO" charge="0.68077"/>
-   <Atom name="O" type="protein-O3" charge="-0.78975"/>
-   <Atom name="OXT" type="protein-O3" charge="-0.78975"/>
-   <Bond atomName1="N" atomName2="CD"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CD" atomName2="HD2"/>
-   <Bond atomName1="CD" atomName2="HD3"/>
-   <Bond atomName1="CD" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="HG2"/>
-   <Bond atomName1="CG" atomName2="HG3"/>
-   <Bond atomName1="CG" atomName2="CB"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <Bond atomName1="C" atomName2="OXT"/>
-   <ExternalBond atomName="N"/>
-  </Residue>
-  <Residue name="CSER">
-   <Atom name="N" type="protein-N" charge="-0.74668"/>
-   <Atom name="H" type="protein-H" charge="0.37486"/>
-   <Atom name="CA" type="protein-CX" charge="0.294"/>
-   <Atom name="HA" type="protein-H1" charge="0.02507"/>
-   <Atom name="CB" type="protein-2C" charge="0.03129"/>
-   <Atom name="HB2" type="protein-H1" charge="0.05251"/>
-   <Atom name="HB3" type="protein-H1" charge="0.05251"/>
-   <Atom name="OG" type="protein-OA" charge="-0.59434"/>
-   <Atom name="HG" type="protein-HO" charge="0.37593"/>
-   <Atom name="C" type="protein-CO" charge="0.75823"/>
-   <Atom name="O" type="protein-O3" charge="-0.81169"/>
-   <Atom name="OXT" type="protein-O3" charge="-0.81169"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="OG"/>
-   <Bond atomName1="OG" atomName2="HG"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <Bond atomName1="C" atomName2="OXT"/>
-   <ExternalBond atomName="N"/>
-  </Residue>
-  <Residue name="CTHR">
-   <Atom name="N" type="protein-N" charge="-0.74668"/>
-   <Atom name="H" type="protein-H" charge="0.37486"/>
-   <Atom name="CA" type="protein-CX" charge="0.33829"/>
-   <Atom name="HA" type="protein-H1" charge="0.00468"/>
-   <Atom name="CB" type="protein-3C" charge="0.11114"/>
-   <Atom name="HB" type="protein-H1" charge="0.04005"/>
-   <Atom name="CG2" type="protein-CT" charge="-0.28595"/>
-   <Atom name="HG21" type="protein-HC" charge="0.08492"/>
-   <Atom name="HG22" type="protein-HC" charge="0.08492"/>
-   <Atom name="HG23" type="protein-HC" charge="0.08492"/>
-   <Atom name="OG1" type="protein-OA" charge="-0.58562"/>
-   <Atom name="HG1" type="protein-HO" charge="0.35962"/>
-   <Atom name="C" type="protein-CO" charge="0.75823"/>
-   <Atom name="O" type="protein-O3" charge="-0.81169"/>
-   <Atom name="OXT" type="protein-O3" charge="-0.81169"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB"/>
-   <Bond atomName1="CB" atomName2="CG2"/>
-   <Bond atomName1="CB" atomName2="OG1"/>
-   <Bond atomName1="CG2" atomName2="HG21"/>
-   <Bond atomName1="CG2" atomName2="HG22"/>
-   <Bond atomName1="CG2" atomName2="HG23"/>
-   <Bond atomName1="OG1" atomName2="HG1"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <Bond atomName1="C" atomName2="OXT"/>
-   <ExternalBond atomName="N"/>
-  </Residue>
-  <Residue name="CTRP">
-   <Atom name="N" type="protein-N" charge="-0.74668"/>
-   <Atom name="H" type="protein-H" charge="0.37486"/>
-   <Atom name="CA" type="protein-CX" charge="0.33157"/>
-   <Atom name="HA" type="protein-H1" charge="0.01203"/>
-   <Atom name="CB" type="protein-TA" charge="-0.21601"/>
-   <Atom name="HB2" type="protein-HC" charge="0.07021"/>
-   <Atom name="HB3" type="protein-HC" charge="0.07021"/>
-   <Atom name="CG" type="protein-C*" charge="-0.05669"/>
-   <Atom name="CD1" type="protein-CW" charge="-0.12723"/>
-   <Atom name="HD1" type="protein-H4" charge="0.18894"/>
-   <Atom name="NE1" type="protein-NA" charge="-0.48884"/>
-   <Atom name="HE1" type="protein-H" charge="0.39422"/>
-   <Atom name="CE2" type="protein-CN" charge="0.26453"/>
-   <Atom name="CZ2" type="protein-CA" charge="-0.34562"/>
-   <Atom name="HZ2" type="protein-HA" charge="0.16875"/>
-   <Atom name="CH2" type="protein-CA" charge="-0.13992"/>
-   <Atom name="HH2" type="protein-HA" charge="0.14149"/>
-   <Atom name="CZ3" type="protein-CA" charge="-0.21557"/>
-   <Atom name="HZ3" type="protein-HA" charge="0.14771"/>
-   <Atom name="CE3" type="protein-CA" charge="-0.24421"/>
-   <Atom name="HE3" type="protein-HA" charge="0.17347"/>
-   <Atom name="CD2" type="protein-CB" charge="0.10793"/>
-   <Atom name="C" type="protein-CO" charge="0.75823"/>
-   <Atom name="O" type="protein-O3" charge="-0.81169"/>
-   <Atom name="OXT" type="protein-O3" charge="-0.81169"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="CD1"/>
-   <Bond atomName1="CG" atomName2="CD2"/>
-   <Bond atomName1="CD1" atomName2="HD1"/>
-   <Bond atomName1="CD1" atomName2="NE1"/>
-   <Bond atomName1="NE1" atomName2="HE1"/>
-   <Bond atomName1="NE1" atomName2="CE2"/>
-   <Bond atomName1="CE2" atomName2="CZ2"/>
-   <Bond atomName1="CE2" atomName2="CD2"/>
-   <Bond atomName1="CZ2" atomName2="HZ2"/>
-   <Bond atomName1="CZ2" atomName2="CH2"/>
-   <Bond atomName1="CH2" atomName2="HH2"/>
-   <Bond atomName1="CH2" atomName2="CZ3"/>
-   <Bond atomName1="CZ3" atomName2="HZ3"/>
-   <Bond atomName1="CZ3" atomName2="CE3"/>
-   <Bond atomName1="CE3" atomName2="HE3"/>
-   <Bond atomName1="CE3" atomName2="CD2"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <Bond atomName1="C" atomName2="OXT"/>
-   <ExternalBond atomName="N"/>
-  </Residue>
-  <Residue name="CTYR">
-   <Atom name="N" type="protein-N" charge="-0.74668"/>
-   <Atom name="H" type="protein-H" charge="0.37486"/>
-   <Atom name="CA" type="protein-CX" charge="0.33041"/>
-   <Atom name="HA" type="protein-H1" charge="0.01476"/>
-   <Atom name="CB" type="protein-TA" charge="-0.2414"/>
-   <Atom name="HB2" type="protein-HC" charge="0.07357"/>
-   <Atom name="HB3" type="protein-HC" charge="0.07357"/>
-   <Atom name="CG" type="protein-CA" charge="0.11599"/>
-   <Atom name="CD1" type="protein-CA" charge="-0.20615"/>
-   <Atom name="HD1" type="protein-HA" charge="0.1669"/>
-   <Atom name="CE1" type="protein-CA" charge="-0.28454"/>
-   <Atom name="HE1" type="protein-HA" charge="0.17573"/>
-   <Atom name="CZ" type="protein-C" charge="0.32748"/>
-   <Atom name="OH" type="protein-OA" charge="-0.53026"/>
-   <Atom name="HH" type="protein-HO" charge="0.36897"/>
-   <Atom name="CE2" type="protein-CA" charge="-0.28454"/>
-   <Atom name="HE2" type="protein-HA" charge="0.17573"/>
-   <Atom name="CD2" type="protein-CA" charge="-0.20615"/>
-   <Atom name="HD2" type="protein-HA" charge="0.1669"/>
-   <Atom name="C" type="protein-CO" charge="0.75823"/>
-   <Atom name="O" type="protein-O3" charge="-0.81169"/>
-   <Atom name="OXT" type="protein-O3" charge="-0.81169"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="CD1"/>
-   <Bond atomName1="CG" atomName2="CD2"/>
-   <Bond atomName1="CD1" atomName2="HD1"/>
-   <Bond atomName1="CD1" atomName2="CE1"/>
-   <Bond atomName1="CE1" atomName2="HE1"/>
-   <Bond atomName1="CE1" atomName2="CZ"/>
-   <Bond atomName1="CZ" atomName2="OH"/>
-   <Bond atomName1="CZ" atomName2="CE2"/>
-   <Bond atomName1="OH" atomName2="HH"/>
-   <Bond atomName1="CE2" atomName2="HE2"/>
-   <Bond atomName1="CE2" atomName2="CD2"/>
-   <Bond atomName1="CD2" atomName2="HD2"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <Bond atomName1="C" atomName2="OXT"/>
-   <ExternalBond atomName="N"/>
-  </Residue>
-  <Residue name="CVAL">
-   <Atom name="N" type="protein-N" charge="-0.74668"/>
-   <Atom name="H" type="protein-H" charge="0.37486"/>
-   <Atom name="CA" type="protein-CX" charge="0.23649"/>
-   <Atom name="HA" type="protein-H1" charge="0.0253"/>
-   <Atom name="CB" type="protein-3C" charge="0.14515"/>
-   <Atom name="HB" type="protein-HC" charge="0.00761"/>
-   <Atom name="CG1" type="protein-CT" charge="-0.29771"/>
-   <Atom name="HG11" type="protein-HC" charge="0.06964"/>
-   <Atom name="HG12" type="protein-HC" charge="0.06964"/>
-   <Atom name="HG13" type="protein-HC" charge="0.06964"/>
-   <Atom name="CG2" type="protein-CT" charge="-0.29771"/>
-   <Atom name="HG21" type="protein-HC" charge="0.06964"/>
-   <Atom name="HG22" type="protein-HC" charge="0.06964"/>
-   <Atom name="HG23" type="protein-HC" charge="0.06964"/>
-   <Atom name="C" type="protein-CO" charge="0.75823"/>
-   <Atom name="O" type="protein-O3" charge="-0.81169"/>
-   <Atom name="OXT" type="protein-O3" charge="-0.81169"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB"/>
-   <Bond atomName1="CB" atomName2="CG1"/>
-   <Bond atomName1="CB" atomName2="CG2"/>
-   <Bond atomName1="CG1" atomName2="HG11"/>
-   <Bond atomName1="CG1" atomName2="HG12"/>
-   <Bond atomName1="CG1" atomName2="HG13"/>
-   <Bond atomName1="CG2" atomName2="HG21"/>
-   <Bond atomName1="CG2" atomName2="HG22"/>
-   <Bond atomName1="CG2" atomName2="HG23"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <Bond atomName1="C" atomName2="OXT"/>
-   <ExternalBond atomName="N"/>
-  </Residue>
-  <Residue name="NHE">
-   <Atom name="N" type="protein-ND" charge="-0.79352"/>
-   <Atom name="HN1" type="protein-H" charge="0.39676"/>
-   <Atom name="HN2" type="protein-H" charge="0.39676"/>
-   <Bond atomName1="N" atomName2="HN1"/>
-   <Bond atomName1="N" atomName2="HN2"/>
-   <ExternalBond atomName="N"/>
-  </Residue>
-  <Residue name="NME">
-   <Atom name="N" type="protein-N" charge="-0.55366"/>
-   <Atom name="H" type="protein-H" charge="0.33672"/>
-   <Atom name="CH3" type="protein-CT" charge="-0.01295"/>
-   <Atom name="HH31" type="protein-H1" charge="0.07663"/>
-   <Atom name="HH32" type="protein-H1" charge="0.07663"/>
-   <Atom name="HH33" type="protein-H1" charge="0.07663"/>
-   <Bond atomName1="N" atomName2="H"/>
-   <Bond atomName1="N" atomName2="CH3"/>
-   <Bond atomName1="CH3" atomName2="HH31"/>
-   <Bond atomName1="CH3" atomName2="HH32"/>
-   <Bond atomName1="CH3" atomName2="HH33"/>
-   <ExternalBond atomName="N"/>
-  </Residue>
-  <Residue name="ACE">
-   <Atom name="HH31" type="protein-HC" charge="0.02217"/>
-   <Atom name="CH3" type="protein-CT" charge="-0.0163"/>
-   <Atom name="HH32" type="protein-HC" charge="0.02217"/>
-   <Atom name="HH33" type="protein-HC" charge="0.02217"/>
-   <Atom name="C" type="protein-C" charge="0.52664"/>
-   <Atom name="O" type="protein-OD" charge="-0.57685"/>
-   <Bond atomName1="HH31" atomName2="CH3"/>
-   <Bond atomName1="CH3" atomName2="HH32"/>
-   <Bond atomName1="CH3" atomName2="HH33"/>
-   <Bond atomName1="CH3" atomName2="C"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="NALA">
-   <Atom name="N" type="protein-NL" charge="-0.57901"/>
-   <Atom name="H1" type="protein-H" charge="0.41726"/>
-   <Atom name="H2" type="protein-H" charge="0.41726"/>
-   <Atom name="H3" type="protein-H" charge="0.41726"/>
-   <Atom name="CA" type="protein-CX" charge="-0.30687"/>
-   <Atom name="HA" type="protein-HP" charge="0.19632"/>
-   <Atom name="CB" type="protein-CT" charge="-0.04614"/>
-   <Atom name="HB1" type="protein-HC" charge="0.07255"/>
-   <Atom name="HB2" type="protein-HC" charge="0.07255"/>
-   <Atom name="HB3" type="protein-HC" charge="0.07255"/>
-   <Atom name="C" type="protein-C" charge="0.86628"/>
-   <Atom name="O" type="protein-OD" charge="-0.60001"/>
-   <Bond atomName1="N" atomName2="H1"/>
-   <Bond atomName1="N" atomName2="H2"/>
-   <Bond atomName1="N" atomName2="H3"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB1"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="NARG">
-   <Atom name="N" type="protein-NL" charge="-0.55563"/>
-   <Atom name="H1" type="protein-H" charge="0.42068"/>
-   <Atom name="H2" type="protein-H" charge="0.42068"/>
-   <Atom name="H3" type="protein-H" charge="0.42068"/>
-   <Atom name="CA" type="protein-TP" charge="-0.43574"/>
-   <Atom name="HA" type="protein-HP" charge="0.22117"/>
-   <Atom name="CB" type="protein-C8" charge="0.02261"/>
-   <Atom name="HB2" type="protein-HC" charge="0.06652"/>
-   <Atom name="HB3" type="protein-HC" charge="0.06652"/>
-   <Atom name="CG" type="protein-C8" charge="-0.09031"/>
-   <Atom name="HG2" type="protein-HC" charge="0.07565"/>
-   <Atom name="HG3" type="protein-HC" charge="0.07565"/>
-   <Atom name="CD" type="protein-C8" charge="0.00155"/>
-   <Atom name="HD2" type="protein-H1" charge="0.12163"/>
-   <Atom name="HD3" type="protein-H1" charge="0.12163"/>
-   <Atom name="NE" type="protein-N2" charge="-0.55169"/>
-   <Atom name="HE" type="protein-TH" charge="0.39503"/>
-   <Atom name="CZ" type="protein-CA" charge="0.68974"/>
-   <Atom name="NH1" type="protein-N2" charge="-0.78519"/>
-   <Atom name="HH11" type="protein-TH" charge="0.43756"/>
-   <Atom name="HH12" type="protein-TH" charge="0.43756"/>
-   <Atom name="NH2" type="protein-N2" charge="-0.78519"/>
-   <Atom name="HH21" type="protein-TH" charge="0.43756"/>
-   <Atom name="HH22" type="protein-TH" charge="0.43756"/>
-   <Atom name="C" type="protein-C" charge="0.93375"/>
-   <Atom name="O" type="protein-OD" charge="-0.59998"/>
-   <Bond atomName1="N" atomName2="H1"/>
-   <Bond atomName1="N" atomName2="H2"/>
-   <Bond atomName1="N" atomName2="H3"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="HG2"/>
-   <Bond atomName1="CG" atomName2="HG3"/>
-   <Bond atomName1="CG" atomName2="CD"/>
-   <Bond atomName1="CD" atomName2="HD2"/>
-   <Bond atomName1="CD" atomName2="HD3"/>
-   <Bond atomName1="CD" atomName2="NE"/>
-   <Bond atomName1="NE" atomName2="HE"/>
-   <Bond atomName1="NE" atomName2="CZ"/>
-   <Bond atomName1="CZ" atomName2="NH1"/>
-   <Bond atomName1="CZ" atomName2="NH2"/>
-   <Bond atomName1="NH1" atomName2="HH11"/>
-   <Bond atomName1="NH1" atomName2="HH12"/>
-   <Bond atomName1="NH2" atomName2="HH21"/>
-   <Bond atomName1="NH2" atomName2="HH22"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="NASH">
-   <Atom name="N" type="protein-NL" charge="-0.57901"/>
-   <Atom name="H1" type="protein-H" charge="0.41726"/>
-   <Atom name="H2" type="protein-H" charge="0.41726"/>
-   <Atom name="H3" type="protein-H" charge="0.41726"/>
-   <Atom name="CA" type="protein-CX" charge="-0.28453"/>
-   <Atom name="HA" type="protein-HP" charge="0.19375"/>
-   <Atom name="CB" type="protein-2C" charge="-0.04657"/>
-   <Atom name="HB2" type="protein-HC" charge="0.09891"/>
-   <Atom name="HB3" type="protein-HC" charge="0.09891"/>
-   <Atom name="CG" type="protein-C" charge="0.61332"/>
-   <Atom name="OD1" type="protein-O" charge="-0.51422"/>
-   <Atom name="OD2" type="protein-OH" charge="-0.57065"/>
-   <Atom name="HD2" type="protein-HO" charge="0.47204"/>
-   <Atom name="C" type="protein-C" charge="0.86628"/>
-   <Atom name="O" type="protein-OD" charge="-0.60001"/>
-   <Bond atomName1="N" atomName2="H1"/>
-   <Bond atomName1="N" atomName2="H2"/>
-   <Bond atomName1="N" atomName2="H3"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="OD1"/>
-   <Bond atomName1="CG" atomName2="OD2"/>
-   <Bond atomName1="OD2" atomName2="HD2"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="NASN">
-   <Atom name="N" type="protein-NL" charge="-0.57901"/>
-   <Atom name="H1" type="protein-H" charge="0.41726"/>
-   <Atom name="H2" type="protein-H" charge="0.41726"/>
-   <Atom name="H3" type="protein-H" charge="0.41726"/>
-   <Atom name="CA" type="protein-CX" charge="-0.28854"/>
-   <Atom name="HA" type="protein-HP" charge="0.19917"/>
-   <Atom name="CB" type="protein-2C" charge="-0.14198"/>
-   <Atom name="HB2" type="protein-HC" charge="0.10577"/>
-   <Atom name="HB3" type="protein-HC" charge="0.10577"/>
-   <Atom name="CG" type="protein-C" charge="0.68363"/>
-   <Atom name="OD1" type="protein-OD" charge="-0.57945"/>
-   <Atom name="ND2" type="protein-ND" charge="-0.90315"/>
-   <Atom name="HD21" type="protein-H" charge="0.46825"/>
-   <Atom name="HD22" type="protein-H" charge="0.41149"/>
-   <Atom name="C" type="protein-C" charge="0.86628"/>
-   <Atom name="O" type="protein-OD" charge="-0.60001"/>
-   <Bond atomName1="N" atomName2="H1"/>
-   <Bond atomName1="N" atomName2="H2"/>
-   <Bond atomName1="N" atomName2="H3"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="OD1"/>
-   <Bond atomName1="CG" atomName2="ND2"/>
-   <Bond atomName1="ND2" atomName2="HD21"/>
-   <Bond atomName1="ND2" atomName2="HD22"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="NASP">
-   <Atom name="N" type="protein-NL" charge="-0.67824"/>
-   <Atom name="H1" type="protein-H" charge="0.4245"/>
-   <Atom name="H2" type="protein-H" charge="0.4245"/>
-   <Atom name="H3" type="protein-H" charge="0.4245"/>
-   <Atom name="CA" type="protein-TM" charge="-0.14531"/>
-   <Atom name="HA" type="protein-HP" charge="0.1356"/>
-   <Atom name="CB" type="protein-2C" charge="-0.01341"/>
-   <Atom name="HB2" type="protein-HC" charge="0.02837"/>
-   <Atom name="HB3" type="protein-HC" charge="0.02837"/>
-   <Atom name="CG" type="protein-CO" charge="0.75101"/>
-   <Atom name="OD1" type="protein-O3" charge="-0.77122"/>
-   <Atom name="OD2" type="protein-O3" charge="-0.77122"/>
-   <Atom name="C" type="protein-C" charge="0.78778"/>
-   <Atom name="O" type="protein-OD" charge="-0.62523"/>
-   <Bond atomName1="N" atomName2="H1"/>
-   <Bond atomName1="N" atomName2="H2"/>
-   <Bond atomName1="N" atomName2="H3"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="OD1"/>
-   <Bond atomName1="CG" atomName2="OD2"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="NCYM">
-   <Atom name="N" type="protein-NL" charge="-0.67824"/>
-   <Atom name="H1" type="protein-H" charge="0.4245"/>
-   <Atom name="H2" type="protein-H" charge="0.4245"/>
-   <Atom name="H3" type="protein-H" charge="0.4245"/>
-   <Atom name="CA" type="protein-TM" charge="-0.14692"/>
-   <Atom name="HA" type="protein-HP" charge="0.1501"/>
-   <Atom name="CB" type="protein-2C" charge="-0.05731"/>
-   <Atom name="HB2" type="protein-H1" charge="0.12089"/>
-   <Atom name="HB3" type="protein-H1" charge="0.12089"/>
-   <Atom name="SG" type="protein-SH" charge="-0.94546"/>
-   <Atom name="C" type="protein-C" charge="0.78778"/>
-   <Atom name="O" type="protein-OD" charge="-0.62523"/>
-   <Bond atomName1="N" atomName2="H1"/>
-   <Bond atomName1="N" atomName2="H2"/>
-   <Bond atomName1="N" atomName2="H3"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="SG"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="NCYS">
-   <Atom name="N" type="protein-NL" charge="-0.57901"/>
-   <Atom name="H1" type="protein-H" charge="0.41726"/>
-   <Atom name="H2" type="protein-H" charge="0.41726"/>
-   <Atom name="H3" type="protein-H" charge="0.41726"/>
-   <Atom name="CA" type="protein-CX" charge="-0.26817"/>
-   <Atom name="HA" type="protein-HP" charge="0.18603"/>
-   <Atom name="CB" type="protein-2C" charge="-0.09826"/>
-   <Atom name="HB2" type="protein-H1" charge="0.13404"/>
-   <Atom name="HB3" type="protein-H1" charge="0.13404"/>
-   <Atom name="SG" type="protein-SH" charge="-0.24071"/>
-   <Atom name="HG" type="protein-HS" charge="0.21399"/>
-   <Atom name="C" type="protein-C" charge="0.86628"/>
-   <Atom name="O" type="protein-OD" charge="-0.60001"/>
-   <Bond atomName1="N" atomName2="H1"/>
-   <Bond atomName1="N" atomName2="H2"/>
-   <Bond atomName1="N" atomName2="H3"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="SG"/>
-   <Bond atomName1="SG" atomName2="HG"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="NCYX">
-   <Atom name="N" type="protein-NL" charge="-0.57901"/>
-   <Atom name="H1" type="protein-H" charge="0.41726"/>
-   <Atom name="H2" type="protein-H" charge="0.41726"/>
-   <Atom name="H3" type="protein-H" charge="0.41726"/>
-   <Atom name="CA" type="protein-CX" charge="-0.32888"/>
-   <Atom name="HA" type="protein-HP" charge="0.21969"/>
-   <Atom name="CB" type="protein-2C" charge="-0.1221"/>
-   <Atom name="HB2" type="protein-H1" charge="0.14205"/>
-   <Atom name="HB3" type="protein-H1" charge="0.14205"/>
-   <Atom name="SG" type="protein-S" charge="0.00815"/>
-   <Atom name="C" type="protein-C" charge="0.86628"/>
-   <Atom name="O" type="protein-OD" charge="-0.60001"/>
-   <Bond atomName1="N" atomName2="H1"/>
-   <Bond atomName1="N" atomName2="H2"/>
-   <Bond atomName1="N" atomName2="H3"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="SG"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="NGLH">
-   <Atom name="N" type="protein-NL" charge="-0.57901"/>
-   <Atom name="H1" type="protein-H" charge="0.41726"/>
-   <Atom name="H2" type="protein-H" charge="0.41726"/>
-   <Atom name="H3" type="protein-H" charge="0.41726"/>
-   <Atom name="CA" type="protein-CX" charge="-0.35065"/>
-   <Atom name="HA" type="protein-HP" charge="0.21783"/>
-   <Atom name="CB" type="protein-2C" charge="-0.00802"/>
-   <Atom name="HB2" type="protein-HC" charge="0.08233"/>
-   <Atom name="HB3" type="protein-HC" charge="0.08233"/>
-   <Atom name="CG" type="protein-2C" charge="-0.13715"/>
-   <Atom name="HG2" type="protein-HC" charge="0.09906"/>
-   <Atom name="HG3" type="protein-HC" charge="0.09906"/>
-   <Atom name="CD" type="protein-C" charge="0.61666"/>
-   <Atom name="OE1" type="protein-O" charge="-0.53525"/>
-   <Atom name="OE2" type="protein-OH" charge="-0.58775"/>
-   <Atom name="HE2" type="protein-HO" charge="0.48251"/>
-   <Atom name="C" type="protein-C" charge="0.86628"/>
-   <Atom name="O" type="protein-OD" charge="-0.60001"/>
-   <Bond atomName1="N" atomName2="H1"/>
-   <Bond atomName1="N" atomName2="H2"/>
-   <Bond atomName1="N" atomName2="H3"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="HG2"/>
-   <Bond atomName1="CG" atomName2="HG3"/>
-   <Bond atomName1="CG" atomName2="CD"/>
-   <Bond atomName1="CD" atomName2="OE1"/>
-   <Bond atomName1="CD" atomName2="OE2"/>
-   <Bond atomName1="OE2" atomName2="HE2"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="NGLN">
-   <Atom name="N" type="protein-NL" charge="-0.57901"/>
-   <Atom name="H1" type="protein-H" charge="0.41726"/>
-   <Atom name="H2" type="protein-H" charge="0.41726"/>
-   <Atom name="H3" type="protein-H" charge="0.41726"/>
-   <Atom name="CA" type="protein-CX" charge="-0.33009"/>
-   <Atom name="HA" type="protein-HP" charge="0.19043"/>
-   <Atom name="CB" type="protein-2C" charge="0.00168"/>
-   <Atom name="HB2" type="protein-HC" charge="0.07453"/>
-   <Atom name="HB3" type="protein-HC" charge="0.07453"/>
-   <Atom name="CG" type="protein-2C" charge="-0.09634"/>
-   <Atom name="HG2" type="protein-HC" charge="0.06339"/>
-   <Atom name="HG3" type="protein-HC" charge="0.06339"/>
-   <Atom name="CD" type="protein-C" charge="0.62545"/>
-   <Atom name="OE1" type="protein-OD" charge="-0.57948"/>
-   <Atom name="NE2" type="protein-ND" charge="-0.88146"/>
-   <Atom name="HE21" type="protein-H" charge="0.45328"/>
-   <Atom name="HE22" type="protein-H" charge="0.40165"/>
-   <Atom name="C" type="protein-C" charge="0.86628"/>
-   <Atom name="O" type="protein-OD" charge="-0.60001"/>
-   <Bond atomName1="N" atomName2="H1"/>
-   <Bond atomName1="N" atomName2="H2"/>
-   <Bond atomName1="N" atomName2="H3"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="HG2"/>
-   <Bond atomName1="CG" atomName2="HG3"/>
-   <Bond atomName1="CG" atomName2="CD"/>
-   <Bond atomName1="CD" atomName2="OE1"/>
-   <Bond atomName1="CD" atomName2="NE2"/>
-   <Bond atomName1="NE2" atomName2="HE21"/>
-   <Bond atomName1="NE2" atomName2="HE22"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="NGLU">
-   <Atom name="N" type="protein-NL" charge="-0.67824"/>
-   <Atom name="H1" type="protein-H" charge="0.4245"/>
-   <Atom name="H2" type="protein-H" charge="0.4245"/>
-   <Atom name="H3" type="protein-H" charge="0.4245"/>
-   <Atom name="CA" type="protein-TM" charge="-0.14956"/>
-   <Atom name="HA" type="protein-HP" charge="0.15153"/>
-   <Atom name="CB" type="protein-2C" charge="0.01587"/>
-   <Atom name="HB2" type="protein-HC" charge="0.05517"/>
-   <Atom name="HB3" type="protein-HC" charge="0.05517"/>
-   <Atom name="CG" type="protein-2C" charge="-0.20791"/>
-   <Atom name="HG2" type="protein-HC" charge="0.05222"/>
-   <Atom name="HG3" type="protein-HC" charge="0.05222"/>
-   <Atom name="CD" type="protein-CO" charge="0.81958"/>
-   <Atom name="OE1" type="protein-O3" charge="-0.80105"/>
-   <Atom name="OE2" type="protein-O3" charge="-0.80105"/>
-   <Atom name="C" type="protein-C" charge="0.78778"/>
-   <Atom name="O" type="protein-OD" charge="-0.62523"/>
-   <Bond atomName1="N" atomName2="H1"/>
-   <Bond atomName1="N" atomName2="H2"/>
-   <Bond atomName1="N" atomName2="H3"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="HG2"/>
-   <Bond atomName1="CG" atomName2="HG3"/>
-   <Bond atomName1="CG" atomName2="CD"/>
-   <Bond atomName1="CD" atomName2="OE1"/>
-   <Bond atomName1="CD" atomName2="OE2"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="NGLY">
-   <Atom name="N" type="protein-NL" charge="-0.34343"/>
-   <Atom name="H1" type="protein-H" charge="0.36841"/>
-   <Atom name="H2" type="protein-H" charge="0.36841"/>
-   <Atom name="H3" type="protein-H" charge="0.36841"/>
-   <Atom name="CA" type="protein-TG" charge="-0.45131"/>
-   <Atom name="HA2" type="protein-HP" charge="0.21061"/>
-   <Atom name="HA3" type="protein-HP" charge="0.21061"/>
-   <Atom name="C" type="protein-C" charge="0.90833"/>
-   <Atom name="O" type="protein-OD" charge="-0.64004"/>
-   <Bond atomName1="N" atomName2="H1"/>
-   <Bond atomName1="N" atomName2="H2"/>
-   <Bond atomName1="N" atomName2="H3"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA2"/>
-   <Bond atomName1="CA" atomName2="HA3"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="NHID">
-   <Atom name="N" type="protein-NL" charge="-0.57901"/>
-   <Atom name="H1" type="protein-H" charge="0.41726"/>
-   <Atom name="H2" type="protein-H" charge="0.41726"/>
-   <Atom name="H3" type="protein-H" charge="0.41726"/>
-   <Atom name="CA" type="protein-CX" charge="-0.29585"/>
-   <Atom name="HA" type="protein-HP" charge="0.18815"/>
-   <Atom name="CB" type="protein-TA" charge="-0.05104"/>
-   <Atom name="HB2" type="protein-HC" charge="0.09588"/>
-   <Atom name="HB3" type="protein-HC" charge="0.09588"/>
-   <Atom name="CG" type="protein-CC" charge="0.01667"/>
-   <Atom name="ND1" type="protein-NA" charge="-0.3541"/>
-   <Atom name="HD1" type="protein-H" charge="0.36984"/>
-   <Atom name="CE1" type="protein-CR" charge="0.22082"/>
-   <Atom name="HE1" type="protein-H5" charge="0.13389"/>
-   <Atom name="NE2" type="protein-NB" charge="-0.55994"/>
-   <Atom name="CD2" type="protein-CV" charge="0.07247"/>
-   <Atom name="HD2" type="protein-H4" charge="0.12829"/>
-   <Atom name="C" type="protein-C" charge="0.86628"/>
-   <Atom name="O" type="protein-OD" charge="-0.60001"/>
-   <Bond atomName1="N" atomName2="H1"/>
-   <Bond atomName1="N" atomName2="H2"/>
-   <Bond atomName1="N" atomName2="H3"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="ND1"/>
-   <Bond atomName1="CG" atomName2="CD2"/>
-   <Bond atomName1="ND1" atomName2="HD1"/>
-   <Bond atomName1="ND1" atomName2="CE1"/>
-   <Bond atomName1="CE1" atomName2="HE1"/>
-   <Bond atomName1="CE1" atomName2="NE2"/>
-   <Bond atomName1="NE2" atomName2="CD2"/>
-   <Bond atomName1="CD2" atomName2="HD2"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="NHIE">
-   <Atom name="N" type="protein-NL" charge="-0.57901"/>
-   <Atom name="H1" type="protein-H" charge="0.41726"/>
-   <Atom name="H2" type="protein-H" charge="0.41726"/>
-   <Atom name="H3" type="protein-H" charge="0.41726"/>
-   <Atom name="CA" type="protein-CX" charge="-0.31328"/>
-   <Atom name="HA" type="protein-HP" charge="0.19723"/>
-   <Atom name="CB" type="protein-TA" charge="-0.09251"/>
-   <Atom name="HB2" type="protein-HC" charge="0.10035"/>
-   <Atom name="HB3" type="protein-HC" charge="0.10035"/>
-   <Atom name="CG" type="protein-CC" charge="0.28206"/>
-   <Atom name="ND1" type="protein-NB" charge="-0.57714"/>
-   <Atom name="CE1" type="protein-CR" charge="0.12112"/>
-   <Atom name="HE1" type="protein-H5" charge="0.15646"/>
-   <Atom name="NE2" type="protein-NA" charge="-0.19794"/>
-   <Atom name="HE2" type="protein-H" charge="0.36647"/>
-   <Atom name="CD2" type="protein-CW" charge="-0.26707"/>
-   <Atom name="HD2" type="protein-H4" charge="0.18486"/>
-   <Atom name="C" type="protein-C" charge="0.86628"/>
-   <Atom name="O" type="protein-OD" charge="-0.60001"/>
-   <Bond atomName1="N" atomName2="H1"/>
-   <Bond atomName1="N" atomName2="H2"/>
-   <Bond atomName1="N" atomName2="H3"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="ND1"/>
-   <Bond atomName1="CG" atomName2="CD2"/>
-   <Bond atomName1="ND1" atomName2="CE1"/>
-   <Bond atomName1="CE1" atomName2="HE1"/>
-   <Bond atomName1="CE1" atomName2="NE2"/>
-   <Bond atomName1="NE2" atomName2="HE2"/>
-   <Bond atomName1="NE2" atomName2="CD2"/>
-   <Bond atomName1="CD2" atomName2="HD2"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="NHIP">
-   <Atom name="N" type="protein-NL" charge="-0.55563"/>
-   <Atom name="H1" type="protein-H" charge="0.42068"/>
-   <Atom name="H2" type="protein-H" charge="0.42068"/>
-   <Atom name="H3" type="protein-H" charge="0.42068"/>
-   <Atom name="CA" type="protein-TP" charge="-0.35744"/>
-   <Atom name="HA" type="protein-HP" charge="0.20599"/>
-   <Atom name="CB" type="protein-C8" charge="-0.02917"/>
-   <Atom name="HB2" type="protein-HC" charge="0.12825"/>
-   <Atom name="HB3" type="protein-HC" charge="0.12825"/>
-   <Atom name="CG" type="protein-CC" charge="0.00654"/>
-   <Atom name="ND1" type="protein-NA" charge="-0.18032"/>
-   <Atom name="HD1" type="protein-H" charge="0.40428"/>
-   <Atom name="CE1" type="protein-CR" charge="0.03759"/>
-   <Atom name="HE1" type="protein-H5" charge="0.23242"/>
-   <Atom name="NE2" type="protein-NA" charge="-0.18237"/>
-   <Atom name="HE2" type="protein-H" charge="0.42563"/>
-   <Atom name="CD2" type="protein-CW" charge="-0.07402"/>
-   <Atom name="HD2" type="protein-H4" charge="0.21419"/>
-   <Atom name="C" type="protein-C" charge="0.93375"/>
-   <Atom name="O" type="protein-OD" charge="-0.59998"/>
-   <Bond atomName1="N" atomName2="H1"/>
-   <Bond atomName1="N" atomName2="H2"/>
-   <Bond atomName1="N" atomName2="H3"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="ND1"/>
-   <Bond atomName1="CG" atomName2="CD2"/>
-   <Bond atomName1="ND1" atomName2="HD1"/>
-   <Bond atomName1="ND1" atomName2="CE1"/>
-   <Bond atomName1="CE1" atomName2="HE1"/>
-   <Bond atomName1="CE1" atomName2="NE2"/>
-   <Bond atomName1="NE2" atomName2="HE2"/>
-   <Bond atomName1="NE2" atomName2="CD2"/>
-   <Bond atomName1="CD2" atomName2="HD2"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="NILE">
-   <Atom name="N" type="protein-NL" charge="-0.57901"/>
-   <Atom name="H1" type="protein-H" charge="0.41726"/>
-   <Atom name="H2" type="protein-H" charge="0.41726"/>
-   <Atom name="H3" type="protein-H" charge="0.41726"/>
-   <Atom name="CA" type="protein-CX" charge="-0.40513"/>
-   <Atom name="HA" type="protein-HP" charge="0.2071"/>
-   <Atom name="CB" type="protein-3C" charge="0.06954"/>
-   <Atom name="HB" type="protein-HC" charge="0.07681"/>
-   <Atom name="CG2" type="protein-CT" charge="-0.16834"/>
-   <Atom name="HG21" type="protein-HC" charge="0.06868"/>
-   <Atom name="HG22" type="protein-HC" charge="0.06868"/>
-   <Atom name="HG23" type="protein-HC" charge="0.06868"/>
-   <Atom name="CG1" type="protein-2C" charge="-0.03372"/>
-   <Atom name="HG12" type="protein-HC" charge="0.04739"/>
-   <Atom name="HG13" type="protein-HC" charge="0.04739"/>
-   <Atom name="CD1" type="protein-CT" charge="-0.17404"/>
-   <Atom name="HD11" type="protein-HC" charge="0.06264"/>
-   <Atom name="HD12" type="protein-HC" charge="0.06264"/>
-   <Atom name="HD13" type="protein-HC" charge="0.06264"/>
-   <Atom name="C" type="protein-C" charge="0.86628"/>
-   <Atom name="O" type="protein-OD" charge="-0.60001"/>
-   <Bond atomName1="N" atomName2="H1"/>
-   <Bond atomName1="N" atomName2="H2"/>
-   <Bond atomName1="N" atomName2="H3"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB"/>
-   <Bond atomName1="CB" atomName2="CG2"/>
-   <Bond atomName1="CB" atomName2="CG1"/>
-   <Bond atomName1="CG2" atomName2="HG21"/>
-   <Bond atomName1="CG2" atomName2="HG22"/>
-   <Bond atomName1="CG2" atomName2="HG23"/>
-   <Bond atomName1="CG1" atomName2="HG12"/>
-   <Bond atomName1="CG1" atomName2="HG13"/>
-   <Bond atomName1="CG1" atomName2="CD1"/>
-   <Bond atomName1="CD1" atomName2="HD11"/>
-   <Bond atomName1="CD1" atomName2="HD12"/>
-   <Bond atomName1="CD1" atomName2="HD13"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="NLEU">
-   <Atom name="N" type="protein-NL" charge="-0.57901"/>
-   <Atom name="H1" type="protein-H" charge="0.41726"/>
-   <Atom name="H2" type="protein-H" charge="0.41726"/>
-   <Atom name="H3" type="protein-H" charge="0.41726"/>
-   <Atom name="CA" type="protein-CX" charge="-0.32093"/>
-   <Atom name="HA" type="protein-HP" charge="0.18089"/>
-   <Atom name="CB" type="protein-2C" charge="-0.09217"/>
-   <Atom name="HB2" type="protein-HC" charge="0.07706"/>
-   <Atom name="HB3" type="protein-HC" charge="0.07706"/>
-   <Atom name="CG" type="protein-3C" charge="0.18051"/>
-   <Atom name="HG" type="protein-HC" charge="0.02512"/>
-   <Atom name="CD1" type="protein-CT" charge="-0.27194"/>
-   <Atom name="HD11" type="protein-HC" charge="0.07955"/>
-   <Atom name="HD12" type="protein-HC" charge="0.07955"/>
-   <Atom name="HD13" type="protein-HC" charge="0.07955"/>
-   <Atom name="CD2" type="protein-CT" charge="-0.27194"/>
-   <Atom name="HD21" type="protein-HC" charge="0.07955"/>
-   <Atom name="HD22" type="protein-HC" charge="0.07955"/>
-   <Atom name="HD23" type="protein-HC" charge="0.07955"/>
-   <Atom name="C" type="protein-C" charge="0.86628"/>
-   <Atom name="O" type="protein-OD" charge="-0.60001"/>
-   <Bond atomName1="N" atomName2="H1"/>
-   <Bond atomName1="N" atomName2="H2"/>
-   <Bond atomName1="N" atomName2="H3"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="HG"/>
-   <Bond atomName1="CG" atomName2="CD1"/>
-   <Bond atomName1="CG" atomName2="CD2"/>
-   <Bond atomName1="CD1" atomName2="HD11"/>
-   <Bond atomName1="CD1" atomName2="HD12"/>
-   <Bond atomName1="CD1" atomName2="HD13"/>
-   <Bond atomName1="CD2" atomName2="HD21"/>
-   <Bond atomName1="CD2" atomName2="HD22"/>
-   <Bond atomName1="CD2" atomName2="HD23"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="NLYS">
-   <Atom name="N" type="protein-NL" charge="-0.55563"/>
-   <Atom name="H1" type="protein-H" charge="0.42068"/>
-   <Atom name="H2" type="protein-H" charge="0.42068"/>
-   <Atom name="H3" type="protein-H" charge="0.42068"/>
-   <Atom name="CA" type="protein-TP" charge="-0.45822"/>
-   <Atom name="HA" type="protein-HP" charge="0.23746"/>
-   <Atom name="CB" type="protein-C8" charge="0.02634"/>
-   <Atom name="HB2" type="protein-HC" charge="0.06984"/>
-   <Atom name="HB3" type="protein-HC" charge="0.06984"/>
-   <Atom name="CG" type="protein-C8" charge="-0.11736"/>
-   <Atom name="HG2" type="protein-HC" charge="0.06991"/>
-   <Atom name="HG3" type="protein-HC" charge="0.06991"/>
-   <Atom name="CD" type="protein-C8" charge="-0.11969"/>
-   <Atom name="HD2" type="protein-HC" charge="0.09094"/>
-   <Atom name="HD3" type="protein-HC" charge="0.09094"/>
-   <Atom name="CE" type="protein-C8" charge="0.09556"/>
-   <Atom name="HE2" type="protein-HP" charge="0.10189"/>
-   <Atom name="HE3" type="protein-HP" charge="0.10189"/>
-   <Atom name="NZ" type="protein-NL" charge="-0.61902"/>
-   <Atom name="HZ1" type="protein-H" charge="0.41653"/>
-   <Atom name="HZ2" type="protein-H" charge="0.41653"/>
-   <Atom name="HZ3" type="protein-H" charge="0.41653"/>
-   <Atom name="C" type="protein-C" charge="0.93375"/>
-   <Atom name="O" type="protein-OD" charge="-0.59998"/>
-   <Bond atomName1="N" atomName2="H1"/>
-   <Bond atomName1="N" atomName2="H2"/>
-   <Bond atomName1="N" atomName2="H3"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="HG2"/>
-   <Bond atomName1="CG" atomName2="HG3"/>
-   <Bond atomName1="CG" atomName2="CD"/>
-   <Bond atomName1="CD" atomName2="HD2"/>
-   <Bond atomName1="CD" atomName2="HD3"/>
-   <Bond atomName1="CD" atomName2="CE"/>
-   <Bond atomName1="CE" atomName2="HE2"/>
-   <Bond atomName1="CE" atomName2="HE3"/>
-   <Bond atomName1="CE" atomName2="NZ"/>
-   <Bond atomName1="NZ" atomName2="HZ1"/>
-   <Bond atomName1="NZ" atomName2="HZ2"/>
-   <Bond atomName1="NZ" atomName2="HZ3"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="NMET">
-   <Atom name="N" type="protein-NL" charge="-0.57901"/>
-   <Atom name="H1" type="protein-H" charge="0.41726"/>
-   <Atom name="H2" type="protein-H" charge="0.41726"/>
-   <Atom name="H3" type="protein-H" charge="0.41726"/>
-   <Atom name="CA" type="protein-CX" charge="-0.30797"/>
-   <Atom name="HA" type="protein-HP" charge="0.17882"/>
-   <Atom name="CB" type="protein-2C" charge="-0.03297"/>
-   <Atom name="HB2" type="protein-HC" charge="0.0973"/>
-   <Atom name="HB3" type="protein-HC" charge="0.0973"/>
-   <Atom name="CG" type="protein-2C" charge="-0.21549"/>
-   <Atom name="HG2" type="protein-H1" charge="0.13432"/>
-   <Atom name="HG3" type="protein-H1" charge="0.13432"/>
-   <Atom name="SD" type="protein-S" charge="-0.16731"/>
-   <Atom name="CE" type="protein-CT" charge="-0.20119"/>
-   <Atom name="HE1" type="protein-H1" charge="0.11461"/>
-   <Atom name="HE2" type="protein-H1" charge="0.11461"/>
-   <Atom name="HE3" type="protein-H1" charge="0.11461"/>
-   <Atom name="C" type="protein-C" charge="0.86628"/>
-   <Atom name="O" type="protein-OD" charge="-0.60001"/>
-   <Bond atomName1="N" atomName2="H1"/>
-   <Bond atomName1="N" atomName2="H2"/>
-   <Bond atomName1="N" atomName2="H3"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="HG2"/>
-   <Bond atomName1="CG" atomName2="HG3"/>
-   <Bond atomName1="CG" atomName2="SD"/>
-   <Bond atomName1="SD" atomName2="CE"/>
-   <Bond atomName1="CE" atomName2="HE1"/>
-   <Bond atomName1="CE" atomName2="HE2"/>
-   <Bond atomName1="CE" atomName2="HE3"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="NNLE">
-   <Atom name="N" type="protein-NL" charge="-0.57901"/>
-   <Atom name="H1" type="protein-H" charge="0.41726"/>
-   <Atom name="H2" type="protein-H" charge="0.41726"/>
-   <Atom name="H3" type="protein-H" charge="0.41726"/>
-   <Atom name="CA" type="protein-CX" charge="-0.35466"/>
-   <Atom name="HA" type="protein-HP" charge="0.20584"/>
-   <Atom name="CB" type="protein-2C" charge="0.0077"/>
-   <Atom name="HB2" type="protein-HC" charge="0.06216"/>
-   <Atom name="HB3" type="protein-HC" charge="0.06216"/>
-   <Atom name="CG" type="protein-2C" charge="-0.07442"/>
-   <Atom name="HG2" type="protein-HC" charge="0.04402"/>
-   <Atom name="HG3" type="protein-HC" charge="0.04402"/>
-   <Atom name="CD" type="protein-2C" charge="0.03153"/>
-   <Atom name="HD2" type="protein-HC" charge="0.02363"/>
-   <Atom name="HD3" type="protein-HC" charge="0.02363"/>
-   <Atom name="CE" type="protein-CT" charge="-0.18901"/>
-   <Atom name="HE1" type="protein-HC" charge="0.05812"/>
-   <Atom name="HE2" type="protein-HC" charge="0.05812"/>
-   <Atom name="HE3" type="protein-HC" charge="0.05812"/>
-   <Atom name="C" type="protein-C" charge="0.86628"/>
-   <Atom name="O" type="protein-OD" charge="-0.60001"/>
-   <Bond atomName1="N" atomName2="H1"/>
-   <Bond atomName1="N" atomName2="H2"/>
-   <Bond atomName1="N" atomName2="H3"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="HG2"/>
-   <Bond atomName1="CG" atomName2="HG3"/>
-   <Bond atomName1="CG" atomName2="CD"/>
-   <Bond atomName1="CD" atomName2="HD2"/>
-   <Bond atomName1="CD" atomName2="HD3"/>
-   <Bond atomName1="CD" atomName2="CE"/>
-   <Bond atomName1="CE" atomName2="HE1"/>
-   <Bond atomName1="CE" atomName2="HE2"/>
-   <Bond atomName1="CE" atomName2="HE3"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="NPHE">
-   <Atom name="N" type="protein-NL" charge="-0.57901"/>
-   <Atom name="H1" type="protein-H" charge="0.41726"/>
-   <Atom name="H2" type="protein-H" charge="0.41726"/>
-   <Atom name="H3" type="protein-H" charge="0.41726"/>
-   <Atom name="CA" type="protein-CX" charge="-0.32727"/>
-   <Atom name="HA" type="protein-HP" charge="0.18909"/>
-   <Atom name="CB" type="protein-TA" charge="-0.00037"/>
-   <Atom name="HB2" type="protein-HC" charge="0.0813"/>
-   <Atom name="HB3" type="protein-HC" charge="0.0813"/>
-   <Atom name="CG" type="protein-CA" charge="0.03317"/>
-   <Atom name="CD1" type="protein-CA" charge="-0.20939"/>
-   <Atom name="HD1" type="protein-HA" charge="0.15366"/>
-   <Atom name="CE1" type="protein-CA" charge="-0.09256"/>
-   <Atom name="HE1" type="protein-HA" charge="0.1421"/>
-   <Atom name="CZ" type="protein-CA" charge="-0.12612"/>
-   <Atom name="HZ" type="protein-HA" charge="0.14224"/>
-   <Atom name="CE2" type="protein-CA" charge="-0.09256"/>
-   <Atom name="HE2" type="protein-HA" charge="0.1421"/>
-   <Atom name="CD2" type="protein-CA" charge="-0.20939"/>
-   <Atom name="HD2" type="protein-HA" charge="0.15366"/>
-   <Atom name="C" type="protein-C" charge="0.86628"/>
-   <Atom name="O" type="protein-OD" charge="-0.60001"/>
-   <Bond atomName1="N" atomName2="H1"/>
-   <Bond atomName1="N" atomName2="H2"/>
-   <Bond atomName1="N" atomName2="H3"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="CD1"/>
-   <Bond atomName1="CG" atomName2="CD2"/>
-   <Bond atomName1="CD1" atomName2="HD1"/>
-   <Bond atomName1="CD1" atomName2="CE1"/>
-   <Bond atomName1="CE1" atomName2="HE1"/>
-   <Bond atomName1="CE1" atomName2="CZ"/>
-   <Bond atomName1="CZ" atomName2="HZ"/>
-   <Bond atomName1="CZ" atomName2="CE2"/>
-   <Bond atomName1="CE2" atomName2="HE2"/>
-   <Bond atomName1="CE2" atomName2="CD2"/>
-   <Bond atomName1="CD2" atomName2="HD2"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="NPRO">
-   <Atom name="N" type="protein-NL" charge="-0.3526"/>
-   <Atom name="H2" type="protein-H" charge="0.38149"/>
-   <Atom name="H3" type="protein-H" charge="0.38149"/>
-   <Atom name="CD" type="protein-CT" charge="0.02496"/>
-   <Atom name="HD2" type="protein-HP" charge="0.09922"/>
-   <Atom name="HD3" type="protein-HP" charge="0.09922"/>
-   <Atom name="CG" type="protein-CT" charge="0.02186"/>
-   <Atom name="HG2" type="protein-HC" charge="0.04637"/>
-   <Atom name="HG3" type="protein-HC" charge="0.04637"/>
-   <Atom name="CB" type="protein-CT" charge="0.05785"/>
-   <Atom name="HB2" type="protein-HC" charge="0.04675"/>
-   <Atom name="HB3" type="protein-HC" charge="0.04675"/>
-   <Atom name="CA" type="protein-TJ" charge="-0.32656"/>
-   <Atom name="HA" type="protein-HP" charge="0.18205"/>
-   <Atom name="C" type="protein-C" charge="0.83604"/>
-   <Atom name="O" type="protein-OD" charge="-0.59126"/>
-   <Bond atomName1="N" atomName2="H2"/>
-   <Bond atomName1="N" atomName2="H3"/>
-   <Bond atomName1="N" atomName2="CD"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CD" atomName2="HD2"/>
-   <Bond atomName1="CD" atomName2="HD3"/>
-   <Bond atomName1="CD" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="HG2"/>
-   <Bond atomName1="CG" atomName2="HG3"/>
-   <Bond atomName1="CG" atomName2="CB"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="NSER">
-   <Atom name="N" type="protein-NL" charge="-0.57901"/>
-   <Atom name="H1" type="protein-H" charge="0.41726"/>
-   <Atom name="H2" type="protein-H" charge="0.41726"/>
-   <Atom name="H3" type="protein-H" charge="0.41726"/>
-   <Atom name="CA" type="protein-CX" charge="-0.28106"/>
-   <Atom name="HA" type="protein-HP" charge="0.19248"/>
-   <Atom name="CB" type="protein-2C" charge="0.11779"/>
-   <Atom name="HB2" type="protein-H1" charge="0.07536"/>
-   <Atom name="HB3" type="protein-H1" charge="0.07536"/>
-   <Atom name="OG" type="protein-OA" charge="-0.52119"/>
-   <Atom name="HG" type="protein-HO" charge="0.40222"/>
-   <Atom name="C" type="protein-C" charge="0.86628"/>
-   <Atom name="O" type="protein-OD" charge="-0.60001"/>
-   <Bond atomName1="N" atomName2="H1"/>
-   <Bond atomName1="N" atomName2="H2"/>
-   <Bond atomName1="N" atomName2="H3"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="OG"/>
-   <Bond atomName1="OG" atomName2="HG"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="NTHR">
-   <Atom name="N" type="protein-NL" charge="-0.57901"/>
-   <Atom name="H1" type="protein-H" charge="0.41726"/>
-   <Atom name="H2" type="protein-H" charge="0.41726"/>
-   <Atom name="H3" type="protein-H" charge="0.41726"/>
-   <Atom name="CA" type="protein-CX" charge="-0.31466"/>
-   <Atom name="HA" type="protein-HP" charge="0.20462"/>
-   <Atom name="CB" type="protein-3C" charge="0.19475"/>
-   <Atom name="HB" type="protein-H1" charge="0.07213"/>
-   <Atom name="CG2" type="protein-CT" charge="-0.23337"/>
-   <Atom name="HG21" type="protein-HC" charge="0.09063"/>
-   <Atom name="HG22" type="protein-HC" charge="0.09063"/>
-   <Atom name="HG23" type="protein-HC" charge="0.09063"/>
-   <Atom name="OG1" type="protein-OA" charge="-0.54959"/>
-   <Atom name="HG1" type="protein-HO" charge="0.41519"/>
-   <Atom name="C" type="protein-C" charge="0.86628"/>
-   <Atom name="O" type="protein-OD" charge="-0.60001"/>
-   <Bond atomName1="N" atomName2="H1"/>
-   <Bond atomName1="N" atomName2="H2"/>
-   <Bond atomName1="N" atomName2="H3"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB"/>
-   <Bond atomName1="CB" atomName2="CG2"/>
-   <Bond atomName1="CB" atomName2="OG1"/>
-   <Bond atomName1="CG2" atomName2="HG21"/>
-   <Bond atomName1="CG2" atomName2="HG22"/>
-   <Bond atomName1="CG2" atomName2="HG23"/>
-   <Bond atomName1="OG1" atomName2="HG1"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="NTRP">
-   <Atom name="N" type="protein-NL" charge="-0.57901"/>
-   <Atom name="H1" type="protein-H" charge="0.41726"/>
-   <Atom name="H2" type="protein-H" charge="0.41726"/>
-   <Atom name="H3" type="protein-H" charge="0.41726"/>
-   <Atom name="CA" type="protein-CX" charge="-0.33508"/>
-   <Atom name="HA" type="protein-HP" charge="0.19667"/>
-   <Atom name="CB" type="protein-TA" charge="0.00121"/>
-   <Atom name="HB2" type="protein-HC" charge="0.09575"/>
-   <Atom name="HB3" type="protein-HC" charge="0.09575"/>
-   <Atom name="CG" type="protein-C*" charge="-0.20804"/>
-   <Atom name="CD1" type="protein-CW" charge="-0.12845"/>
-   <Atom name="HD1" type="protein-H4" charge="0.19461"/>
-   <Atom name="NE1" type="protein-NA" charge="-0.40094"/>
-   <Atom name="HE1" type="protein-H" charge="0.39352"/>
-   <Atom name="CE2" type="protein-CN" charge="0.19128"/>
-   <Atom name="CZ2" type="protein-CA" charge="-0.24187"/>
-   <Atom name="HZ2" type="protein-HA" charge="0.16613"/>
-   <Atom name="CH2" type="protein-CA" charge="-0.14844"/>
-   <Atom name="HH2" type="protein-HA" charge="0.15364"/>
-   <Atom name="CZ3" type="protein-CA" charge="-0.11849"/>
-   <Atom name="HZ3" type="protein-HA" charge="0.14765"/>
-   <Atom name="CE3" type="protein-CA" charge="-0.35016"/>
-   <Atom name="HE3" type="protein-HA" charge="0.18149"/>
-   <Atom name="CD2" type="protein-CB" charge="0.17473"/>
-   <Atom name="C" type="protein-C" charge="0.86628"/>
-   <Atom name="O" type="protein-OD" charge="-0.60001"/>
-   <Bond atomName1="N" atomName2="H1"/>
-   <Bond atomName1="N" atomName2="H2"/>
-   <Bond atomName1="N" atomName2="H3"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="CD1"/>
-   <Bond atomName1="CG" atomName2="CD2"/>
-   <Bond atomName1="CD1" atomName2="HD1"/>
-   <Bond atomName1="CD1" atomName2="NE1"/>
-   <Bond atomName1="NE1" atomName2="HE1"/>
-   <Bond atomName1="NE1" atomName2="CE2"/>
-   <Bond atomName1="CE2" atomName2="CZ2"/>
-   <Bond atomName1="CE2" atomName2="CD2"/>
-   <Bond atomName1="CZ2" atomName2="HZ2"/>
-   <Bond atomName1="CZ2" atomName2="CH2"/>
-   <Bond atomName1="CH2" atomName2="HH2"/>
-   <Bond atomName1="CH2" atomName2="CZ3"/>
-   <Bond atomName1="CZ3" atomName2="HZ3"/>
-   <Bond atomName1="CZ3" atomName2="CE3"/>
-   <Bond atomName1="CE3" atomName2="HE3"/>
-   <Bond atomName1="CE3" atomName2="CD2"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="NTYR">
-   <Atom name="N" type="protein-NL" charge="-0.57901"/>
-   <Atom name="H1" type="protein-H" charge="0.41726"/>
-   <Atom name="H2" type="protein-H" charge="0.41726"/>
-   <Atom name="H3" type="protein-H" charge="0.41726"/>
-   <Atom name="CA" type="protein-CX" charge="-0.3337"/>
-   <Atom name="HA" type="protein-HP" charge="0.19467"/>
-   <Atom name="CB" type="protein-TA" charge="-0.00442"/>
-   <Atom name="HB2" type="protein-HC" charge="0.08352"/>
-   <Atom name="HB3" type="protein-HC" charge="0.08352"/>
-   <Atom name="CG" type="protein-CA" charge="-0.02908"/>
-   <Atom name="CD1" type="protein-CA" charge="-0.14186"/>
-   <Atom name="HD1" type="protein-HA" charge="0.14215"/>
-   <Atom name="CE1" type="protein-CA" charge="-0.29982"/>
-   <Atom name="HE1" type="protein-HA" charge="0.19254"/>
-   <Atom name="CZ" type="protein-C" charge="0.40303"/>
-   <Atom name="OH" type="protein-OA" charge="-0.51327"/>
-   <Atom name="HH" type="protein-HO" charge="0.39067"/>
-   <Atom name="CE2" type="protein-CA" charge="-0.29982"/>
-   <Atom name="HE2" type="protein-HA" charge="0.19254"/>
-   <Atom name="CD2" type="protein-CA" charge="-0.14186"/>
-   <Atom name="HD2" type="protein-HA" charge="0.14215"/>
-   <Atom name="C" type="protein-C" charge="0.86628"/>
-   <Atom name="O" type="protein-OD" charge="-0.60001"/>
-   <Bond atomName1="N" atomName2="H1"/>
-   <Bond atomName1="N" atomName2="H2"/>
-   <Bond atomName1="N" atomName2="H3"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB2"/>
-   <Bond atomName1="CB" atomName2="HB3"/>
-   <Bond atomName1="CB" atomName2="CG"/>
-   <Bond atomName1="CG" atomName2="CD1"/>
-   <Bond atomName1="CG" atomName2="CD2"/>
-   <Bond atomName1="CD1" atomName2="HD1"/>
-   <Bond atomName1="CD1" atomName2="CE1"/>
-   <Bond atomName1="CE1" atomName2="HE1"/>
-   <Bond atomName1="CE1" atomName2="CZ"/>
-   <Bond atomName1="CZ" atomName2="OH"/>
-   <Bond atomName1="CZ" atomName2="CE2"/>
-   <Bond atomName1="OH" atomName2="HH"/>
-   <Bond atomName1="CE2" atomName2="HE2"/>
-   <Bond atomName1="CE2" atomName2="CD2"/>
-   <Bond atomName1="CD2" atomName2="HD2"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
-  <Residue name="NVAL">
-   <Atom name="N" type="protein-NL" charge="-0.57901"/>
-   <Atom name="H1" type="protein-H" charge="0.41726"/>
-   <Atom name="H2" type="protein-H" charge="0.41726"/>
-   <Atom name="H3" type="protein-H" charge="0.41726"/>
-   <Atom name="CA" type="protein-CX" charge="-0.41747"/>
-   <Atom name="HA" type="protein-HP" charge="0.21719"/>
-   <Atom name="CB" type="protein-3C" charge="0.18748"/>
-   <Atom name="HB" type="protein-HC" charge="0.06114"/>
-   <Atom name="CG1" type="protein-CT" charge="-0.26546"/>
-   <Atom name="HG11" type="protein-HC" charge="0.09059"/>
-   <Atom name="HG12" type="protein-HC" charge="0.09059"/>
-   <Atom name="HG13" type="protein-HC" charge="0.09059"/>
-   <Atom name="CG2" type="protein-CT" charge="-0.26546"/>
-   <Atom name="HG21" type="protein-HC" charge="0.09059"/>
-   <Atom name="HG22" type="protein-HC" charge="0.09059"/>
-   <Atom name="HG23" type="protein-HC" charge="0.09059"/>
-   <Atom name="C" type="protein-C" charge="0.86628"/>
-   <Atom name="O" type="protein-OD" charge="-0.60001"/>
-   <Bond atomName1="N" atomName2="H1"/>
-   <Bond atomName1="N" atomName2="H2"/>
-   <Bond atomName1="N" atomName2="H3"/>
-   <Bond atomName1="N" atomName2="CA"/>
-   <Bond atomName1="CA" atomName2="HA"/>
-   <Bond atomName1="CA" atomName2="CB"/>
-   <Bond atomName1="CA" atomName2="C"/>
-   <Bond atomName1="CB" atomName2="HB"/>
-   <Bond atomName1="CB" atomName2="CG1"/>
-   <Bond atomName1="CB" atomName2="CG2"/>
-   <Bond atomName1="CG1" atomName2="HG11"/>
-   <Bond atomName1="CG1" atomName2="HG12"/>
-   <Bond atomName1="CG1" atomName2="HG13"/>
-   <Bond atomName1="CG2" atomName2="HG21"/>
-   <Bond atomName1="CG2" atomName2="HG22"/>
-   <Bond atomName1="CG2" atomName2="HG23"/>
-   <Bond atomName1="C" atomName2="O"/>
-   <ExternalBond atomName="C"/>
-  </Residue>
- </Residues>
- <HarmonicBondForce>
-  <Bond type1="protein-C" type2="protein-C" length="0.1525" k="259407.99999999994"/>
-  <Bond type1="protein-C" type2="protein-CB" length="0.1419" k="374049.5999999999"/>
-  <Bond type1="protein-C" type2="protein-NA" length="0.1388" k="349782.3999999999"/>
-  <Bond type1="protein-C" type2="protein-O" length="0.12290000000000001" k="476975.9999999999"/>
-  <Bond type1="protein-C" type2="protein-OH" length="0.13640000000000002" k="376559.99999999994"/>
-  <Bond type1="protein-C" type2="protein-H4" length="0.10800000000000001" k="307105.5999999999"/>
-  <Bond type1="protein-C" type2="protein-H5" length="0.10800000000000001" k="307105.5999999999"/>
-  <Bond type1="protein-CA" type2="protein-H4" length="0.10800000000000001" k="307105.5999999999"/>
-  <Bond type1="protein-CA" type2="protein-NA" length="0.1381" k="357313.5999999999"/>
-  <Bond type1="protein-CA" type2="protein-OH" length="0.13640000000000002" k="376559.99999999994"/>
-  <Bond type1="protein-CB" type2="protein-CB" length="0.137" k="435135.99999999994"/>
-  <Bond type1="protein-CB" type2="protein-NB" length="0.1391" k="346435.19999999995"/>
-  <Bond type1="protein-CT" type2="protein-N2" length="0.1463" k="282001.5999999999"/>
-  <Bond type1="protein-CT" type2="protein-OH" length="0.141" k="267775.99999999994"/>
-  <Bond type1="protein-C*" type2="protein-HC" length="0.10800000000000001" k="307105.5999999999"/>
-  <Bond type1="protein-CT" type2="protein-N3" length="0.1471" k="307105.5999999999"/>
-  <Bond type1="protein-CT" type2="protein-SH" length="0.18100000000000002" k="198321.59999999998"/>
-  <Bond type1="protein-H" type2="protein-N3" length="0.101" k="363171.19999999995"/>
-  <Bond type1="protein-HO" type2="protein-OH" length="0.096" k="462750.3999999999"/>
-  <Bond type1="protein-N2" type2="protein-H" length="0.101" k="363171.19999999995"/>
-  <Bond type1="protein-C" type2="protein-N" length="0.1335" k="410031.99999999994"/>
-  <Bond type1="protein-C" type2="protein-TN" length="0.1335" k="410031.99999999994"/>
-  <Bond type1="protein-H" type2="protein-N" length="0.101" k="363171.19999999995"/>
-  <Bond type1="protein-H" type2="protein-NL" length="0.101" k="363171.19999999995"/>
-  <Bond type1="protein-N" type2="protein-CX" length="0.1449" k="282001.5999999999"/>
-  <Bond type1="protein-TN" type2="protein-TJ" length="0.1449" k="282001.5999999999"/>
-  <Bond type1="protein-N" type2="protein-TG" length="0.1449" k="282001.5999999999"/>
-  <Bond type1="protein-N" type2="protein-TP" length="0.1449" k="282001.5999999999"/>
-  <Bond type1="protein-N" type2="protein-TM" length="0.1449" k="282001.5999999999"/>
-  <Bond type1="protein-N" type2="protein-CT" length="0.1449" k="282001.5999999999"/>
-  <Bond type1="protein-NL" type2="protein-CX" length="0.1471" k="307105.5999999999"/>
-  <Bond type1="protein-NL" type2="protein-TJ" length="0.1471" k="307105.5999999999"/>
-  <Bond type1="protein-NL" type2="protein-TG" length="0.1471" k="307105.5999999999"/>
-  <Bond type1="protein-NL" type2="protein-TP" length="0.1471" k="307105.5999999999"/>
-  <Bond type1="protein-NL" type2="protein-TM" length="0.1471" k="307105.5999999999"/>
-  <Bond type1="protein-TN" type2="protein-CT" length="0.1449" k="282001.5999999999"/>
-  <Bond type1="protein-NL" type2="protein-CT" length="0.1471" k="307105.5999999999"/>
-  <Bond type1="protein-CX" type2="protein-CT" length="0.1526" k="259407.99999999994"/>
-  <Bond type1="protein-CX" type2="protein-2C" length="0.1526" k="259407.99999999994"/>
-  <Bond type1="protein-CX" type2="protein-3C" length="0.1526" k="259407.99999999994"/>
-  <Bond type1="protein-CX" type2="protein-TA" length="0.1526" k="259407.99999999994"/>
-  <Bond type1="protein-TJ" type2="protein-CT" length="0.1526" k="259407.99999999994"/>
-  <Bond type1="protein-TP" type2="protein-C8" length="0.1526" k="259407.99999999994"/>
-  <Bond type1="protein-TM" type2="protein-2C" length="0.1526" k="259407.99999999994"/>
-  <Bond type1="protein-CX" type2="protein-H1" length="0.10900000000000001" k="284511.99999999994"/>
-  <Bond type1="protein-TJ" type2="protein-H1" length="0.10900000000000001" k="284511.99999999994"/>
-  <Bond type1="protein-TG" type2="protein-H1" length="0.10900000000000001" k="284511.99999999994"/>
-  <Bond type1="protein-TP" type2="protein-H1" length="0.10900000000000001" k="284511.99999999994"/>
-  <Bond type1="protein-TM" type2="protein-H1" length="0.10900000000000001" k="284511.99999999994"/>
-  <Bond type1="protein-CX" type2="protein-HP" length="0.10900000000000001" k="284511.99999999994"/>
-  <Bond type1="protein-TJ" type2="protein-HP" length="0.10900000000000001" k="284511.99999999994"/>
-  <Bond type1="protein-TG" type2="protein-HP" length="0.10900000000000001" k="284511.99999999994"/>
-  <Bond type1="protein-TP" type2="protein-HP" length="0.10900000000000001" k="284511.99999999994"/>
-  <Bond type1="protein-TM" type2="protein-HP" length="0.10900000000000001" k="284511.99999999994"/>
-  <Bond type1="protein-CX" type2="protein-C" length="0.1522" k="265265.6"/>
-  <Bond type1="protein-TJ" type2="protein-C" length="0.1522" k="265265.6"/>
-  <Bond type1="protein-TG" type2="protein-C" length="0.1522" k="265265.6"/>
-  <Bond type1="protein-TP" type2="protein-C" length="0.1522" k="265265.6"/>
-  <Bond type1="protein-TM" type2="protein-C" length="0.1522" k="265265.6"/>
-  <Bond type1="protein-CT" type2="protein-C" length="0.1522" k="265265.6"/>
-  <Bond type1="protein-CX" type2="protein-CO" length="0.1522" k="265265.6"/>
-  <Bond type1="protein-TJ" type2="protein-CO" length="0.1522" k="265265.6"/>
-  <Bond type1="protein-TG" type2="protein-CO" length="0.1522" k="265265.6"/>
-  <Bond type1="protein-TP" type2="protein-CO" length="0.1522" k="265265.6"/>
-  <Bond type1="protein-TM" type2="protein-CO" length="0.1522" k="265265.6"/>
-  <Bond type1="protein-C" type2="protein-OD" length="0.12290000000000001" k="476975.9999999999"/>
-  <Bond type1="protein-CO" type2="protein-O3" length="0.125" k="548940.7999999999"/>
-  <Bond type1="protein-C" type2="protein-ND" length="0.1335" k="410031.99999999994"/>
-  <Bond type1="protein-ND" type2="protein-H" length="0.101" k="363171.19999999995"/>
-  <Bond type1="protein-CT" type2="protein-HC" length="0.10900000000000001" k="284511.99999999994"/>
-  <Bond type1="protein-CT" type2="protein-H1" length="0.10900000000000001" k="284511.99999999994"/>
-  <Bond type1="protein-CT" type2="protein-HP" length="0.10900000000000001" k="284511.99999999994"/>
-  <Bond type1="protein-CT" type2="protein-CT" length="0.1526" k="259407.99999999994"/>
-  <Bond type1="protein-CT" type2="protein-S" length="0.18100000000000002" k="189953.59999999998"/>
-  <Bond type1="protein-2C" type2="protein-CT" length="0.1526" k="259407.99999999994"/>
-  <Bond type1="protein-2C" type2="protein-HC" length="0.10900000000000001" k="284511.99999999994"/>
-  <Bond type1="protein-2C" type2="protein-H1" length="0.10900000000000001" k="284511.99999999994"/>
-  <Bond type1="protein-2C" type2="protein-C" length="0.1522" k="265265.6"/>
-  <Bond type1="protein-2C" type2="protein-CO" length="0.1522" k="265265.6"/>
-  <Bond type1="protein-2C" type2="protein-SH" length="0.18100000000000002" k="198321.59999999998"/>
-  <Bond type1="protein-2C" type2="protein-S" length="0.18100000000000002" k="189953.59999999998"/>
-  <Bond type1="protein-2C" type2="protein-3C" length="0.1526" k="259407.99999999994"/>
-  <Bond type1="protein-2C" type2="protein-OA" length="0.141" k="267775.99999999994"/>
-  <Bond type1="protein-2C" type2="protein-N3" length="0.1471" k="307105.5999999999"/>
-  <Bond type1="protein-2C" type2="protein-2C" length="0.1526" k="259407.99999999994"/>
-  <Bond type1="protein-SH" type2="protein-HS" length="0.13360000000000002" k="229283.19999999995"/>
-  <Bond type1="protein-S" type2="protein-S" length="0.20379999999999998" k="138908.79999999996"/>
-  <Bond type1="protein-OA" type2="protein-HO" length="0.096" k="462750.3999999999"/>
-  <Bond type1="protein-3C" type2="protein-CT" length="0.1526" k="259407.99999999994"/>
-  <Bond type1="protein-3C" type2="protein-HC" length="0.10900000000000001" k="284511.99999999994"/>
-  <Bond type1="protein-3C" type2="protein-H1" length="0.10900000000000001" k="284511.99999999994"/>
-  <Bond type1="protein-3C" type2="protein-OA" length="0.141" k="267775.99999999994"/>
-  <Bond type1="protein-TA" type2="protein-HC" length="0.10900000000000001" k="284511.99999999994"/>
-  <Bond type1="protein-TA" type2="protein-CC" length="0.1504" k="265265.6"/>
-  <Bond type1="protein-CC" type2="protein-CV" length="0.1375" k="428441.5999999999"/>
-  <Bond type1="protein-CC" type2="protein-CW" length="0.1371" k="433462.3999999999"/>
-  <Bond type1="protein-CC" type2="protein-NA" length="0.1385" k="353129.5999999999"/>
-  <Bond type1="protein-CC" type2="protein-NB" length="0.1394" k="343087.99999999994"/>
-  <Bond type1="protein-CV" type2="protein-NB" length="0.1394" k="343087.99999999994"/>
-  <Bond type1="protein-CW" type2="protein-NA" length="0.1381" k="357313.5999999999"/>
-  <Bond type1="protein-CR" type2="protein-NA" length="0.1343" k="399153.5999999999"/>
-  <Bond type1="protein-CR" type2="protein-NB" length="0.1335" k="408358.3999999999"/>
-  <Bond type1="protein-CV" type2="protein-H4" length="0.10800000000000001" k="307105.5999999999"/>
-  <Bond type1="protein-CW" type2="protein-H4" length="0.10800000000000001" k="307105.5999999999"/>
-  <Bond type1="protein-CR" type2="protein-H5" length="0.10800000000000001" k="307105.5999999999"/>
-  <Bond type1="protein-NA" type2="protein-H" length="0.101" k="363171.19999999995"/>
-  <Bond type1="protein-TA" type2="protein-CA" length="0.15100000000000002" k="265265.6"/>
-  <Bond type1="protein-CA" type2="protein-CA" length="0.13999999999999999" k="392459.19999999995"/>
-  <Bond type1="protein-CA" type2="protein-HA" length="0.10800000000000001" k="307105.5999999999"/>
-  <Bond type1="protein-TA" type2="protein-C*" length="0.14950000000000002" k="265265.6"/>
-  <Bond type1="protein-CA" type2="protein-CB" length="0.1404" k="392459.19999999995"/>
-  <Bond type1="protein-C*" type2="protein-CB" length="0.1459" k="324678.39999999997"/>
-  <Bond type1="protein-C*" type2="protein-CW" length="0.13520000000000001" k="456892.79999999993"/>
-  <Bond type1="protein-CB" type2="protein-CN" length="0.1419" k="374049.5999999999"/>
-  <Bond type1="protein-CN" type2="protein-NA" length="0.13799999999999998" k="358150.3999999999"/>
-  <Bond type1="protein-CA" type2="protein-CN" length="0.13999999999999999" k="392459.19999999995"/>
-  <Bond type1="protein-C" type2="protein-OA" length="0.13640000000000002" k="376559.99999999994"/>
-  <Bond type1="protein-CA" type2="protein-C" length="0.1409" k="392459.19999999995"/>
-  <Bond type1="protein-C8" type2="protein-C8" length="0.1526" k="259407.99999999994"/>
-  <Bond type1="protein-C8" type2="protein-CC" length="0.1504" k="265265.6"/>
-  <Bond type1="protein-C8" type2="protein-N2" length="0.1463" k="282001.5999999999"/>
-  <Bond type1="protein-C8" type2="protein-NL" length="0.1471" k="307105.5999999999"/>
-  <Bond type1="protein-N2" type2="protein-CA" length="0.134" k="402500.79999999993"/>
-  <Bond type1="protein-C8" type2="protein-HC" length="0.10900000000000001" k="284511.99999999994"/>
-  <Bond type1="protein-C8" type2="protein-H1" length="0.10900000000000001" k="284511.99999999994"/>
-  <Bond type1="protein-C8" type2="protein-HP" length="0.10900000000000001" k="284511.99999999994"/>
-  <Bond type1="protein-N2" type2="protein-TH" length="0.101" k="363171.19999999995"/>
- </HarmonicBondForce>
- <HarmonicAngleForce>
-  <Angle type1="protein-C" type2="protein-C" type3="protein-O" angle="2.0943951023931953" k="669.44"/>
-  <Angle type1="protein-C" type2="protein-C" type3="protein-OH" angle="2.0943951023931953" k="669.44"/>
-  <Angle type1="protein-CA" type2="protein-C" type3="protein-OH" angle="2.0943951023931953" k="585.76"/>
-  <Angle type1="protein-CB" type2="protein-C" type3="protein-NA" angle="1.9425514574696887" k="585.76"/>
-  <Angle type1="protein-CB" type2="protein-C" type3="protein-O" angle="2.2479840765686965" k="669.44"/>
-  <Angle type1="protein-CT" type2="protein-C" type3="protein-O" angle="2.101376419401173" k="669.44"/>
-  <Angle type1="protein-CT" type2="protein-C" type3="protein-CT" angle="2.0420352248333655" k="527.184"/>
-  <Angle type1="protein-CT" type2="protein-C" type3="protein-OH" angle="1.9198621771937625" k="669.44"/>
-  <Angle type1="protein-NA" type2="protein-C" type3="protein-O" angle="2.1048670779051615" k="669.44"/>
-  <Angle type1="protein-N" type2="protein-C" type3="protein-O" angle="2.1450096507010312" k="669.44"/>
-  <Angle type1="protein-O" type2="protein-C" type3="protein-O" angle="2.199114857512855" k="669.44"/>
-  <Angle type1="protein-O" type2="protein-C" type3="protein-OH" angle="2.0943951023931953" k="669.44"/>
-  <Angle type1="protein-H4" type2="protein-C" type3="protein-C" angle="2.0943951023931953" k="418.40000000000003"/>
-  <Angle type1="protein-H4" type2="protein-C" type3="protein-CT" angle="2.007128639793479" k="418.40000000000003"/>
-  <Angle type1="protein-H4" type2="protein-C" type3="protein-O" angle="2.0943951023931953" k="418.40000000000003"/>
-  <Angle type1="protein-H4" type2="protein-C" type3="protein-OH" angle="2.0943951023931953" k="418.40000000000003"/>
-  <Angle type1="protein-H5" type2="protein-C" type3="protein-N" angle="2.0943951023931953" k="418.40000000000003"/>
-  <Angle type1="protein-H5" type2="protein-C" type3="protein-O" angle="2.076941809873252" k="418.40000000000003"/>
-  <Angle type1="protein-H5" type2="protein-C" type3="protein-OH" angle="1.8675022996339325" k="418.40000000000003"/>
-  <Angle type1="protein-CA" type2="protein-CA" type3="protein-H4" angle="2.0943951023931953" k="418.40000000000003"/>
-  <Angle type1="protein-CA" type2="protein-CA" type3="protein-OH" angle="2.0943951023931953" k="585.76"/>
-  <Angle type1="protein-CB" type2="protein-CA" type3="protein-H4" angle="2.0943951023931953" k="418.40000000000003"/>
-  <Angle type1="protein-CB" type2="protein-CA" type3="protein-N2" angle="2.155481626212997" k="585.76"/>
-  <Angle type1="protein-N2" type2="protein-CA" type3="protein-NA" angle="2.0245819323134224" k="585.76"/>
-  <Angle type1="protein-C" type2="protein-CB" type3="protein-CB" angle="2.080432468377241" k="527.184"/>
-  <Angle type1="protein-C" type2="protein-CB" type3="protein-NB" angle="2.2689280275926285" k="585.76"/>
-  <Angle type1="protein-CA" type2="protein-CB" type3="protein-CB" angle="2.0472712125893486" k="527.184"/>
-  <Angle type1="protein-CA" type2="protein-CB" type3="protein-NB" angle="2.3108159296404924" k="585.76"/>
-  <Angle type1="protein-CB" type2="protein-CB" type3="protein-NB" angle="1.9268434942017398" k="585.76"/>
-  <Angle type1="protein-H1" type2="protein-CT" type3="protein-OH" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-H1" type2="protein-CT" type3="protein-S" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-H1" type2="protein-CT" type3="protein-SH" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-H1" type2="protein-CT" type3="protein-N2" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-HP" type2="protein-CT" type3="protein-HP" angle="1.911135530933791" k="292.88"/>
-  <Angle type1="protein-HP" type2="protein-CT" type3="protein-N3" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-C" type2="protein-CT" type3="protein-H1" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-C" type2="protein-CT" type3="protein-HP" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-C" type2="protein-CT" type3="protein-N" angle="1.9216075064457567" k="527.184"/>
-  <Angle type1="protein-C" type2="protein-CT" type3="protein-N3" angle="1.9408061282176945" k="669.44"/>
-  <Angle type1="protein-C" type2="protein-CT" type3="protein-CT" angle="1.9390607989657" k="527.184"/>
-  <Angle type1="protein-CC" type2="protein-CT" type3="protein-CT" angle="1.9739673840055867" k="527.184"/>
-  <Angle type1="protein-CT" type2="protein-CT" type3="protein-CT" angle="1.911135530933791" k="334.72"/>
-  <Angle type1="protein-CT" type2="protein-CT" type3="protein-HC" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-CT" type2="protein-CT" type3="protein-H1" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-CT" type2="protein-CT" type3="protein-HP" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-CT" type2="protein-CT" type3="protein-OH" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-CT" type2="protein-CT" type3="protein-S" angle="2.0018926520374962" k="418.40000000000003"/>
-  <Angle type1="protein-CT" type2="protein-CT" type3="protein-SH" angle="1.8954275676658419" k="418.40000000000003"/>
-  <Angle type1="protein-CT" type2="protein-CT" type3="protein-CA" angle="1.9896753472735358" k="527.184"/>
-  <Angle type1="protein-CT" type2="protein-CT" type3="protein-N2" angle="1.9408061282176945" k="669.44"/>
-  <Angle type1="protein-CT" type2="protein-CT" type3="protein-N" angle="1.9146261894377796" k="669.44"/>
-  <Angle type1="protein-CT" type2="protein-CT" type3="protein-N3" angle="1.9408061282176945" k="669.44"/>
-  <Angle type1="protein-C*" type2="protein-CT" type3="protein-CT" angle="2.0176006153054447" k="527.184"/>
-  <Angle type1="protein-C" type2="protein-N" type3="protein-CT" angle="2.1275563581810877" k="418.40000000000003"/>
-  <Angle type1="protein-CT" type2="protein-N" type3="protein-H" angle="2.0601866490541068" k="418.40000000000003"/>
-  <Angle type1="protein-CT" type2="protein-N" type3="protein-CT" angle="2.059488517353309" k="418.40000000000003"/>
-  <Angle type1="protein-H" type2="protein-N" type3="protein-H" angle="2.0943951023931953" k="292.88"/>
-  <Angle type1="protein-CA" type2="protein-N2" type3="protein-H" angle="2.0943951023931953" k="418.40000000000003"/>
-  <Angle type1="protein-CA" type2="protein-N2" type3="protein-CT" angle="2.150245638457014" k="418.40000000000003"/>
-  <Angle type1="protein-CT" type2="protein-N2" type3="protein-H" angle="2.0664698343612864" k="418.40000000000003"/>
-  <Angle type1="protein-H" type2="protein-N2" type3="protein-H" angle="2.0943951023931953" k="292.88"/>
-  <Angle type1="protein-CT" type2="protein-N3" type3="protein-H" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-CT" type2="protein-N3" type3="protein-CT" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-H" type2="protein-N3" type3="protein-H" angle="1.911135530933791" k="292.88"/>
-  <Angle type1="protein-C" type2="protein-NA" type3="protein-C" angle="2.2060961745208325" k="585.76"/>
-  <Angle type1="protein-C" type2="protein-NA" type3="protein-CA" angle="2.1851522234969005" k="585.76"/>
-  <Angle type1="protein-C" type2="protein-NA" type3="protein-H" angle="2.038544566329377" k="418.40000000000003"/>
-  <Angle type1="protein-CA" type2="protein-NA" type3="protein-H" angle="2.059488517353309" k="418.40000000000003"/>
-  <Angle type1="protein-C" type2="protein-OH" type3="protein-HO" angle="1.9722220547535925" k="418.40000000000003"/>
-  <Angle type1="protein-CA" type2="protein-OH" type3="protein-HO" angle="1.9722220547535925" k="418.40000000000003"/>
-  <Angle type1="protein-CT" type2="protein-OH" type3="protein-HO" angle="1.8936822384138476" k="460.24"/>
-  <Angle type1="protein-CT" type2="protein-S" type3="protein-CT" angle="1.726130630222392" k="518.816"/>
-  <Angle type1="protein-CT" type2="protein-S" type3="protein-S" angle="1.8099064343181197" k="569.024"/>
-  <Angle type1="protein-CT" type2="protein-SH" type3="protein-HS" angle="1.6755160819145565" k="359.824"/>
-  <Angle type1="protein-HS" type2="protein-SH" type3="protein-HS" angle="1.6069246423111792" k="292.88"/>
-  <Angle type1="protein-N" type2="protein-C" type3="protein-2C" angle="2.035053907825388" k="585.76"/>
-  <Angle type1="protein-O" type2="protein-C" type3="protein-2C" angle="2.101376419401173" k="669.44"/>
-  <Angle type1="protein-OH" type2="protein-C" type3="protein-2C" angle="1.9198621771937625" k="669.44"/>
-  <Angle type1="protein-CB" type2="protein-C*" type3="protein-2C" angle="2.2444934180647076" k="585.76"/>
-  <Angle type1="protein-CW" type2="protein-C*" type3="protein-2C" angle="2.181661564992912" k="585.76"/>
-  <Angle type1="protein-CA" type2="protein-CA" type3="protein-2C" angle="2.0943951023931953" k="585.76"/>
-  <Angle type1="protein-CV" type2="protein-CC" type3="protein-2C" angle="2.0943951023931953" k="585.76"/>
-  <Angle type1="protein-CW" type2="protein-CC" type3="protein-2C" angle="2.0943951023931953" k="585.76"/>
-  <Angle type1="protein-NA" type2="protein-CC" type3="protein-2C" angle="2.0943951023931953" k="585.76"/>
-  <Angle type1="protein-NB" type2="protein-CC" type3="protein-2C" angle="2.0943951023931953" k="585.76"/>
-  <Angle type1="protein-HC" type2="protein-CT" type3="protein-2C" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-HC" type2="protein-CT" type3="protein-3C" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-HO" type2="protein-OH" type3="protein-2C" angle="1.8936822384138476" k="460.24"/>
-  <Angle type1="protein-HO" type2="protein-OH" type3="protein-3C" angle="1.8936822384138476" k="460.24"/>
-  <Angle type1="protein-CT" type2="protein-S" type3="protein-2C" angle="1.726130630222392" k="518.816"/>
-  <Angle type1="protein-2C" type2="protein-S" type3="protein-S" angle="1.8099064343181197" k="569.024"/>
-  <Angle type1="protein-HS" type2="protein-SH" type3="protein-2C" angle="1.6755160819145565" k="359.824"/>
-  <Angle type1="protein-C" type2="protein-2C" type3="protein-HC" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-C" type2="protein-2C" type3="protein-2C" angle="1.9390607989657" k="527.184"/>
-  <Angle type1="protein-C*" type2="protein-2C" type3="protein-HC" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-CA" type2="protein-2C" type3="protein-HC" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-CC" type2="protein-2C" type3="protein-HC" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-CO" type2="protein-2C" type3="protein-HC" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-CO" type2="protein-2C" type3="protein-2C" angle="1.9390607989657" k="527.184"/>
-  <Angle type1="protein-CT" type2="protein-2C" type3="protein-HC" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-CT" type2="protein-2C" type3="protein-3C" angle="1.911135530933791" k="334.72"/>
-  <Angle type1="protein-H1" type2="protein-2C" type3="protein-H1" angle="1.911135530933791" k="292.88"/>
-  <Angle type1="protein-H1" type2="protein-2C" type3="protein-OH" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-H1" type2="protein-2C" type3="protein-S" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-H1" type2="protein-2C" type3="protein-SH" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-H1" type2="protein-2C" type3="protein-2C" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-HC" type2="protein-2C" type3="protein-HC" angle="1.911135530933791" k="292.88"/>
-  <Angle type1="protein-HC" type2="protein-2C" type3="protein-2C" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-HC" type2="protein-2C" type3="protein-3C" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-S" type2="protein-2C" type3="protein-2C" angle="2.0018926520374962" k="418.40000000000003"/>
-  <Angle type1="protein-CT" type2="protein-3C" type3="protein-CT" angle="1.911135530933791" k="334.72"/>
-  <Angle type1="protein-CT" type2="protein-3C" type3="protein-H1" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-CT" type2="protein-3C" type3="protein-HC" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-CT" type2="protein-3C" type3="protein-OH" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-CT" type2="protein-3C" type3="protein-2C" angle="1.911135530933791" k="334.72"/>
-  <Angle type1="protein-H1" type2="protein-3C" type3="protein-OH" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-HC" type2="protein-3C" type3="protein-2C" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-OD" type2="protein-C" type3="protein-N" angle="2.1771237089377267" k="667.4835616"/>
-  <Angle type1="protein-OD" type2="protein-C" type3="protein-TN" angle="2.1450096507010312" k="669.44"/>
-  <Angle type1="protein-OD" type2="protein-C" type3="protein-ND" angle="2.1450096507010312" k="669.44"/>
-  <Angle type1="protein-C" type2="protein-N" type3="protein-CX" angle="2.0875883183104174" k="411.090552"/>
-  <Angle type1="protein-C" type2="protein-TN" type3="protein-TJ" angle="2.1275563581810877" k="418.40000000000003"/>
-  <Angle type1="protein-C" type2="protein-N" type3="protein-TG" angle="2.0074777056438777" k="369.1702192"/>
-  <Angle type1="protein-C" type2="protein-N" type3="protein-TP" angle="2.026850860341015" k="370.3107776"/>
-  <Angle type1="protein-C" type2="protein-N" type3="protein-TM" angle="2.1390755312442504" k="376.0570832"/>
-  <Angle type1="protein-C" type2="protein-TN" type3="protein-CT" angle="2.1275563581810877" k="418.40000000000003"/>
-  <Angle type1="protein-C" type2="protein-N" type3="protein-H" angle="2.0968385633459876" k="408.8169664"/>
-  <Angle type1="protein-H" type2="protein-N" type3="protein-CX" angle="2.0355775066009865" k="405.5233216"/>
-  <Angle type1="protein-H" type2="protein-N" type3="protein-TG" angle="2.026501794490616" k="343.0227296"/>
-  <Angle type1="protein-H" type2="protein-N" type3="protein-TP" angle="1.9697785938008003" k="335.648848"/>
-  <Angle type1="protein-H" type2="protein-N" type3="protein-TM" angle="2.016378884829049" k="363.6406448"/>
-  <Angle type1="protein-H" type2="protein-NL" type3="protein-CX" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-H" type2="protein-NL" type3="protein-TJ" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-H" type2="protein-NL" type3="protein-TG" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-H" type2="protein-NL" type3="protein-TP" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-H" type2="protein-NL" type3="protein-TM" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-H" type2="protein-NL" type3="protein-CT" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-H" type2="protein-NL" type3="protein-H" angle="1.911135530933791" k="292.88"/>
-  <Angle type1="protein-CT" type2="protein-TN" type3="protein-TJ" angle="2.059488517353309" k="418.40000000000003"/>
-  <Angle type1="protein-CT" type2="protein-NL" type3="protein-TJ" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-N" type2="protein-CX" type3="protein-C" angle="1.8715165569135197" k="521.364056"/>
-  <Angle type1="protein-TN" type2="protein-TJ" type3="protein-C" angle="1.8856537238546738" k="518.7356672000001"/>
-  <Angle type1="protein-N" type2="protein-TG" type3="protein-C" angle="1.879021472697095" k="524.5865728"/>
-  <Angle type1="protein-N" type2="protein-TP" type3="protein-C" angle="1.8505726058895877" k="470.93514080000006"/>
-  <Angle type1="protein-N" type2="protein-TM" type3="protein-C" angle="1.8404496962280206" k="516.3399088"/>
-  <Angle type1="protein-NL" type2="protein-CX" type3="protein-C" angle="1.9408061282176945" k="669.44"/>
-  <Angle type1="protein-NL" type2="protein-TJ" type3="protein-C" angle="1.9408061282176945" k="669.44"/>
-  <Angle type1="protein-NL" type2="protein-TG" type3="protein-C" angle="1.9408061282176945" k="669.44"/>
-  <Angle type1="protein-NL" type2="protein-TP" type3="protein-C" angle="1.9408061282176945" k="669.44"/>
-  <Angle type1="protein-NL" type2="protein-TM" type3="protein-C" angle="1.9408061282176945" k="669.44"/>
-  <Angle type1="protein-N" type2="protein-CX" type3="protein-CO" angle="1.9216075064457567" k="527.184"/>
-  <Angle type1="protein-TN" type2="protein-TJ" type3="protein-CO" angle="1.9216075064457567" k="527.184"/>
-  <Angle type1="protein-N" type2="protein-TG" type3="protein-CO" angle="1.9216075064457567" k="527.184"/>
-  <Angle type1="protein-N" type2="protein-TP" type3="protein-CO" angle="1.9216075064457567" k="527.184"/>
-  <Angle type1="protein-N" type2="protein-TM" type3="protein-CO" angle="1.9216075064457567" k="527.184"/>
-  <Angle type1="protein-N" type2="protein-CX" type3="protein-CT" angle="1.9603538158400309" k="669.5370688"/>
-  <Angle type1="protein-N" type2="protein-CX" type3="protein-TA" angle="1.943773187946085" k="659.8971328"/>
-  <Angle type1="protein-N" type2="protein-CX" type3="protein-2C" angle="1.9401079965168966" k="662.6836768000001"/>
-  <Angle type1="protein-N" type2="protein-CX" type3="protein-3C" angle="1.9395843977412983" k="658.4084656000001"/>
-  <Angle type1="protein-TN" type2="protein-TJ" type3="protein-CT" angle="1.8807668019490895" k="659.9105216"/>
-  <Angle type1="protein-N" type2="protein-TP" type3="protein-C8" angle="1.9134044589613834" k="647.1258912"/>
-  <Angle type1="protein-N" type2="protein-TM" type3="protein-2C" angle="1.9401079965168966" k="676.5712096"/>
-  <Angle type1="protein-NL" type2="protein-CX" type3="protein-CT" angle="1.9408061282176945" k="669.44"/>
-  <Angle type1="protein-NL" type2="protein-CX" type3="protein-2C" angle="1.9408061282176945" k="669.44"/>
-  <Angle type1="protein-NL" type2="protein-CX" type3="protein-3C" angle="1.9408061282176945" k="669.44"/>
-  <Angle type1="protein-NL" type2="protein-CX" type3="protein-TA" angle="1.9408061282176945" k="669.44"/>
-  <Angle type1="protein-NL" type2="protein-TJ" type3="protein-CT" angle="1.9408061282176945" k="669.44"/>
-  <Angle type1="protein-NL" type2="protein-TM" type3="protein-2C" angle="1.9408061282176945" k="669.44"/>
-  <Angle type1="protein-NL" type2="protein-TP" type3="protein-C8" angle="1.9408061282176945" k="669.44"/>
-  <Angle type1="protein-N" type2="protein-CX" type3="protein-H1" angle="1.9336502782845177" k="420.5689856"/>
-  <Angle type1="protein-TN" type2="protein-TJ" type3="protein-H1" angle="1.92981055393013" k="408.03121120000003"/>
-  <Angle type1="protein-N" type2="protein-TG" type3="protein-H1" angle="1.924400033248948" k="436.8313568"/>
-  <Angle type1="protein-N" type2="protein-TP" type3="protein-H1" angle="1.9352210746113125" k="403.2673088"/>
-  <Angle type1="protein-N" type2="protein-TM" type3="protein-H1" angle="1.9603538158400309" k="442.4262016"/>
-  <Angle type1="protein-N" type2="protein-CT" type3="protein-H1" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-NL" type2="protein-CX" type3="protein-HP" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-NL" type2="protein-TJ" type3="protein-HP" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-NL" type2="protein-TG" type3="protein-HP" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-NL" type2="protein-TP" type3="protein-HP" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-NL" type2="protein-TM" type3="protein-HP" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-TN" type2="protein-CT" type3="protein-CT" angle="1.9146261894377796" k="669.44"/>
-  <Angle type1="protein-NL" type2="protein-CT" type3="protein-CT" angle="1.9408061282176945" k="669.44"/>
-  <Angle type1="protein-TN" type2="protein-CT" type3="protein-H1" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-NL" type2="protein-CT" type3="protein-HP" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-CT" type2="protein-CX" type3="protein-H1" angle="1.9734437852299882" k="419.90791360000003"/>
-  <Angle type1="protein-2C" type2="protein-CX" type3="protein-H1" angle="1.9568631573360424" k="420.9262992"/>
-  <Angle type1="protein-3C" type2="protein-CX" type3="protein-H1" angle="1.9671605999228088" k="422.0835936"/>
-  <Angle type1="protein-TA" type2="protein-CX" type3="protein-H1" angle="1.9617500792416265" k="429.0599952"/>
-  <Angle type1="protein-CT" type2="protein-TJ" type3="protein-H1" angle="1.9528489000564553" k="420.140544"/>
-  <Angle type1="protein-C8" type2="protein-TP" type3="protein-H1" angle="1.9168951174653721" k="431.5645376"/>
-  <Angle type1="protein-2C" type2="protein-TM" type3="protein-H1" angle="1.92370190154815" k="427.1997888"/>
-  <Angle type1="protein-CT" type2="protein-CX" type3="protein-HP" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-2C" type2="protein-CX" type3="protein-HP" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-3C" type2="protein-CX" type3="protein-HP" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-TA" type2="protein-CX" type3="protein-HP" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-CT" type2="protein-TJ" type3="protein-HP" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-C8" type2="protein-TP" type3="protein-HP" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-2C" type2="protein-TM" type3="protein-HP" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-H1" type2="protein-TG" type3="protein-H1" angle="1.9385372001901018" k="316.04680800000006"/>
-  <Angle type1="protein-HP" type2="protein-TG" type3="protein-HP" angle="1.911135530933791" k="292.88"/>
-  <Angle type1="protein-CT" type2="protein-CX" type3="protein-C" angle="1.9509290378792616" k="523.8309424"/>
-  <Angle type1="protein-2C" type2="protein-CX" type3="protein-C" angle="1.9308577514813268" k="521.0377040000001"/>
-  <Angle type1="protein-3C" type2="protein-CX" type3="protein-C" angle="1.9409806611428937" k="518.5222832000001"/>
-  <Angle type1="protein-TA" type2="protein-CX" type3="protein-C" angle="1.9364428050877087" k="514.878856"/>
-  <Angle type1="protein-CT" type2="protein-TJ" type3="protein-C" angle="1.9198621771937625" k="477.81447360000004"/>
-  <Angle type1="protein-C8" type2="protein-TP" type3="protein-C" angle="1.9481365110760707" k="505.64309440000005"/>
-  <Angle type1="protein-2C" type2="protein-TM" type3="protein-C" angle="1.9420278586940904" k="501.9829312"/>
-  <Angle type1="protein-CT" type2="protein-CX" type3="protein-CO" angle="1.9390607989657" k="527.184"/>
-  <Angle type1="protein-2C" type2="protein-CX" type3="protein-CO" angle="1.9390607989657" k="527.184"/>
-  <Angle type1="protein-3C" type2="protein-CX" type3="protein-CO" angle="1.9390607989657" k="527.184"/>
-  <Angle type1="protein-TA" type2="protein-CX" type3="protein-CO" angle="1.9390607989657" k="527.184"/>
-  <Angle type1="protein-CT" type2="protein-TJ" type3="protein-CO" angle="1.9390607989657" k="527.184"/>
-  <Angle type1="protein-C8" type2="protein-TP" type3="protein-CO" angle="1.9390607989657" k="527.184"/>
-  <Angle type1="protein-2C" type2="protein-TM" type3="protein-CO" angle="1.9390607989657" k="527.184"/>
-  <Angle type1="protein-HC" type2="protein-CT" type3="protein-C" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-H1" type2="protein-CX" type3="protein-C" angle="1.9505799720288628" k="417.36738880000007"/>
-  <Angle type1="protein-H1" type2="protein-TJ" type3="protein-C" angle="1.8894934482090613" k="382.296264"/>
-  <Angle type1="protein-H1" type2="protein-TG" type3="protein-C" angle="1.9380136014145037" k="420.4886528"/>
-  <Angle type1="protein-H1" type2="protein-TP" type3="protein-C" angle="2.008873969045473" k="393.40060000000005"/>
-  <Angle type1="protein-H1" type2="protein-TM" type3="protein-C" angle="1.9257962966505433" k="410.2085648"/>
-  <Angle type1="protein-HP" type2="protein-CX" type3="protein-C" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-HP" type2="protein-TJ" type3="protein-C" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-HP" type2="protein-TG" type3="protein-C" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-HP" type2="protein-TP" type3="protein-C" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-HP" type2="protein-TM" type3="protein-C" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-H1" type2="protein-CX" type3="protein-CO" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-H1" type2="protein-TJ" type3="protein-CO" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-H1" type2="protein-TG" type3="protein-CO" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-H1" type2="protein-TP" type3="protein-CO" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-H1" type2="protein-TM" type3="protein-CO" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-CX" type2="protein-C" type3="protein-N" angle="2.0001473227855016" k="565.5604848"/>
-  <Angle type1="protein-TJ" type2="protein-C" type3="protein-N" angle="2.035053907825388" k="585.76"/>
-  <Angle type1="protein-TG" type2="protein-C" type3="protein-N" angle="1.9727456535291907" k="519.3992496"/>
-  <Angle type1="protein-TP" type2="protein-C" type3="protein-N" angle="2.0244073993882226" k="565.3705312000001"/>
-  <Angle type1="protein-TM" type2="protein-C" type3="protein-N" angle="1.9991001252343052" k="556.7950048"/>
-  <Angle type1="protein-CT" type2="protein-C" type3="protein-N" angle="2.035053907825388" k="585.76"/>
-  <Angle type1="protein-CX" type2="protein-C" type3="protein-TN" angle="2.035053907825388" k="585.76"/>
-  <Angle type1="protein-TJ" type2="protein-C" type3="protein-TN" angle="2.035053907825388" k="585.76"/>
-  <Angle type1="protein-TG" type2="protein-C" type3="protein-TN" angle="2.035053907825388" k="585.76"/>
-  <Angle type1="protein-TP" type2="protein-C" type3="protein-TN" angle="2.035053907825388" k="585.76"/>
-  <Angle type1="protein-TM" type2="protein-C" type3="protein-TN" angle="2.035053907825388" k="585.76"/>
-  <Angle type1="protein-CT" type2="protein-C" type3="protein-TN" angle="2.035053907825388" k="585.76"/>
-  <Angle type1="protein-CX" type2="protein-C" type3="protein-ND" angle="2.035053907825388" k="585.76"/>
-  <Angle type1="protein-TJ" type2="protein-C" type3="protein-ND" angle="2.035053907825388" k="585.76"/>
-  <Angle type1="protein-TG" type2="protein-C" type3="protein-ND" angle="2.035053907825388" k="585.76"/>
-  <Angle type1="protein-TP" type2="protein-C" type3="protein-ND" angle="2.035053907825388" k="585.76"/>
-  <Angle type1="protein-TM" type2="protein-C" type3="protein-ND" angle="2.035053907825388" k="585.76"/>
-  <Angle type1="protein-CT" type2="protein-C" type3="protein-ND" angle="2.035053907825388" k="585.76"/>
-  <Angle type1="protein-CX" type2="protein-C" type3="protein-OD" angle="2.0992820242987795" k="657.8478096"/>
-  <Angle type1="protein-TJ" type2="protein-C" type3="protein-OD" angle="2.101376419401173" k="669.44"/>
-  <Angle type1="protein-TG" type2="protein-C" type3="protein-OD" angle="2.1287780886574836" k="629.2828048"/>
-  <Angle type1="protein-TP" type2="protein-C" type3="protein-OD" angle="2.122843969200703" k="643.2347712"/>
-  <Angle type1="protein-TM" type2="protein-C" type3="protein-OD" angle="2.055474260073722" k="647.1083184"/>
-  <Angle type1="protein-CT" type2="protein-C" type3="protein-OD" angle="2.101376419401173" k="669.44"/>
-  <Angle type1="protein-CX" type2="protein-CO" type3="protein-O3" angle="2.0420352248333655" k="585.76"/>
-  <Angle type1="protein-TJ" type2="protein-CO" type3="protein-O3" angle="2.0420352248333655" k="585.76"/>
-  <Angle type1="protein-TG" type2="protein-CO" type3="protein-O3" angle="2.0420352248333655" k="585.76"/>
-  <Angle type1="protein-TP" type2="protein-CO" type3="protein-O3" angle="2.0420352248333655" k="585.76"/>
-  <Angle type1="protein-TM" type2="protein-CO" type3="protein-O3" angle="2.0420352248333655" k="585.76"/>
-  <Angle type1="protein-CX" type2="protein-C" type3="protein-O" angle="2.101376419401173" k="669.44"/>
-  <Angle type1="protein-CX" type2="protein-C" type3="protein-OH" angle="1.9198621771937625" k="669.44"/>
-  <Angle type1="protein-CX" type2="protein-2C" type3="protein-C" angle="1.9390607989657" k="527.184"/>
-  <Angle type1="protein-CX" type2="protein-2C" type3="protein-SH" angle="1.8954275676658419" k="418.40000000000003"/>
-  <Angle type1="protein-CX" type2="protein-2C" type3="protein-S" angle="2.0018926520374962" k="418.40000000000003"/>
-  <Angle type1="protein-CX" type2="protein-2C" type3="protein-2C" angle="1.911135530933791" k="334.72"/>
-  <Angle type1="protein-CX" type2="protein-2C" type3="protein-3C" angle="1.911135530933791" k="334.72"/>
-  <Angle type1="protein-CX" type2="protein-2C" type3="protein-OA" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-CX" type2="protein-3C" type3="protein-CT" angle="1.911135530933791" k="334.72"/>
-  <Angle type1="protein-CX" type2="protein-3C" type3="protein-2C" angle="1.911135530933791" k="334.72"/>
-  <Angle type1="protein-CX" type2="protein-3C" type3="protein-OA" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-CX" type2="protein-TA" type3="protein-CC" angle="1.9739673840055867" k="527.184"/>
-  <Angle type1="protein-CX" type2="protein-TA" type3="protein-CA" angle="1.9896753472735358" k="527.184"/>
-  <Angle type1="protein-CX" type2="protein-TA" type3="protein-C*" angle="2.0176006153054447" k="527.184"/>
-  <Angle type1="protein-TJ" type2="protein-CT" type3="protein-CT" angle="1.911135530933791" k="334.72"/>
-  <Angle type1="protein-TP" type2="protein-C8" type3="protein-C8" angle="1.911135530933791" k="334.72"/>
-  <Angle type1="protein-TP" type2="protein-C8" type3="protein-CC" angle="1.9739673840055867" k="527.184"/>
-  <Angle type1="protein-TM" type2="protein-2C" type3="protein-2C" angle="1.911135530933791" k="334.72"/>
-  <Angle type1="protein-TM" type2="protein-2C" type3="protein-CO" angle="1.9390607989657" k="527.184"/>
-  <Angle type1="protein-TM" type2="protein-2C" type3="protein-SH" angle="1.8954275676658419" k="418.40000000000003"/>
-  <Angle type1="protein-CX" type2="protein-CT" type3="protein-HC" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-CX" type2="protein-2C" type3="protein-HC" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-CX" type2="protein-3C" type3="protein-HC" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-CX" type2="protein-TA" type3="protein-HC" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-TJ" type2="protein-CT" type3="protein-HC" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-TP" type2="protein-C8" type3="protein-HC" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-TM" type2="protein-2C" type3="protein-HC" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-CX" type2="protein-2C" type3="protein-H1" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-CX" type2="protein-3C" type3="protein-H1" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-TM" type2="protein-2C" type3="protein-H1" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-HC" type2="protein-CT" type3="protein-HC" angle="1.911135530933791" k="292.88"/>
-  <Angle type1="protein-HC" type2="protein-TA" type3="protein-HC" angle="1.911135530933791" k="292.88"/>
-  <Angle type1="protein-H1" type2="protein-CT" type3="protein-H1" angle="1.911135530933791" k="292.88"/>
-  <Angle type1="protein-HC" type2="protein-2C" type3="protein-N3" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-2C" type2="protein-N3" type3="protein-H" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-2C" type2="protein-2C" type3="protein-N3" angle="1.9408061282176945" k="669.44"/>
-  <Angle type1="protein-2C" type2="protein-2C" type3="protein-2C" angle="1.911135530933791" k="334.72"/>
-  <Angle type1="protein-2C" type2="protein-2C" type3="protein-CT" angle="1.911135530933791" k="334.72"/>
-  <Angle type1="protein-2C" type2="protein-C" type3="protein-OD" angle="2.101376419401173" k="669.44"/>
-  <Angle type1="protein-H1" type2="protein-2C" type3="protein-OA" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-C" type2="protein-ND" type3="protein-H" angle="2.0943951023931953" k="418.40000000000003"/>
-  <Angle type1="protein-H" type2="protein-ND" type3="protein-H" angle="2.0943951023931953" k="292.88"/>
-  <Angle type1="protein-2C" type2="protein-C" type3="protein-ND" angle="2.035053907825388" k="585.76"/>
-  <Angle type1="protein-HO" type2="protein-OA" type3="protein-2C" angle="1.8936822384138476" k="460.24"/>
-  <Angle type1="protein-CT" type2="protein-3C" type3="protein-OA" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-H1" type2="protein-3C" type3="protein-OA" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-HO" type2="protein-OA" type3="protein-3C" angle="1.8936822384138476" k="460.24"/>
-  <Angle type1="protein-TA" type2="protein-CC" type3="protein-NA" angle="2.0943951023931953" k="585.76"/>
-  <Angle type1="protein-TA" type2="protein-CC" type3="protein-NB" angle="2.0943951023931953" k="585.76"/>
-  <Angle type1="protein-TA" type2="protein-CC" type3="protein-CV" angle="2.0943951023931953" k="585.76"/>
-  <Angle type1="protein-TA" type2="protein-CC" type3="protein-CW" angle="2.0943951023931953" k="585.76"/>
-  <Angle type1="protein-CV" type2="protein-CC" type3="protein-NA" angle="2.0943951023931953" k="585.76"/>
-  <Angle type1="protein-CW" type2="protein-CC" type3="protein-NB" angle="2.0943951023931953" k="585.76"/>
-  <Angle type1="protein-CW" type2="protein-CC" type3="protein-NA" angle="2.0943951023931953" k="585.76"/>
-  <Angle type1="protein-CC" type2="protein-CV" type3="protein-NB" angle="2.0943951023931953" k="585.76"/>
-  <Angle type1="protein-CC" type2="protein-CW" type3="protein-NA" angle="2.0943951023931953" k="585.76"/>
-  <Angle type1="protein-CV" type2="protein-NB" type3="protein-CR" angle="2.0420352248333655" k="585.76"/>
-  <Angle type1="protein-CW" type2="protein-NA" type3="protein-CR" angle="2.0943951023931953" k="585.76"/>
-  <Angle type1="protein-NB" type2="protein-CR" type3="protein-NA" angle="2.0943951023931953" k="585.76"/>
-  <Angle type1="protein-NA" type2="protein-CR" type3="protein-NA" angle="2.0943951023931953" k="585.76"/>
-  <Angle type1="protein-CR" type2="protein-NA" type3="protein-CC" angle="2.0943951023931953" k="585.76"/>
-  <Angle type1="protein-CR" type2="protein-NB" type3="protein-CC" angle="2.0420352248333655" k="585.76"/>
-  <Angle type1="protein-CC" type2="protein-TA" type3="protein-HC" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-CC" type2="protein-CV" type3="protein-H4" angle="2.0943951023931953" k="418.40000000000003"/>
-  <Angle type1="protein-CC" type2="protein-CW" type3="protein-H4" angle="2.0943951023931953" k="418.40000000000003"/>
-  <Angle type1="protein-CC" type2="protein-NA" type3="protein-H" angle="2.0943951023931953" k="418.40000000000003"/>
-  <Angle type1="protein-CW" type2="protein-NA" type3="protein-H" angle="2.0943951023931953" k="418.40000000000003"/>
-  <Angle type1="protein-CR" type2="protein-NA" type3="protein-H" angle="2.0943951023931953" k="418.40000000000003"/>
-  <Angle type1="protein-NB" type2="protein-CV" type3="protein-H4" angle="2.0943951023931953" k="418.40000000000003"/>
-  <Angle type1="protein-NA" type2="protein-CW" type3="protein-H4" angle="2.0943951023931953" k="418.40000000000003"/>
-  <Angle type1="protein-NA" type2="protein-CR" type3="protein-H5" angle="2.0943951023931953" k="418.40000000000003"/>
-  <Angle type1="protein-NB" type2="protein-CR" type3="protein-H5" angle="2.0943951023931953" k="418.40000000000003"/>
-  <Angle type1="protein-TA" type2="protein-CA" type3="protein-CA" angle="2.0943951023931953" k="585.76"/>
-  <Angle type1="protein-CA" type2="protein-CA" type3="protein-CA" angle="2.0943951023931953" k="527.184"/>
-  <Angle type1="protein-CA" type2="protein-CA" type3="protein-HA" angle="2.0943951023931953" k="418.40000000000003"/>
-  <Angle type1="protein-CA" type2="protein-TA" type3="protein-HC" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-CA" type2="protein-CA" type3="protein-C" angle="2.0943951023931953" k="527.184"/>
-  <Angle type1="protein-CA" type2="protein-C" type3="protein-CA" angle="2.0943951023931953" k="527.184"/>
-  <Angle type1="protein-CA" type2="protein-C" type3="protein-OA" angle="2.0943951023931953" k="585.76"/>
-  <Angle type1="protein-C" type2="protein-OA" type3="protein-HO" angle="1.9722220547535925" k="418.40000000000003"/>
-  <Angle type1="protein-C" type2="protein-CA" type3="protein-HA" angle="2.0943951023931953" k="418.40000000000003"/>
-  <Angle type1="protein-TA" type2="protein-C*" type3="protein-CB" angle="2.2444934180647076" k="585.76"/>
-  <Angle type1="protein-TA" type2="protein-C*" type3="protein-CW" angle="2.181661564992912" k="585.76"/>
-  <Angle type1="protein-CB" type2="protein-C*" type3="protein-CW" angle="1.8570303241219668" k="527.184"/>
-  <Angle type1="protein-C*" type2="protein-CW" type3="protein-NA" angle="1.8971728969178363" k="585.76"/>
-  <Angle type1="protein-C*" type2="protein-CB" type3="protein-CA" angle="2.3544491609403506" k="527.184"/>
-  <Angle type1="protein-C*" type2="protein-CB" type3="protein-CN" angle="1.8989182261698305" k="527.184"/>
-  <Angle type1="protein-CN" type2="protein-NA" type3="protein-CW" angle="1.9477874452256716" k="585.76"/>
-  <Angle type1="protein-CA" type2="protein-CA" type3="protein-CB" angle="2.0943951023931953" k="527.184"/>
-  <Angle type1="protein-CA" type2="protein-CA" type3="protein-CN" angle="2.0943951023931953" k="527.184"/>
-  <Angle type1="protein-CA" type2="protein-CB" type3="protein-CN" angle="2.028072590817411" k="527.184"/>
-  <Angle type1="protein-CA" type2="protein-CN" type3="protein-NA" angle="2.3177972466484698" k="585.76"/>
-  <Angle type1="protein-CB" type2="protein-CN" type3="protein-NA" angle="1.8221237390820801" k="585.76"/>
-  <Angle type1="protein-CA" type2="protein-CN" type3="protein-CB" angle="2.1415189921970423" k="527.184"/>
-  <Angle type1="protein-C*" type2="protein-TA" type3="protein-HC" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-C*" type2="protein-CW" type3="protein-H4" angle="2.0943951023931953" k="418.40000000000003"/>
-  <Angle type1="protein-CB" type2="protein-CA" type3="protein-HA" angle="2.0943951023931953" k="418.40000000000003"/>
-  <Angle type1="protein-CN" type2="protein-CA" type3="protein-HA" angle="2.0943951023931953" k="418.40000000000003"/>
-  <Angle type1="protein-CN" type2="protein-NA" type3="protein-H" angle="2.1485003092050197" k="418.40000000000003"/>
-  <Angle type1="protein-C8" type2="protein-C8" type3="protein-C8" angle="1.911135530933791" k="334.72"/>
-  <Angle type1="protein-C8" type2="protein-C8" type3="protein-N2" angle="1.9408061282176945" k="669.44"/>
-  <Angle type1="protein-C8" type2="protein-N2" type3="protein-CA" angle="2.150245638457014" k="418.40000000000003"/>
-  <Angle type1="protein-N2" type2="protein-CA" type3="protein-N2" angle="2.0943951023931953" k="585.76"/>
-  <Angle type1="protein-C8" type2="protein-CC" type3="protein-NA" angle="2.0943951023931953" k="585.76"/>
-  <Angle type1="protein-C8" type2="protein-CC" type3="protein-CW" angle="2.0943951023931953" k="585.76"/>
-  <Angle type1="protein-C8" type2="protein-C8" type3="protein-NL" angle="1.9408061282176945" k="669.44"/>
-  <Angle type1="protein-C8" type2="protein-C8" type3="protein-HC" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-C8" type2="protein-C8" type3="protein-H1" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-C8" type2="protein-C8" type3="protein-HP" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-H1" type2="protein-C8" type3="protein-N2" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-HP" type2="protein-C8" type3="protein-NL" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-C8" type2="protein-NL" type3="protein-H" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-CC" type2="protein-C8" type3="protein-HC" angle="1.911135530933791" k="418.40000000000003"/>
-  <Angle type1="protein-C8" type2="protein-N2" type3="protein-TH" angle="2.0664698343612864" k="418.40000000000003"/>
-  <Angle type1="protein-CA" type2="protein-N2" type3="protein-TH" angle="2.0943951023931953" k="418.40000000000003"/>
-  <Angle type1="protein-HC" type2="protein-C8" type3="protein-HC" angle="1.911135530933791" k="292.88"/>
-  <Angle type1="protein-H1" type2="protein-C8" type3="protein-H1" angle="1.911135530933791" k="292.88"/>
-  <Angle type1="protein-HP" type2="protein-C8" type3="protein-HP" angle="1.911135530933791" k="292.88"/>
-  <Angle type1="protein-TH" type2="protein-N2" type3="protein-TH" angle="2.0943951023931953" k="292.88"/>
-  <Angle type1="protein-2C" type2="protein-CO" type3="protein-O3" angle="2.0420352248333655" k="585.76"/>
-  <Angle type1="protein-O3" type2="protein-CO" type3="protein-O3" angle="2.199114857512855" k="669.44"/>
- </HarmonicAngleForce>
- <PeriodicTorsionForce ordering="amber">
-  <Proper type1="" type2="protein-C" type3="protein-C" type4="" periodicity1="2" phase1="3.141592653589793" k1="15.167"/>
-  <Proper type1="" type2="protein-C" type3="protein-CB" type4="" periodicity1="2" phase1="3.141592653589793" k1="12.552"/>
-  <Proper type1="" type2="protein-C" type3="protein-NA" type4="" periodicity1="2" phase1="3.141592653589793" k1="5.6484000000000005"/>
-  <Proper type1="" type2="protein-C" type3="protein-O" type4="" periodicity1="2" phase1="3.141592653589793" k1="11.7152"/>
-  <Proper type1="" type2="protein-CA" type3="protein-N2" type4="" periodicity1="2" phase1="3.141592653589793" k1="10.0416"/>
-  <Proper type1="" type2="protein-CA" type3="protein-NA" type4="" periodicity1="2" phase1="3.141592653589793" k1="6.276"/>
-  <Proper type1="" type2="protein-CA" type3="protein-OH" type4="" periodicity1="2" phase1="3.141592653589793" k1="3.7656"/>
-  <Proper type1="" type2="protein-CB" type3="protein-CB" type4="" periodicity1="2" phase1="3.141592653589793" k1="22.8028"/>
-  <Proper type1="" type2="protein-CB" type3="protein-NB" type4="" periodicity1="2" phase1="3.141592653589793" k1="10.6692"/>
-  <Proper type1="" type2="protein-CT" type3="protein-N2" type4="" periodicity1="3" phase1="0.0" k1="0.0"/>
-  <Proper type1="" type2="protein-CT" type3="protein-N3" type4="" periodicity1="3" phase1="0.0" k1="0.6508630400000001"/>
-  <Proper type1="" type2="protein-CT" type3="protein-OH" type4="" periodicity1="3" phase1="0.0" k1="0.6973472800000001"/>
-  <Proper type1="" type2="protein-CT" type3="protein-SH" type4="" periodicity1="3" phase1="0.0" k1="1.046"/>
-  <Proper type1="" type2="protein-N" type3="protein-CX" type4="" periodicity1="2" phase1="0.0" k1="1.6182875200000002"/>
-  <Proper type1="" type2="protein-TN" type3="protein-TJ" type4="" periodicity1="2" phase1="0.0" k1="4.0437104800000006"/>
-  <Proper type1="" type2="protein-N" type3="protein-TG" type4="" periodicity1="2" phase1="0.0" k1="0.65077936"/>
-  <Proper type1="" type2="protein-N" type3="protein-TP" type4="" periodicity1="2" phase1="0.0" k1="3.76806856"/>
-  <Proper type1="" type2="protein-N" type3="protein-TM" type4="" periodicity1="2" phase1="0.0" k1="2.3499017600000003"/>
-  <Proper type1="" type2="protein-N" type3="protein-CT" type4="" periodicity1="2" phase1="0.0" k1="1.4574964000000001"/>
-  <Proper type1="" type2="protein-NL" type3="protein-CX" type4="" periodicity1="3" phase1="0.0" k1="0.30120616"/>
-  <Proper type1="" type2="protein-NL" type3="protein-TJ" type4="" periodicity1="3" phase1="0.0" k1="0.8321139200000001"/>
-  <Proper type1="" type2="protein-NL" type3="protein-TG" type4="" periodicity1="3" phase1="0.0" k1="0.15409672000000002"/>
-  <Proper type1="" type2="protein-NL" type3="protein-TP" type4="" periodicity1="3" phase1="0.0" k1="0.26355016000000003"/>
-  <Proper type1="" type2="protein-NL" type3="protein-TM" type4="" periodicity1="3" phase1="0.0" k1="0.31045280000000003"/>
-  <Proper type1="" type2="protein-TN" type3="protein-CT" type4="" periodicity1="2" phase1="0.0" k1="-1.80677672"/>
-  <Proper type1="" type2="protein-NL" type3="protein-CT" type4="" periodicity1="3" phase1="0.0" k1="0.53270688"/>
-  <Proper type1="" type2="protein-CX" type3="protein-C" type4="" periodicity1="2" phase1="0.0" k1="0.00828432"/>
-  <Proper type1="" type2="protein-TJ" type3="protein-C" type4="" periodicity1="2" phase1="0.0" k1="-1.1341150400000002"/>
-  <Proper type1="" type2="protein-TG" type3="protein-C" type4="" periodicity1="2" phase1="0.0" k1="-3.0618512"/>
-  <Proper type1="" type2="protein-TP" type3="protein-C" type4="" periodicity1="2" phase1="0.0" k1="-0.81918536"/>
-  <Proper type1="" type2="protein-TM" type3="protein-C" type4="" periodicity1="2" phase1="0.0" k1="3.64518448"/>
-  <Proper type1="" type2="protein-CT" type3="protein-C" type4="" periodicity1="2" phase1="0.0" k1="-0.49651528"/>
-  <Proper type1="" type2="protein-CX" type3="protein-CO" type4="" periodicity1="2" phase1="0.0" k1="-9.52127776"/>
-  <Proper type1="" type2="protein-TJ" type3="protein-CO" type4="" periodicity1="2" phase1="0.0" k1="1.52188816"/>
-  <Proper type1="" type2="protein-TG" type3="protein-CO" type4="" periodicity1="2" phase1="0.0" k1="-10.90024048"/>
-  <Proper type1="" type2="protein-TP" type3="protein-CO" type4="" periodicity1="2" phase1="0.0" k1="-11.038730880000001"/>
-  <Proper type1="" type2="protein-TM" type3="protein-CO" type4="" periodicity1="2" phase1="0.0" k1="-5.69998872"/>
-  <Proper type1="" type2="protein-C" type3="protein-N" type4="" periodicity1="2" phase1="3.141592653589793" k1="10.3204636"/>
-  <Proper type1="" type2="protein-C" type3="protein-TN" type4="" periodicity1="2" phase1="3.141592653589793" k1="12.49003496"/>
-  <Proper type1="" type2="protein-C" type3="protein-ND" type4="" periodicity1="2" phase1="3.141592653589793" k1="8.819620960000002"/>
-  <Proper type1="" type2="protein-CX" type3="protein-CT" type4="" periodicity1="3" phase1="0.0" k1="1.03102128"/>
-  <Proper type1="" type2="protein-CX" type3="protein-2C" type4="" periodicity1="3" phase1="0.0" k1="0.9144132"/>
-  <Proper type1="" type2="protein-CX" type3="protein-3C" type4="" periodicity1="3" phase1="0.0" k1="-0.31250296000000005"/>
-  <Proper type1="" type2="protein-CX" type3="protein-TA" type4="" periodicity1="3" phase1="0.0" k1="1.59130072"/>
-  <Proper type1="" type2="protein-TJ" type3="protein-CT" type4="" periodicity1="3" phase1="0.0" k1="0.9190156"/>
-  <Proper type1="" type2="protein-TP" type3="protein-C8" type4="" periodicity1="3" phase1="0.0" k1="1.3925188800000001"/>
-  <Proper type1="" type2="protein-TM" type3="protein-2C" type4="" periodicity1="3" phase1="0.0" k1="0.49128528"/>
-  <Proper type1="" type2="protein-TA" type3="protein-CC" type4="" periodicity1="2" phase1="0.0" k1="2.3836248"/>
-  <Proper type1="" type2="protein-TA" type3="protein-CA" type4="" periodicity1="2" phase1="0.0" k1="-1.92664832"/>
-  <Proper type1="" type2="protein-TA" type3="protein-C*" type4="" periodicity1="2" phase1="0.0" k1="-2.89838232"/>
-  <Proper type1="" type2="protein-2C" type3="protein-SH" type4="" periodicity1="3" phase1="0.0" k1="2.7598082400000004"/>
-  <Proper type1="" type2="protein-2C" type3="protein-S" type4="" periodicity1="3" phase1="0.0" k1="0.9985116"/>
-  <Proper type1="" type2="protein-2C" type3="protein-CT" type4="" periodicity1="3" phase1="0.0" k1="0.4920384"/>
-  <Proper type1="" type2="protein-2C" type3="protein-2C" type4="" periodicity1="3" phase1="0.0" k1="0.6024541600000001"/>
-  <Proper type1="" type2="protein-2C" type3="protein-N3" type4="" periodicity1="3" phase1="0.0" k1="0.6642100000000001"/>
-  <Proper type1="" type2="protein-3C" type3="protein-CT" type4="" periodicity1="3" phase1="0.0" k1="0.64170008"/>
-  <Proper type1="" type2="protein-3C" type3="protein-2C" type4="" periodicity1="3" phase1="0.0" k1="0.21991104000000003"/>
-  <Proper type1="" type2="protein-CT" type3="protein-CT" type4="" periodicity1="3" phase1="0.0" k1="0.90817904"/>
-  <Proper type1="" type2="protein-CV" type3="protein-NB" type4="" periodicity1="2" phase1="3.141592653589793" k1="-6.4451591200000005"/>
-  <Proper type1="" type2="protein-CW" type3="protein-NA" type4="" periodicity1="2" phase1="3.141592653589793" k1="3.0231492"/>
-  <Proper type1="" type2="protein-CR" type3="protein-NA" type4="" periodicity1="2" phase1="3.141592653589793" k1="15.001188080000002"/>
-  <Proper type1="" type2="protein-CR" type3="protein-NB" type4="" periodicity1="2" phase1="3.141592653589793" k1="0.17874048"/>
-  <Proper type1="" type2="protein-CC" type3="protein-NA" type4="protein-H" periodicity1="2" phase1="3.141592653589793" k1="5.98031672"/>
-  <Proper type1="" type2="protein-CA" type3="protein-CA" type4="" periodicity1="2" phase1="3.141592653589793" k1="15.6184536"/>
-  <Proper type1="" type2="protein-CB" type3="protein-CN" type4="" periodicity1="2" phase1="3.141592653589793" k1="25.15583976"/>
-  <Proper type1="" type2="protein-CN" type3="protein-NA" type4="" periodicity1="2" phase1="3.141592653589793" k1="8.475738"/>
-  <Proper type1="" type2="protein-C*" type3="protein-CB" type4="" periodicity1="2" phase1="3.141592653589793" k1="3.38728272"/>
-  <Proper type1="" type2="protein-C*" type3="protein-CW" type4="" periodicity1="2" phase1="3.141592653589793" k1="39.88448208"/>
-  <Proper type1="" type2="protein-C" type3="protein-CA" type4="" periodicity1="2" phase1="3.141592653589793" k1="17.16552944"/>
-  <Proper type1="" type2="protein-CA" type3="protein-CB" type4="" periodicity1="2" phase1="3.141592653589793" k1="12.05887376"/>
-  <Proper type1="" type2="protein-CA" type3="protein-CN" type4="" periodicity1="2" phase1="3.141592653589793" k1="14.821903680000002"/>
-  <Proper type1="" type2="protein-C8" type3="protein-C8" type4="" periodicity1="3" phase1="0.0" k1="0.7064684"/>
-  <Proper type1="" type2="protein-C8" type3="protein-N2" type4="" periodicity1="3" phase1="0.0" k1="3.5255220800000004"/>
-  <Proper type1="" type2="protein-C8" type3="protein-CC" type4="" periodicity1="2" phase1="0.0" k1="7.994661680000001"/>
-  <Proper type1="" type2="protein-C8" type3="protein-NL" type4="" periodicity1="3" phase1="0.0" k1="-1.22762744"/>
-  <Proper type1="" type2="protein-C" type3="protein-OH" type4="" periodicity1="2" phase1="3.141592653589793" k1="10.12733016"/>
-  <Proper type1="" type2="protein-CT" type3="protein-S" type4="" periodicity1="3" phase1="0.0" k1="1.0649116800000002"/>
-  <Proper type1="protein-C8" type2="protein-CC" type3="protein-NA" type4="protein-CR" periodicity1="2" phase1="3.141592653589793" k1="27.380974639999998"/>
-  <Proper type1="protein-CW" type2="protein-CC" type3="protein-NA" type4="protein-CR" periodicity1="2" phase1="3.141592653589793" k1="27.380974639999998"/>
-  <Proper type1="protein-TA" type2="protein-CC" type3="protein-NA" type4="protein-CR" periodicity1="2" phase1="3.141592653589793" k1="27.380974639999998"/>
-  <Proper type1="protein-CV" type2="protein-CC" type3="protein-NA" type4="protein-CR" periodicity1="2" phase1="3.141592653589793" k1="27.380974639999998"/>
-  <Proper type1="protein-TA" type2="protein-CC" type3="protein-NB" type4="protein-CR" periodicity1="2" phase1="3.141592653589793" k1="35.712197280000005"/>
-  <Proper type1="protein-CW" type2="protein-CC" type3="protein-NB" type4="protein-CR" periodicity1="2" phase1="3.141592653589793" k1="35.712197280000005"/>
-  <Proper type1="protein-NA" type2="protein-CC" type3="protein-CV" type4="protein-H4" periodicity1="2" phase1="3.141592653589793" k1="24.568113280000002"/>
-  <Proper type1="protein-TA" type2="protein-CC" type3="protein-CV" type4="protein-H4" periodicity1="2" phase1="3.141592653589793" k1="24.568113280000002"/>
-  <Proper type1="protein-NB" type2="protein-CC" type3="protein-CW" type4="protein-H4" periodicity1="2" phase1="3.141592653589793" k1="21.67282712"/>
-  <Proper type1="protein-TA" type2="protein-CC" type3="protein-CW" type4="protein-H4" periodicity1="2" phase1="3.141592653589793" k1="21.67282712"/>
-  <Proper type1="protein-NA" type2="protein-CC" type3="protein-CW" type4="protein-H4" periodicity1="2" phase1="3.141592653589793" k1="21.67282712"/>
-  <Proper type1="protein-C8" type2="protein-CC" type3="protein-CW" type4="protein-H4" periodicity1="2" phase1="3.141592653589793" k1="21.67282712"/>
-  <Proper type1="protein-NA" type2="protein-CC" type3="protein-CV" type4="protein-NB" periodicity1="2" phase1="3.141592653589793" k1="37.98097128"/>
-  <Proper type1="protein-TA" type2="protein-CC" type3="protein-CV" type4="protein-NB" periodicity1="2" phase1="3.141592653589793" k1="37.98097128"/>
-  <Proper type1="protein-NB" type2="protein-CC" type3="protein-CW" type4="protein-NA" periodicity1="2" phase1="3.141592653589793" k1="21.91332344"/>
-  <Proper type1="protein-TA" type2="protein-CC" type3="protein-CW" type4="protein-NA" periodicity1="2" phase1="3.141592653589793" k1="21.91332344"/>
-  <Proper type1="protein-NA" type2="protein-CC" type3="protein-CW" type4="protein-NA" periodicity1="2" phase1="3.141592653589793" k1="21.91332344"/>
-  <Proper type1="protein-C8" type2="protein-CC" type3="protein-CW" type4="protein-NA" periodicity1="2" phase1="3.141592653589793" k1="21.91332344"/>
-  <Proper type1="protein-CT" type2="protein-CT" type3="protein-N" type4="protein-C" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="1.6736000000000002" periodicity3="2" phase3="0.0" k3="8.368" periodicity4="1" phase4="0.0" k4="8.368"/>
-  <Proper type1="protein-CT" type2="protein-CT" type3="protein-C" type4="protein-N" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="1.6736000000000002" periodicity3="2" phase3="0.0" k3="0.8368000000000001" periodicity4="1" phase4="0.0" k4="0.8368000000000001"/>
-  <Proper type1="protein-H" type2="protein-N" type3="protein-C" type4="protein-O" periodicity1="2" phase1="3.141592653589793" k1="10.46" periodicity2="1" phase2="0.0" k2="8.368"/>
-  <Proper type1="protein-CT" type2="protein-S" type3="protein-S" type4="protein-CT" periodicity1="2" phase1="0.0" k1="14.644" periodicity2="3" phase2="0.0" k2="2.5104"/>
-  <Proper type1="protein-H1" type2="protein-CT" type3="protein-C" type4="protein-O" periodicity1="1" phase1="0.0" k1="3.3472000000000004" periodicity2="2" phase2="0.0" k2="0.0" periodicity3="3" phase3="3.141592653589793" k3="0.33472"/>
-  <Proper type1="protein-HC" type2="protein-CT" type3="protein-C" type4="protein-O" periodicity1="1" phase1="0.0" k1="3.3472000000000004" periodicity2="2" phase2="0.0" k2="0.0" periodicity3="3" phase3="3.141592653589793" k3="0.33472"/>
-  <Proper type1="protein-HO" type2="protein-OH" type3="protein-CT" type4="protein-CT" periodicity1="3" phase1="0.0" k1="0.66944" periodicity2="1" phase2="0.0" k2="1.046"/>
-  <Proper type1="protein-CT" type2="protein-CT" type3="protein-CT" type4="protein-CT" periodicity1="3" phase1="0.0" k1="0.75312" periodicity2="2" phase2="3.141592653589793" k2="1.046" periodicity3="1" phase3="3.141592653589793" k3="0.8368000000000001"/>
-  <Proper type1="protein-OH" type2="protein-CT" type3="protein-CT" type4="protein-OH" periodicity1="3" phase1="0.0" k1="0.602496" periodicity2="2" phase2="0.0" k2="4.916200000000001"/>
-  <Proper type1="protein-H1" type2="protein-CT" type3="protein-CT" type4="protein-OH" periodicity1="3" phase1="0.0" k1="0.0" periodicity2="1" phase2="0.0" k2="1.046"/>
-  <Proper type1="protein-HC" type2="protein-CT" type3="protein-CT" type4="protein-OH" periodicity1="3" phase1="0.0" k1="0.0" periodicity2="1" phase2="0.0" k2="1.046"/>
-  <Proper type1="protein-N" type2="protein-CT" type3="protein-CT" type4="protein-OH" periodicity1="1" phase1="0.0" k1="0.0" periodicity2="2" phase2="0.0" k2="6.23416" periodicity3="3" phase3="0.0" k3="0.6527040000000001" periodicity4="4" phase4="0.0" k4="0.0"/>
-  <Proper type1="protein-C" type2="protein-N" type3="protein-CX" type4="protein-C" periodicity1="4" phase1="0.0" k1="-0.37057688" periodicity2="3" phase2="0.0" k2="0.19145984000000002" periodicity3="2" phase3="0.0" k3="1.2314767199999999" periodicity4="1" phase4="0.0" k4="-0.59927432"/>
-  <Proper type1="protein-C" type2="protein-TN" type3="protein-TJ" type4="protein-C" periodicity1="4" phase1="0.0" k1="-0.13171232000000002" periodicity2="3" phase2="0.0" k2="-2.28002896" periodicity3="2" phase3="0.0" k3="3.8781077600000002" periodicity4="1" phase4="0.0" k4="4.47846992"/>
-  <Proper type1="protein-C" type2="protein-N" type3="protein-TG" type4="protein-C" periodicity1="4" phase1="0.0" k1="0.41396496" periodicity2="3" phase2="0.0" k2="1.18206368" periodicity3="2" phase3="0.0" k3="2.2214948000000003" periodicity4="1" phase4="0.0" k4="0.64073776"/>
-  <Proper type1="protein-C" type2="protein-N" type3="protein-TP" type4="protein-C" periodicity1="4" phase1="0.0" k1="-0.00966504" periodicity2="3" phase2="0.0" k2="1.0844509599999999" periodicity3="2" phase3="0.0" k3="2.61776144" periodicity4="1" phase4="0.0" k4="1.50598896"/>
-  <Proper type1="protein-C" type2="protein-N" type3="protein-TM" type4="protein-C" periodicity1="4" phase1="0.0" k1="-0.995792" periodicity2="3" phase2="0.0" k2="0.05945464" periodicity3="2" phase3="0.0" k3="1.92518392" periodicity4="1" phase4="0.0" k4="-1.7311718400000002"/>
-  <Proper type1="protein-C" type2="protein-N" type3="protein-CX" type4="protein-CO" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="0.32275376" periodicity3="2" phase3="0.0" k3="0.51676584" periodicity4="1" phase4="0.0" k4="7.28062024"/>
-  <Proper type1="protein-C" type2="protein-TN" type3="protein-TJ" type4="protein-CO" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-6.112238240000001" periodicity3="2" phase3="0.0" k3="9.846039840000001" periodicity4="1" phase4="0.0" k4="5.60973984"/>
-  <Proper type1="protein-C" type2="protein-N" type3="protein-TG" type4="protein-CO" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="1.42866864" periodicity3="2" phase3="0.0" k3="1.4559064800000001" periodicity4="1" phase4="0.0" k4="9.99415344"/>
-  <Proper type1="protein-C" type2="protein-N" type3="protein-TP" type4="protein-CO" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="1.06394936" periodicity3="2" phase3="0.0" k3="3.4614232000000005" periodicity4="1" phase4="0.0" k4="3.35678136"/>
-  <Proper type1="protein-C" type2="protein-N" type3="protein-TM" type4="protein-CO" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="0.67755696" periodicity3="2" phase3="0.0" k3="-0.72312072" periodicity4="1" phase4="0.0" k4="8.75861824"/>
-  <Proper type1="protein-N" type2="protein-CX" type3="protein-C" type4="protein-N" periodicity1="4" phase1="0.0" k1="-0.45203936" periodicity2="3" phase2="0.0" k2="0.06271816" periodicity3="2" phase3="0.0" k3="-5.21736432" periodicity4="1" phase4="0.0" k4="2.15262616"/>
-  <Proper type1="protein-TN" type2="protein-TJ" type3="protein-C" type4="protein-N" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-0.52438072" periodicity3="2" phase3="0.0" k3="-5.17744896" periodicity4="1" phase4="0.0" k4="1.18085032"/>
-  <Proper type1="protein-N" type2="protein-TG" type3="protein-C" type4="protein-N" periodicity1="4" phase1="0.0" k1="-0.09070912" periodicity2="3" phase2="0.0" k2="0.5106572" periodicity3="2" phase3="0.0" k3="-2.7722347199999997" periodicity4="1" phase4="0.0" k4="2.2961792"/>
-  <Proper type1="protein-N" type2="protein-TP" type3="protein-C" type4="protein-N" periodicity1="4" phase1="0.0" k1="0.34057760000000004" periodicity2="3" phase2="0.0" k2="0.010794719999999999" periodicity3="2" phase3="0.0" k3="-7.35999072" periodicity4="1" phase4="0.0" k4="0.61676344"/>
-  <Proper type1="protein-N" type2="protein-TM" type3="protein-C" type4="protein-N" periodicity1="4" phase1="0.0" k1="-0.047864960000000005" periodicity2="3" phase2="0.0" k2="0.03502008" periodicity3="2" phase3="0.0" k3="-4.326130480000001" periodicity4="1" phase4="0.0" k4="3.83266952"/>
-  <Proper type1="protein-N" type2="protein-CX" type3="protein-C" type4="protein-TN" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-0.6071820800000001" periodicity3="2" phase3="0.0" k3="-5.35146152" periodicity4="1" phase4="0.0" k4="0.22819536"/>
-  <Proper type1="protein-TN" type2="protein-TJ" type3="protein-C" type4="protein-TN" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-1.74882832" periodicity3="2" phase3="0.0" k3="-5.506311360000001" periodicity4="1" phase4="0.0" k4="-1.0774636800000001"/>
-  <Proper type1="protein-N" type2="protein-TG" type3="protein-C" type4="protein-TN" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-2.4631208" periodicity3="2" phase3="0.0" k3="-1.6344796000000001" periodicity4="1" phase4="0.0" k4="12.87588344"/>
-  <Proper type1="protein-N" type2="protein-TP" type3="protein-C" type4="protein-TN" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="1.4470364" periodicity3="2" phase3="0.0" k3="-6.962678080000001" periodicity4="1" phase4="0.0" k4="2.14739616"/>
-  <Proper type1="protein-N" type2="protein-TM" type3="protein-C" type4="protein-TN" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-2.87804808" periodicity3="2" phase3="0.0" k3="-4.8006797599999995" periodicity4="1" phase4="0.0" k4="2.13484416"/>
-  <Proper type1="protein-NL" type2="protein-CX" type3="protein-C" type4="protein-N" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-0.7812783200000001" periodicity3="2" phase3="0.0" k3="-4.07973472" periodicity4="1" phase4="0.0" k4="8.747614320000002"/>
-  <Proper type1="protein-NL" type2="protein-TJ" type3="protein-C" type4="protein-N" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="2.18157944" periodicity3="2" phase3="0.0" k3="-9.41923" periodicity4="1" phase4="0.0" k4="11.29914304"/>
-  <Proper type1="protein-NL" type2="protein-TG" type3="protein-C" type4="protein-N" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="8.40456816" periodicity3="2" phase3="0.0" k3="10.370755280000001" periodicity4="1" phase4="0.0" k4="19.319578160000002"/>
-  <Proper type1="protein-NL" type2="protein-TP" type3="protein-C" type4="protein-N" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="0.33405056" periodicity3="2" phase3="0.0" k3="-3.54924536" periodicity4="1" phase4="0.0" k4="9.665918640000001"/>
-  <Proper type1="protein-NL" type2="protein-TM" type3="protein-C" type4="protein-N" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-3.53029184" periodicity3="2" phase3="0.0" k3="-8.0920652" periodicity4="1" phase4="0.0" k4="1.7922582400000002"/>
-  <Proper type1="protein-NL" type2="protein-CX" type3="protein-C" type4="protein-TN" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="0.56036312" periodicity3="2" phase3="0.0" k3="-7.974536640000001" periodicity4="1" phase4="0.0" k4="3.36891496"/>
-  <Proper type1="protein-NL" type2="protein-TJ" type3="protein-C" type4="protein-TN" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-0.0437228" periodicity3="2" phase3="0.0" k3="-8.507954800000002" periodicity4="1" phase4="0.0" k4="5.57421768"/>
-  <Proper type1="protein-NL" type2="protein-TG" type3="protein-C" type4="protein-TN" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="5.92759832" periodicity3="2" phase3="0.0" k3="8.519167920000001" periodicity4="1" phase4="0.0" k4="8.02298736"/>
-  <Proper type1="protein-NL" type2="protein-TP" type3="protein-C" type4="protein-TN" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="1.25361008" periodicity3="2" phase3="0.0" k3="-9.765790720000002" periodicity4="1" phase4="0.0" k4="6.315329600000001"/>
-  <Proper type1="protein-NL" type2="protein-TM" type3="protein-C" type4="protein-TN" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-2.60123464" periodicity3="2" phase3="0.0" k3="-4.50466176" periodicity4="1" phase4="0.0" k4="4.055174640000001"/>
-  <Proper type1="protein-N" type2="protein-CX" type3="protein-C" type4="protein-ND" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="0.16317600000000002" periodicity3="2" phase3="0.0" k3="-4.89335536" periodicity4="1" phase4="0.0" k4="3.37217848"/>
-  <Proper type1="protein-TN" type2="protein-TJ" type3="protein-C" type4="protein-ND" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="0.38915384" periodicity3="2" phase3="0.0" k3="-4.33487504" periodicity4="1" phase4="0.0" k4="2.03689672"/>
-  <Proper type1="protein-N" type2="protein-TG" type3="protein-C" type4="protein-ND" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-1.5671172" periodicity3="2" phase3="0.0" k3="-5.5787364" periodicity4="1" phase4="0.0" k4="6.730382400000001"/>
-  <Proper type1="protein-N" type2="protein-TP" type3="protein-C" type4="protein-ND" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="1.4609691200000001" periodicity3="2" phase3="0.0" k3="-6.19662952" periodicity4="1" phase4="0.0" k4="0.5118705600000001"/>
-  <Proper type1="protein-N" type2="protein-TM" type3="protein-C" type4="protein-ND" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-1.73686208" periodicity3="2" phase3="0.0" k3="-3.08733176" periodicity4="1" phase4="0.0" k4="3.83706272"/>
-  <Proper type1="protein-NL" type2="protein-CX" type3="protein-C" type4="protein-ND" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="0.0" periodicity3="2" phase3="0.0" k3="0.0" periodicity4="1" phase4="0.0" k4="0.0"/>
-  <Proper type1="protein-NL" type2="protein-TJ" type3="protein-C" type4="protein-ND" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="0.0" periodicity3="2" phase3="0.0" k3="0.0" periodicity4="1" phase4="0.0" k4="0.0"/>
-  <Proper type1="protein-NL" type2="protein-TG" type3="protein-C" type4="protein-ND" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="0.0" periodicity3="2" phase3="0.0" k3="0.0" periodicity4="1" phase4="0.0" k4="0.0"/>
-  <Proper type1="protein-NL" type2="protein-TP" type3="protein-C" type4="protein-ND" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="0.0" periodicity3="2" phase3="0.0" k3="0.0" periodicity4="1" phase4="0.0" k4="0.0"/>
-  <Proper type1="protein-NL" type2="protein-TM" type3="protein-C" type4="protein-ND" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="0.0" periodicity3="2" phase3="0.0" k3="0.0" periodicity4="1" phase4="0.0" k4="0.0"/>
-  <Proper type1="protein-CT" type2="protein-CX" type3="protein-N" type4="protein-C" periodicity1="4" phase1="0.0" k1="-0.92587736" periodicity2="3" phase2="0.0" k2="0.67496288" periodicity3="2" phase3="0.0" k3="0.097278" periodicity4="1" phase4="0.0" k4="-3.0577508800000004"/>
-  <Proper type1="protein-2C" type2="protein-CX" type3="protein-N" type4="protein-C" periodicity1="4" phase1="0.0" k1="-0.24995216" periodicity2="3" phase2="0.0" k2="0.0546012" periodicity3="2" phase3="0.0" k3="1.0593888" periodicity4="1" phase4="0.0" k4="-3.18209936"/>
-  <Proper type1="protein-3C" type2="protein-CX" type3="protein-N" type4="protein-C" periodicity1="4" phase1="0.0" k1="-0.9161286399999999" periodicity2="3" phase2="0.0" k2="-1.02796696" periodicity3="2" phase3="0.0" k3="0.70073632" periodicity4="1" phase4="0.0" k4="-3.63388768"/>
-  <Proper type1="protein-TA" type2="protein-CX" type3="protein-N" type4="protein-C" periodicity1="4" phase1="0.0" k1="-0.33530576" periodicity2="3" phase2="0.0" k2="0.38584848" periodicity3="2" phase3="0.0" k3="1.2341544800000002" periodicity4="1" phase4="0.0" k4="-2.39822696"/>
-  <Proper type1="protein-CT" type2="protein-TJ" type3="protein-TN" type4="protein-C" periodicity1="4" phase1="0.0" k1="1.67180088" periodicity2="3" phase2="0.0" k2="7.78387176" periodicity3="2" phase3="0.0" k3="8.7071132" periodicity4="1" phase4="0.0" k4="-12.82508968"/>
-  <Proper type1="protein-C8" type2="protein-TP" type3="protein-N" type4="protein-C" periodicity1="4" phase1="0.0" k1="0.49078320000000003" periodicity2="3" phase2="0.0" k2="-1.2652834400000001" periodicity3="2" phase3="0.0" k3="2.7544945600000004" periodicity4="1" phase4="0.0" k4="-3.41251224"/>
-  <Proper type1="protein-2C" type2="protein-TM" type3="protein-N" type4="protein-C" periodicity1="4" phase1="0.0" k1="-0.73546352" periodicity2="3" phase2="0.0" k2="-0.049371200000000004" periodicity3="2" phase3="0.0" k3="1.8225504000000001" periodicity4="1" phase4="0.0" k4="2.32136688"/>
-  <Proper type1="protein-CT" type2="protein-CX" type3="protein-C" type4="protein-N" periodicity1="4" phase1="0.0" k1="-1.14022368" periodicity2="3" phase2="0.0" k2="-1.15131128" periodicity3="2" phase3="0.0" k3="-1.75690344" periodicity4="1" phase4="0.0" k4="3.8614554400000003"/>
-  <Proper type1="protein-2C" type2="protein-CX" type3="protein-C" type4="protein-N" periodicity1="4" phase1="0.0" k1="-0.426768" periodicity2="3" phase2="0.0" k2="-1.32021936" periodicity3="2" phase3="0.0" k3="-2.0019603200000002" periodicity4="1" phase4="0.0" k4="2.81156432"/>
-  <Proper type1="protein-3C" type2="protein-CX" type3="protein-C" type4="protein-N" periodicity1="4" phase1="0.0" k1="-0.8856691200000001" periodicity2="3" phase2="0.0" k2="-1.1606416" periodicity3="2" phase3="0.0" k3="-1.6464458400000002" periodicity4="1" phase4="0.0" k4="2.91369576"/>
-  <Proper type1="protein-TA" type2="protein-CX" type3="protein-C" type4="protein-N" periodicity1="4" phase1="0.0" k1="-0.92692336" periodicity2="3" phase2="0.0" k2="-1.43703664" periodicity3="2" phase3="0.0" k3="-1.62305728" periodicity4="1" phase4="0.0" k4="2.5951678400000002"/>
-  <Proper type1="protein-CT" type2="protein-TJ" type3="protein-C" type4="protein-N" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-1.22900816" periodicity3="2" phase3="0.0" k3="-2.75842752" periodicity4="1" phase4="0.0" k4="4.715660880000001"/>
-  <Proper type1="protein-C8" type2="protein-TP" type3="protein-C" type4="protein-N" periodicity1="4" phase1="0.0" k1="-0.3661" periodicity2="3" phase2="0.0" k2="-1.56159432" periodicity3="2" phase3="0.0" k3="-1.8694112" periodicity4="1" phase4="0.0" k4="5.50836152"/>
-  <Proper type1="protein-2C" type2="protein-TM" type3="protein-C" type4="protein-N" periodicity1="4" phase1="0.0" k1="-0.7337899200000001" periodicity2="3" phase2="0.0" k2="-0.31208456" periodicity3="2" phase3="0.0" k3="1.3924352" periodicity4="1" phase4="0.0" k4="-1.2380456"/>
-  <Proper type1="protein-CT" type2="protein-CX" type3="protein-C" type4="protein-TN" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-0.58881432" periodicity3="2" phase3="0.0" k3="-1.47536208" periodicity4="1" phase4="0.0" k4="1.87978752"/>
-  <Proper type1="protein-2C" type2="protein-CX" type3="protein-C" type4="protein-TN" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-1.35720592" periodicity3="2" phase3="0.0" k3="-3.79873728" periodicity4="1" phase4="0.0" k4="1.06327992"/>
-  <Proper type1="protein-3C" type2="protein-CX" type3="protein-C" type4="protein-TN" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-0.20254744000000002" periodicity3="2" phase3="0.0" k3="-3.2608422400000006" periodicity4="1" phase4="0.0" k4="1.8812100800000002"/>
-  <Proper type1="protein-TA" type2="protein-CX" type3="protein-C" type4="protein-TN" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-1.6717172000000002" periodicity3="2" phase3="0.0" k3="-3.0462030400000004" periodicity4="1" phase4="0.0" k4="0.00807512"/>
-  <Proper type1="protein-CT" type2="protein-TJ" type3="protein-C" type4="protein-TN" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="0.54944288" periodicity3="2" phase3="0.0" k3="-2.39320616" periodicity4="1" phase4="0.0" k4="1.13486816"/>
-  <Proper type1="protein-C8" type2="protein-TP" type3="protein-C" type4="protein-TN" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-2.45174032" periodicity3="2" phase3="0.0" k3="-2.0632140800000003" periodicity4="1" phase4="0.0" k4="3.9029607200000003"/>
-  <Proper type1="protein-2C" type2="protein-TM" type3="protein-C" type4="protein-TN" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-0.16133503999999999" periodicity3="2" phase3="0.0" k3="1.1756621600000001" periodicity4="1" phase4="0.0" k4="1.5270763200000002"/>
-  <Proper type1="protein-CT" type2="protein-CX" type3="protein-C" type4="protein-ND" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-0.43400632" periodicity3="2" phase3="0.0" k3="-1.19624744" periodicity4="1" phase4="0.0" k4="4.4683028"/>
-  <Proper type1="protein-2C" type2="protein-CX" type3="protein-C" type4="protein-ND" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-0.1165244" periodicity3="2" phase3="0.0" k3="-1.5596278399999999" periodicity4="1" phase4="0.0" k4="4.07220352"/>
-  <Proper type1="protein-3C" type2="protein-CX" type3="protein-C" type4="protein-ND" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-0.25246256" periodicity3="2" phase3="0.0" k3="-0.97629456" periodicity4="1" phase4="0.0" k4="3.71124984"/>
-  <Proper type1="protein-TA" type2="protein-CX" type3="protein-C" type4="protein-ND" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-0.36480296" periodicity3="2" phase3="0.0" k3="-1.02223488" periodicity4="1" phase4="0.0" k4="3.9743397600000003"/>
-  <Proper type1="protein-CT" type2="protein-TJ" type3="protein-C" type4="protein-ND" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-1.17302624" periodicity3="2" phase3="0.0" k3="-2.6429491200000004" periodicity4="1" phase4="0.0" k4="4.2722824"/>
-  <Proper type1="protein-C8" type2="protein-TP" type3="protein-C" type4="protein-ND" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-1.0599745600000001" periodicity3="2" phase3="0.0" k3="-1.3108472000000002" periodicity4="1" phase4="0.0" k4="5.70848224"/>
-  <Proper type1="protein-2C" type2="protein-TM" type3="protein-C" type4="protein-ND" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="2.01974232" periodicity3="2" phase3="0.0" k3="2.0302860000000003" periodicity4="1" phase4="0.0" k4="-0.62868784"/>
-  <Proper type1="protein-H1" type2="protein-TG" type3="protein-N" type4="protein-C" periodicity1="3" phase1="0.0" k1="-0.33191672" periodicity2="2" phase2="0.0" k2="0.83885016" periodicity3="1" phase3="0.0" k3="1.5549417600000002"/>
-  <Proper type1="protein-H1" type2="protein-TG" type3="protein-C" type4="protein-N" periodicity1="3" phase1="0.0" k1="-0.5091928" periodicity2="2" phase2="0.0" k2="3.21536216" periodicity3="1" phase3="0.0" k3="3.8989859200000003"/>
-  <Proper type1="protein-H1" type2="protein-TG" type3="protein-C" type4="protein-TN" periodicity1="3" phase1="0.0" k1="0.4865992" periodicity2="2" phase2="0.0" k2="5.41861472" periodicity3="1" phase3="0.0" k3="14.28087064"/>
-  <Proper type1="protein-H1" type2="protein-TG" type3="protein-C" type4="protein-ND" periodicity1="3" phase1="0.0" k1="0.7083512000000001" periodicity2="2" phase2="0.0" k2="0.07376392" periodicity3="1" phase3="0.0" k3="6.58653648"/>
-  <Proper type1="protein-HP" type2="protein-TG" type3="protein-C" type4="protein-N" periodicity1="3" phase1="0.0" k1="-4.87536416" periodicity2="2" phase2="0.0" k2="24.92730968" periodicity3="1" phase3="0.0" k3="12.8348384"/>
-  <Proper type1="protein-HP" type2="protein-TG" type3="protein-C" type4="protein-TN" periodicity1="3" phase1="0.0" k1="-3.18335456" periodicity2="2" phase2="0.0" k2="20.615614" periodicity3="1" phase3="0.0" k3="7.74985584"/>
-  <Proper type1="protein-HP" type2="protein-TG" type3="protein-C" type4="protein-ND" periodicity1="3" phase1="0.0" k1="0.0" periodicity2="2" phase2="0.0" k2="0.0" periodicity3="1" phase3="0.0" k3="0.0"/>
-  <Proper type1="protein-N" type2="protein-CX" type3="protein-2C" type4="protein-C" periodicity1="4" phase1="0.0" k1="0.86642272" periodicity2="3" phase2="0.0" k2="1.828408" periodicity3="2" phase3="0.0" k3="0.84449856" periodicity4="1" phase4="0.0" k4="-3.7907040000000003"/>
-  <Proper type1="protein-N" type2="protein-CX" type3="protein-2C" type4="protein-SH" periodicity1="4" phase1="0.0" k1="0.31304688" periodicity2="3" phase2="0.0" k2="3.813716" periodicity3="2" phase3="0.0" k3="-0.83144448" periodicity4="1" phase4="0.0" k4="-1.7070301600000002"/>
-  <Proper type1="protein-N" type2="protein-CX" type3="protein-2C" type4="protein-S" periodicity1="4" phase1="0.0" k1="-0.47789648" periodicity2="3" phase2="0.0" k2="1.31273" periodicity3="2" phase3="0.0" k3="-0.47576264" periodicity4="1" phase4="0.0" k4="-0.45316904"/>
-  <Proper type1="protein-N" type2="protein-CX" type3="protein-2C" type4="protein-2C" periodicity1="4" phase1="0.0" k1="0.81349512" periodicity2="3" phase2="0.0" k2="0.58161784" periodicity3="2" phase3="0.0" k3="0.06204872" periodicity4="1" phase4="0.0" k4="0.20137592"/>
-  <Proper type1="protein-N" type2="protein-CX" type3="protein-2C" type4="protein-3C" periodicity1="4" phase1="0.0" k1="-0.57232936" periodicity2="3" phase2="0.0" k2="1.33256216" periodicity3="2" phase3="0.0" k3="0.02234256" periodicity4="1" phase4="0.0" k4="-0.9347892800000001"/>
-  <Proper type1="protein-N" type2="protein-CX" type3="protein-2C" type4="protein-OA" periodicity1="4" phase1="0.0" k1="0.20631304" periodicity2="3" phase2="0.0" k2="3.51953896" periodicity3="2" phase3="0.0" k3="0.3518744" periodicity4="1" phase4="0.0" k4="1.14398928"/>
-  <Proper type1="protein-N" type2="protein-CX" type3="protein-3C" type4="protein-CT" periodicity1="4" phase1="0.0" k1="-0.5412840800000001" periodicity2="3" phase2="0.0" k2="1.5884556" periodicity3="2" phase3="0.0" k3="-0.05811576" periodicity4="1" phase4="0.0" k4="-0.47429824000000004"/>
-  <Proper type1="protein-N" type2="protein-CX" type3="protein-3C" type4="protein-2C" periodicity1="4" phase1="0.0" k1="-0.38781496" periodicity2="3" phase2="0.0" k2="2.7953304" periodicity3="2" phase3="0.0" k3="-0.5525390400000001" periodicity4="1" phase4="0.0" k4="-0.46153704000000007"/>
-  <Proper type1="protein-N" type2="protein-CX" type3="protein-3C" type4="protein-OA" periodicity1="4" phase1="0.0" k1="-1.5324318399999999" periodicity2="3" phase2="0.0" k2="1.5116792000000001" periodicity3="2" phase3="0.0" k3="1.1116888" periodicity4="1" phase4="0.0" k4="-10.287117120000001"/>
-  <Proper type1="protein-N" type2="protein-CX" type3="protein-TA" type4="protein-CC" periodicity1="4" phase1="0.0" k1="0.41492728" periodicity2="3" phase2="0.0" k2="-1.28708208" periodicity3="2" phase3="0.0" k3="0.81613104" periodicity4="1" phase4="0.0" k4="-2.3996913600000003"/>
-  <Proper type1="protein-N" type2="protein-CX" type3="protein-TA" type4="protein-CA" periodicity1="4" phase1="0.0" k1="-0.92391088" periodicity2="3" phase2="0.0" k2="0.54417104" periodicity3="2" phase3="0.0" k3="0.07430784000000001" periodicity4="1" phase4="0.0" k4="-2.59462392"/>
-  <Proper type1="protein-N" type2="protein-CX" type3="protein-TA" type4="protein-C*" periodicity1="4" phase1="0.0" k1="-1.47260064" periodicity2="3" phase2="0.0" k2="-0.05255104" periodicity3="2" phase3="0.0" k3="0.29660376" periodicity4="1" phase4="0.0" k4="-1.9278616800000001"/>
-  <Proper type1="protein-TN" type2="protein-TJ" type3="protein-CT" type4="protein-CT" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="0.0" periodicity3="2" phase3="0.0" k3="-2.4313224" periodicity4="1" phase4="0.0" k4="-1.13520288"/>
-  <Proper type1="protein-N" type2="protein-TP" type3="protein-C8" type4="protein-C8" periodicity1="4" phase1="0.0" k1="1.34344056" periodicity2="3" phase2="0.0" k2="-1.10336264" periodicity3="2" phase3="0.0" k3="-0.20397" periodicity4="1" phase4="0.0" k4="-1.6354000800000001"/>
-  <Proper type1="protein-N" type2="protein-TP" type3="protein-C8" type4="protein-CC" periodicity1="4" phase1="0.0" k1="1.1738630399999999" periodicity2="3" phase2="0.0" k2="-3.25527752" periodicity3="2" phase3="0.0" k3="2.68704848" periodicity4="1" phase4="0.0" k4="-0.77295216"/>
-  <Proper type1="protein-N" type2="protein-TM" type3="protein-2C" type4="protein-2C" periodicity1="4" phase1="0.0" k1="-1.1334456" periodicity2="3" phase2="0.0" k2="1.09436704" periodicity3="2" phase3="0.0" k3="0.53571936" periodicity4="1" phase4="0.0" k4="-7.69169824"/>
-  <Proper type1="protein-N" type2="protein-TM" type3="protein-2C" type4="protein-CO" periodicity1="4" phase1="0.0" k1="-0.53915024" periodicity2="3" phase2="0.0" k2="2.70637856" periodicity3="2" phase3="0.0" k3="-1.86464144" periodicity4="1" phase4="0.0" k4="-16.7615224"/>
-  <Proper type1="protein-N" type2="protein-TM" type3="protein-2C" type4="protein-SH" periodicity1="4" phase1="0.0" k1="0.34651888000000003" periodicity2="3" phase2="0.0" k2="6.22545728" periodicity3="2" phase3="0.0" k3="-4.13789232" periodicity4="1" phase4="0.0" k4="-7.04476816"/>
-  <Proper type1="protein-NL" type2="protein-CX" type3="protein-2C" type4="protein-C" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-2.8275890400000003" periodicity3="2" phase3="0.0" k3="-8.432810159999999" periodicity4="1" phase4="0.0" k4="-24.24552688"/>
-  <Proper type1="protein-NL" type2="protein-CX" type3="protein-2C" type4="protein-SH" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="3.2333115200000004" periodicity3="2" phase3="0.0" k3="-2.84206568" periodicity4="1" phase4="0.0" k4="-5.774714960000001"/>
-  <Proper type1="protein-NL" type2="protein-CX" type3="protein-2C" type4="protein-S" periodicity1="2" phase1="0.0" k1="0.07832448" periodicity2="1" phase2="0.0" k2="-8.73087832"/>
-  <Proper type1="protein-NL" type2="protein-CX" type3="protein-2C" type4="protein-2C" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-6.367504080000001" periodicity3="2" phase3="0.0" k3="-2.65629608" periodicity4="1" phase4="0.0" k4="-5.1748967200000004"/>
-  <Proper type1="protein-NL" type2="protein-CX" type3="protein-2C" type4="protein-3C" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-0.00840984" periodicity3="2" phase3="0.0" k3="-0.87746848" periodicity4="1" phase4="0.0" k4="-2.6933663200000004"/>
-  <Proper type1="protein-NL" type2="protein-CX" type3="protein-2C" type4="protein-OA" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-3.62819744" periodicity3="2" phase3="0.0" k3="-1.56201272" periodicity4="1" phase4="0.0" k4="-5.14602712"/>
-  <Proper type1="protein-NL" type2="protein-CX" type3="protein-3C" type4="protein-CT" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="1.83439112" periodicity3="2" phase3="0.0" k3="-0.221752" periodicity4="1" phase4="0.0" k4="1.2171256"/>
-  <Proper type1="protein-NL" type2="protein-CX" type3="protein-3C" type4="protein-2C" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="2.9944469600000003" periodicity3="2" phase3="0.0" k3="0.050249840000000004" periodicity4="1" phase4="0.0" k4="0.518816"/>
-  <Proper type1="protein-NL" type2="protein-CX" type3="protein-3C" type4="protein-OA" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-1.27185232" periodicity3="2" phase3="0.0" k3="1.5381220800000002" periodicity4="1" phase4="0.0" k4="-14.315388640000002"/>
-  <Proper type1="protein-NL" type2="protein-TA" type3="protein-CT" type4="protein-CC" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="3.8863920800000002" periodicity3="2" phase3="0.0" k3="2.1648434400000003" periodicity4="1" phase4="0.0" k4="-5.14389328"/>
-  <Proper type1="protein-NL" type2="protein-TA" type3="protein-CT" type4="protein-CA" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="2.77679528" periodicity3="2" phase3="0.0" k3="-1.27796096" periodicity4="1" phase4="0.0" k4="-6.876404"/>
-  <Proper type1="protein-NL" type2="protein-TA" type3="protein-CT" type4="protein-C*" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="2.8779643999999998" periodicity3="2" phase3="0.0" k3="-3.17707856" periodicity4="1" phase4="0.0" k4="-6.18010272"/>
-  <Proper type1="protein-NL" type2="protein-TJ" type3="protein-CT" type4="protein-CT" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="0.0" periodicity3="2" phase3="0.0" k3="-1.9125900800000002" periodicity4="1" phase4="0.0" k4="-5.67952896"/>
-  <Proper type1="protein-NL" type2="protein-TP" type3="protein-C8" type4="protein-C8" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-3.0373748000000003" periodicity3="2" phase3="0.0" k3="-1.41540536" periodicity4="1" phase4="0.0" k4="1.61975192"/>
-  <Proper type1="protein-NL" type2="protein-TP" type3="protein-C8" type4="protein-CC" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-5.2285774400000005" periodicity3="2" phase3="0.0" k3="0.26083056" periodicity4="1" phase4="0.0" k4="-0.10234064"/>
-  <Proper type1="protein-NL" type2="protein-TM" type3="protein-2C" type4="protein-2C" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-0.23924112000000003" periodicity3="2" phase3="0.0" k3="1.26038816" periodicity4="1" phase4="0.0" k4="-18.445373200000002"/>
-  <Proper type1="protein-NL" type2="protein-TM" type3="protein-2C" type4="protein-CO" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="8.75907848" periodicity3="2" phase3="0.0" k3="2.0275245600000003" periodicity4="1" phase4="0.0" k4="-28.284634959999998"/>
-  <Proper type1="protein-NL" type2="protein-TM" type3="protein-2C" type4="protein-SH" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="10.50025008" periodicity3="2" phase3="0.0" k3="-7.69989888" periodicity4="1" phase4="0.0" k4="-25.30349312"/>
-  <Proper type1="protein-C" type2="protein-CX" type3="protein-2C" type4="protein-C" periodicity1="4" phase1="0.0" k1="-0.27831968" periodicity2="3" phase2="0.0" k2="-2.7390556" periodicity3="2" phase3="0.0" k3="0.75106984" periodicity4="1" phase4="0.0" k4="1.54858208"/>
-  <Proper type1="protein-C" type2="protein-CX" type3="protein-2C" type4="protein-SH" periodicity1="4" phase1="0.0" k1="-0.21698224000000002" periodicity2="3" phase2="0.0" k2="-2.93478312" periodicity3="2" phase3="0.0" k3="-1.12708592" periodicity4="1" phase4="0.0" k4="-4.494703840000001"/>
-  <Proper type1="protein-C" type2="protein-CX" type3="protein-2C" type4="protein-S" periodicity1="4" phase1="0.0" k1="-0.72512904" periodicity2="3" phase2="0.0" k2="0.22694016" periodicity3="2" phase3="0.0" k3="-0.5148830400000001" periodicity4="1" phase4="0.0" k4="-1.2564970400000002"/>
-  <Proper type1="protein-C" type2="protein-CX" type3="protein-2C" type4="protein-2C" periodicity1="4" phase1="0.0" k1="1.06453512" periodicity2="3" phase2="0.0" k2="-0.8232020000000001" periodicity3="2" phase3="0.0" k3="-0.63421072" periodicity4="1" phase4="0.0" k4="-1.34143224"/>
-  <Proper type1="protein-C" type2="protein-CX" type3="protein-2C" type4="protein-3C" periodicity1="4" phase1="0.0" k1="-0.79010656" periodicity2="3" phase2="0.0" k2="-2.72060416" periodicity3="2" phase3="0.0" k3="-1.30323232" periodicity4="1" phase4="0.0" k4="-1.96823728"/>
-  <Proper type1="protein-C" type2="protein-CX" type3="protein-2C" type4="protein-OA" periodicity1="4" phase1="0.0" k1="-0.28903072" periodicity2="3" phase2="0.0" k2="-0.35852696" periodicity3="2" phase3="0.0" k3="0.47538608" periodicity4="1" phase4="0.0" k4="-2.71022784"/>
-  <Proper type1="protein-C" type2="protein-CX" type3="protein-3C" type4="protein-CT" periodicity1="4" phase1="0.0" k1="-0.6907365599999999" periodicity2="3" phase2="0.0" k2="2.3824532800000005" periodicity3="2" phase3="0.0" k3="-1.24499104" periodicity4="1" phase4="0.0" k4="-1.79100304"/>
-  <Proper type1="protein-C" type2="protein-CX" type3="protein-3C" type4="protein-2C" periodicity1="4" phase1="0.0" k1="-0.06363864" periodicity2="3" phase2="0.0" k2="0.27773391999999997" periodicity3="2" phase3="0.0" k3="-2.3540020800000003" periodicity4="1" phase4="0.0" k4="0.01426744"/>
-  <Proper type1="protein-C" type2="protein-CX" type3="protein-3C" type4="protein-OA" periodicity1="4" phase1="0.0" k1="-0.86027224" periodicity2="3" phase2="0.0" k2="2.5610264" periodicity3="2" phase3="0.0" k3="0.7744584" periodicity4="1" phase4="0.0" k4="-12.492294320000001"/>
-  <Proper type1="protein-C" type2="protein-CX" type3="protein-TA" type4="protein-CC" periodicity1="4" phase1="0.0" k1="-0.23857168" periodicity2="3" phase2="0.0" k2="-3.47861944" periodicity3="2" phase3="0.0" k3="0.23714912000000002" periodicity4="1" phase4="0.0" k4="-0.22694016"/>
-  <Proper type1="protein-C" type2="protein-CX" type3="protein-TA" type4="protein-CA" periodicity1="4" phase1="0.0" k1="-0.9314420800000001" periodicity2="3" phase2="0.0" k2="-5.01523528" periodicity3="2" phase3="0.0" k3="-0.16070744" periodicity4="1" phase4="0.0" k4="-0.71575688"/>
-  <Proper type1="protein-C" type2="protein-CX" type3="protein-TA" type4="protein-C*" periodicity1="4" phase1="0.0" k1="-1.87012248" periodicity2="3" phase2="0.0" k2="-4.71570272" periodicity3="2" phase3="0.0" k3="-0.10589704" periodicity4="1" phase4="0.0" k4="-2.26044784"/>
-  <Proper type1="protein-C" type2="protein-TJ" type3="protein-CT" type4="protein-CT" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="0.0" periodicity3="2" phase3="0.0" k3="-1.7952707200000002" periodicity4="1" phase4="0.0" k4="-4.79335776"/>
-  <Proper type1="protein-C" type2="protein-TP" type3="protein-C8" type4="protein-C8" periodicity1="4" phase1="0.0" k1="1.2631914400000002" periodicity2="3" phase2="0.0" k2="-3.0878756800000002" periodicity3="2" phase3="0.0" k3="0.41040856" periodicity4="1" phase4="0.0" k4="-3.4045626400000004"/>
-  <Proper type1="protein-C" type2="protein-TP" type3="protein-C8" type4="protein-CC" periodicity1="4" phase1="0.0" k1="-0.18735952" periodicity2="3" phase2="0.0" k2="-1.42456832" periodicity3="2" phase3="0.0" k3="2.73118968" periodicity4="1" phase4="0.0" k4="-2.2863468"/>
-  <Proper type1="protein-C" type2="protein-TM" type3="protein-2C" type4="protein-2C" periodicity1="4" phase1="0.0" k1="-0.75504464" periodicity2="3" phase2="0.0" k2="-0.70492032" periodicity3="2" phase3="0.0" k3="1.42427544" periodicity4="1" phase4="0.0" k4="-6.12654752"/>
-  <Proper type1="protein-C" type2="protein-TM" type3="protein-2C" type4="protein-CO" periodicity1="4" phase1="0.0" k1="-0.45789696" periodicity2="3" phase2="0.0" k2="1.20486648" periodicity3="2" phase3="0.0" k3="0.91525" periodicity4="1" phase4="0.0" k4="-3.42054552"/>
-  <Proper type1="protein-C" type2="protein-TM" type3="protein-2C" type4="protein-SH" periodicity1="4" phase1="0.0" k1="-0.23748384" periodicity2="3" phase2="0.0" k2="3.67769416" periodicity3="2" phase3="0.0" k3="1.8510434400000002" periodicity4="1" phase4="0.0" k4="-4.7243217600000005"/>
-  <Proper type1="protein-CO" type2="protein-CX" type3="protein-2C" type4="protein-C" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-1.31716504" periodicity3="2" phase3="0.0" k3="5.944418" periodicity4="1" phase4="0.0" k4="11.54005776"/>
-  <Proper type1="protein-CO" type2="protein-CX" type3="protein-2C" type4="protein-SH" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="5.54865344" periodicity3="2" phase3="0.0" k3="3.03281424" periodicity4="1" phase4="0.0" k4="-5.74429728"/>
-  <Proper type1="protein-CO" type2="protein-CX" type3="protein-2C" type4="protein-S" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="0.38697816" periodicity3="2" phase3="0.0" k3="3.07862904" periodicity4="1" phase4="0.0" k4="0.76939576"/>
-  <Proper type1="protein-CO" type2="protein-CX" type3="protein-2C" type4="protein-2C" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="0.71751416" periodicity3="2" phase3="0.0" k3="-0.8292688" periodicity4="1" phase4="0.0" k4="-6.92259536"/>
-  <Proper type1="protein-CO" type2="protein-CX" type3="protein-2C" type4="protein-3C" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-1.16666656" periodicity3="2" phase3="0.0" k3="-0.301248" periodicity4="1" phase4="0.0" k4="-1.4443586400000001"/>
-  <Proper type1="protein-CO" type2="protein-CX" type3="protein-2C" type4="protein-OA" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-2.57889208" periodicity3="2" phase3="0.0" k3="-15.99706376" periodicity4="1" phase4="0.0" k4="-29.61251104"/>
-  <Proper type1="protein-CO" type2="protein-CX" type3="protein-3C" type4="protein-CT" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="3.5001252000000003" periodicity3="2" phase3="0.0" k3="-0.52873208" periodicity4="1" phase4="0.0" k4="-5.07180296"/>
-  <Proper type1="protein-CO" type2="protein-CX" type3="protein-3C" type4="protein-2C" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="4.07789376" periodicity3="2" phase3="0.0" k3="0.45413136" periodicity4="1" phase4="0.0" k4="0.68061128"/>
-  <Proper type1="protein-CO" type2="protein-CX" type3="protein-3C" type4="protein-OA" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="5.13514872" periodicity3="2" phase3="0.0" k3="-6.14675624" periodicity4="1" phase4="0.0" k4="-30.00760616"/>
-  <Proper type1="protein-CO" type2="protein-CX" type3="protein-TA" type4="protein-CC" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-3.5944744" periodicity3="2" phase3="0.0" k3="4.1679334400000005" periodicity4="1" phase4="0.0" k4="2.91277528"/>
-  <Proper type1="protein-CO" type2="protein-CX" type3="protein-TA" type4="protein-CA" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-1.94819592" periodicity3="2" phase3="0.0" k3="3.69296576" periodicity4="1" phase4="0.0" k4="1.4949432"/>
-  <Proper type1="protein-CO" type2="protein-CX" type3="protein-TA" type4="protein-C*" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="3.72049648" periodicity3="2" phase3="0.0" k3="8.17905056" periodicity4="1" phase4="0.0" k4="4.85536464"/>
-  <Proper type1="protein-CO" type2="protein-TJ" type3="protein-CT" type4="protein-CT" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="0.0" periodicity3="2" phase3="0.0" k3="5.33539496" periodicity4="1" phase4="0.0" k4="2.6142468800000005"/>
-  <Proper type1="protein-CO" type2="protein-TP" type3="protein-C8" type4="protein-C8" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-4.815281919999999" periodicity3="2" phase3="0.0" k3="2.8034892000000005" periodicity4="1" phase4="0.0" k4="-17.900365360000002"/>
-  <Proper type1="protein-CO" type2="protein-TP" type3="protein-C8" type4="protein-CC" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="5.65752112" periodicity3="2" phase3="0.0" k3="10.9740044" periodicity4="1" phase4="0.0" k4="-8.36682848"/>
-  <Proper type1="protein-CO" type2="protein-TM" type3="protein-2C" type4="protein-CO" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-0.18857288" periodicity3="2" phase3="0.0" k3="-0.15020560000000002" periodicity4="1" phase4="0.0" k4="9.322998"/>
-  <Proper type1="protein-CO" type2="protein-TM" type3="protein-2C" type4="protein-SH" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="5.93090368" periodicity3="2" phase3="0.0" k3="7.70981496" periodicity4="1" phase4="0.0" k4="7.837217760000001"/>
-  <Proper type1="protein-CO" type2="protein-TM" type3="protein-2C" type4="protein-2C" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="14.552203040000002" periodicity3="2" phase3="0.0" k3="15.35958952" periodicity4="1" phase4="0.0" k4="9.013382000000002"/>
-  <Proper type1="protein-H1" type2="protein-CX" type3="protein-2C" type4="protein-OA" periodicity1="3" phase1="0.0" k1="-1.39699576" periodicity2="1" phase2="0.0" k2="1.51155368"/>
-  <Proper type1="protein-H1" type2="protein-CX" type3="protein-3C" type4="protein-OA" periodicity1="3" phase1="0.0" k1="-0.10234064" periodicity2="1" phase2="0.0" k2="-7.701949040000001"/>
-  <Proper type1="protein-HP" type2="protein-CX" type3="protein-2C" type4="protein-OA" periodicity1="3" phase1="0.0" k1="8.5654848" periodicity2="1" phase2="0.0" k2="-0.6473903200000001"/>
-  <Proper type1="protein-HP" type2="protein-CX" type3="protein-3C" type4="protein-OA" periodicity1="3" phase1="0.0" k1="1.9287821600000001" periodicity2="1" phase2="0.0" k2="-9.598765440000001"/>
-  <Proper type1="protein-CX" type2="protein-2C" type3="protein-C" type4="protein-O" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="2.6739944" periodicity3="2" phase3="0.0" k3="-2.15103624" periodicity4="1" phase4="0.0" k4="-5.824964800000001"/>
-  <Proper type1="protein-CX" type2="protein-2C" type3="protein-C" type4="protein-OH" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="0.8711506400000001" periodicity3="2" phase3="0.0" k3="-1.19649848" periodicity4="1" phase4="0.0" k4="0.50258208"/>
-  <Proper type1="protein-CX" type2="protein-2C" type3="protein-C" type4="protein-OD" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-0.97771712" periodicity3="2" phase3="0.0" k3="-3.20038344" periodicity4="1" phase4="0.0" k4="-3.0478348000000004"/>
-  <Proper type1="protein-CX" type2="protein-2C" type3="protein-C" type4="protein-ND" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-0.017447280000000003" periodicity3="2" phase3="0.0" k3="-3.788612" periodicity4="1" phase4="0.0" k4="-2.49927056"/>
-  <Proper type1="protein-CX" type2="protein-2C" type3="protein-S" type4="protein-S" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-0.66764088" periodicity3="2" phase3="0.0" k3="1.91367792" periodicity4="1" phase4="0.0" k4="-4.75946736"/>
-  <Proper type1="protein-CX" type2="protein-2C" type3="protein-2C" type4="protein-C" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-2.79503752" periodicity3="2" phase3="0.0" k3="0.6363445600000001" periodicity4="1" phase4="0.0" k4="-2.7643687999999997"/>
-  <Proper type1="protein-CX" type2="protein-2C" type3="protein-3C" type4="protein-CT" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="1.51239048" periodicity3="2" phase3="0.0" k3="-0.25116552000000003" periodicity4="1" phase4="0.0" k4="0.06719504000000001"/>
-  <Proper type1="protein-CX" type2="protein-2C" type3="protein-2C" type4="protein-2C" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-1.1359560000000002" periodicity3="2" phase3="0.0" k3="-0.08865896000000001" periodicity4="1" phase4="0.0" k4="-0.84031456"/>
-  <Proper type1="protein-CX" type2="protein-2C" type3="protein-2C" type4="protein-S" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="0.98231952" periodicity3="2" phase3="0.0" k3="0.52839736" periodicity4="1" phase4="0.0" k4="-0.9071748800000001"/>
-  <Proper type1="protein-CX" type2="protein-3C" type3="protein-2C" type4="protein-CT" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="1.6127228000000002" periodicity3="2" phase3="0.0" k3="-0.21982736000000003" periodicity4="1" phase4="0.0" k4="1.16239888"/>
-  <Proper type1="protein-CT" type2="protein-3C" type3="protein-2C" type4="protein-CT" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="3.06461264" periodicity3="2" phase3="0.0" k3="-0.89299112" periodicity4="1" phase4="0.0" k4="-0.35292039999999997"/>
-  <Proper type1="protein-CX" type2="protein-TA" type3="protein-CC" type4="protein-NA" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="3.89099448" periodicity3="2" phase3="0.0" k3="3.31075736" periodicity4="1" phase4="0.0" k4="-0.6011989600000001"/>
-  <Proper type1="protein-CX" type2="protein-TA" type3="protein-CC" type4="protein-CV" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="1.77117088" periodicity3="2" phase3="0.0" k3="2.627552" periodicity4="1" phase4="0.0" k4="0.20233824"/>
-  <Proper type1="protein-CX" type2="protein-TA" type3="protein-CC" type4="protein-NB" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="2.06559896" periodicity3="2" phase3="0.0" k3="3.43242808" periodicity4="1" phase4="0.0" k4="-0.44057520000000006"/>
-  <Proper type1="protein-CX" type2="protein-TA" type3="protein-CC" type4="protein-CW" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-0.10970448000000001" periodicity3="2" phase3="0.0" k3="2.29120024" periodicity4="1" phase4="0.0" k4="-0.80303512"/>
-  <Proper type1="protein-CX" type2="protein-TA" type3="protein-CA" type4="protein-CA" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="0.48358672" periodicity3="2" phase3="0.0" k3="-1.63623688" periodicity4="1" phase4="0.0" k4="-2.09292048"/>
-  <Proper type1="protein-CX" type2="protein-TA" type3="protein-C*" type4="protein-CB" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="1.7152308" periodicity3="2" phase3="0.0" k3="-0.8397287999999999" periodicity4="1" phase4="0.0" k4="-2.04024392"/>
-  <Proper type1="protein-CX" type2="protein-TA" type3="protein-C*" type4="protein-CW" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-0.97294736" periodicity3="2" phase3="0.0" k3="-1.0878400000000001" periodicity4="1" phase4="0.0" k4="-2.79646008"/>
-  <Proper type1="protein-TJ" type2="protein-CT" type3="protein-CT" type4="protein-CT" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="0.0" periodicity3="2" phase3="0.0" k3="2.50834984" periodicity4="1" phase4="0.0" k4="0.33287904"/>
-  <Proper type1="protein-TP" type2="protein-C8" type3="protein-C8" type4="protein-C8" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-2.95603784" periodicity3="2" phase3="0.0" k3="0.6649212800000001" periodicity4="1" phase4="0.0" k4="-4.24855912"/>
-  <Proper type1="protein-TP" type2="protein-C8" type3="protein-CC" type4="protein-NA" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="1.60113312" periodicity3="2" phase3="0.0" k3="8.3186288" periodicity4="1" phase4="0.0" k4="0.2204968"/>
-  <Proper type1="protein-TP" type2="protein-C8" type3="protein-CC" type4="protein-CW" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-1.1685912" periodicity3="2" phase3="0.0" k3="3.91438304" periodicity4="1" phase4="0.0" k4="4.3442472"/>
-  <Proper type1="protein-TM" type2="protein-2C" type3="protein-2C" type4="protein-CO" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-3.0346552" periodicity3="2" phase3="0.0" k3="1.98309048" periodicity4="1" phase4="0.0" k4="-7.47500888"/>
-  <Proper type1="protein-TM" type2="protein-2C" type3="protein-CO" type4="protein-O3" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-0.619232" periodicity3="2" phase3="0.0" k3="-3.16360608" periodicity4="1" phase4="0.0" k4="-20.644902"/>
-  <Proper type1="protein-2C" type2="protein-S" type3="protein-S" type4="protein-2C" periodicity1="4" phase1="0.0" k1="1.15612288" periodicity2="3" phase2="0.0" k2="0.0" periodicity3="2" phase3="0.0" k3="17.74647784" periodicity4="1" phase4="0.0" k4="-5.412129520000001"/>
-  <Proper type1="protein-2C" type2="protein-2C" type3="protein-C" type4="protein-O" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="1.01721408" periodicity3="2" phase3="0.0" k3="-2.03785904" periodicity4="1" phase4="0.0" k4="-5.74479936"/>
-  <Proper type1="protein-2C" type2="protein-2C" type3="protein-C" type4="protein-OH" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-0.7973030400000001" periodicity3="2" phase3="0.0" k3="-0.9797254400000001" periodicity4="1" phase4="0.0" k4="1.2042807199999999"/>
-  <Proper type1="protein-2C" type2="protein-2C" type3="protein-C" type4="protein-OD" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="2.0112906400000004" periodicity3="2" phase3="0.0" k3="-3.6778196800000003" periodicity4="1" phase4="0.0" k4="-3.11871176"/>
-  <Proper type1="protein-2C" type2="protein-2C" type3="protein-C" type4="protein-ND" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="1.5357372" periodicity3="2" phase3="0.0" k3="-3.7691564000000004" periodicity4="1" phase4="0.0" k4="-1.24486552"/>
-  <Proper type1="protein-2C" type2="protein-2C" type3="protein-S" type4="protein-CT" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="1.6512992800000001" periodicity3="2" phase3="0.0" k3="2.20095136" periodicity4="1" phase4="0.0" k4="-0.041965520000000006"/>
-  <Proper type1="protein-2C" type2="protein-2C" type3="protein-2C" type4="protein-2C" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-0.5955087200000001" periodicity3="2" phase3="0.0" k3="-0.52103352" periodicity4="1" phase4="0.0" k4="-1.6777840000000002"/>
-  <Proper type1="protein-2C" type2="protein-2C" type3="protein-2C" type4="protein-CT" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="0.17325944000000001" periodicity3="2" phase3="0.0" k3="-1.40691184" periodicity4="1" phase4="0.0" k4="-2.10722976"/>
-  <Proper type1="protein-CT" type2="protein-CT" type3="protein-CT" type4="protein-TN" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="0.0" periodicity3="2" phase3="0.0" k3="-0.32919712" periodicity4="1" phase4="0.0" k4="-0.32986656"/>
-  <Proper type1="protein-C8" type2="protein-C8" type3="protein-C8" type4="protein-N2" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-0.36802464" periodicity3="2" phase3="0.0" k3="-0.7042927200000001" periodicity4="1" phase4="0.0" k4="-3.74200224"/>
-  <Proper type1="protein-C8" type2="protein-C8" type3="protein-C8" type4="protein-C8" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-3.62510128" periodicity3="2" phase3="0.0" k3="1.50824832" periodicity4="1" phase4="0.0" k4="-1.94246384"/>
-  <Proper type1="protein-2C" type2="protein-2C" type3="protein-CO" type4="protein-O3" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="1.79267664" periodicity3="2" phase3="0.0" k3="-2.07727232" periodicity4="1" phase4="0.0" k4="-9.49730344"/>
-  <Proper type1="protein-2C" type2="protein-2C" type3="protein-2C" type4="protein-N3" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="1.8402905600000001" periodicity3="2" phase3="0.0" k3="-0.6118681600000001" periodicity4="1" phase4="0.0" k4="-2.09978224"/>
-  <Proper type1="protein-CT" type2="protein-CT" type3="protein-TN" type4="protein-C" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="0.0" periodicity3="2" phase3="0.0" k3="-2.62847248" periodicity4="1" phase4="0.0" k4="-17.80781528"/>
-  <Proper type1="protein-C8" type2="protein-C8" type3="protein-N2" type4="protein-CA" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-4.3338290399999995" periodicity3="2" phase3="0.0" k3="2.65658896" periodicity4="1" phase4="0.0" k4="-3.4659000800000004"/>
-  <Proper type1="protein-C8" type2="protein-C8" type3="protein-C8" type4="protein-NL" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="-2.91327736" periodicity3="2" phase3="0.0" k3="-0.52668192" periodicity4="1" phase4="0.0" k4="-6.0113201599999995"/>
-  <Proper type1="protein-CT" type2="protein-CT" type3="protein-TN" type4="protein-TJ" periodicity1="4" phase1="0.0" k1="0.0" periodicity2="3" phase2="0.0" k2="0.0" periodicity3="2" phase3="0.0" k3="-0.9386804" periodicity4="1" phase4="0.0" k4="-1.6110492"/>
-  <Proper type1="protein-C8" type2="protein-N2" type3="protein-CA" type4="protein-N2" periodicity1="4" phase1="0.0" k1="7.88257232" periodicity2="2" phase2="0.0" k2="-33.21577184"/>
-  <Proper type1="protein-NB" type2="protein-CR" type3="protein-NA" type4="protein-CC" periodicity1="2" phase1="3.141592653589793" k1="46.09173896"/>
-  <Proper type1="protein-NA" type2="protein-CR" type3="protein-NB" type4="protein-CC" periodicity1="2" phase1="3.141592653589793" k1="30.59273856"/>
-  <Proper type1="protein-NA" type2="protein-CR" type3="protein-NA" type4="protein-CC" periodicity1="2" phase1="3.141592653589793" k1="68.49777024"/>
-  <Proper type1="protein-CC" type2="protein-CV" type3="protein-NB" type4="protein-CR" periodicity1="2" phase1="3.141592653589793" k1="47.18790512"/>
-  <Proper type1="protein-CC" type2="protein-CW" type3="protein-NA" type4="protein-CR" periodicity1="2" phase1="3.141592653589793" k1="14.47597056"/>
-  <Proper type1="protein-NA" type2="protein-CR" type3="protein-NB" type4="protein-CV" periodicity1="2" phase1="3.141592653589793" k1="38.54104152"/>
-  <Proper type1="protein-NB" type2="protein-CR" type3="protein-NA" type4="protein-CW" periodicity1="2" phase1="3.141592653589793" k1="23.13162056"/>
-  <Proper type1="protein-NA" type2="protein-CR" type3="protein-NA" type4="protein-CW" periodicity1="2" phase1="3.141592653589793" k1="69.95145920000002"/>
-  <Proper type1="protein-H" type2="protein-N" type3="protein-C" type4="protein-OD" periodicity1="2" phase1="0.0" k1="-5.26518744" periodicity2="1" phase2="0.0" k2="3.3569068800000004"/>
-  <Proper type1="protein-HC" type2="protein-CT" type3="protein-C" type4="protein-OD" periodicity1="3" phase1="0.0" k1="0.61856256" periodicity2="2" phase2="0.0" k2="-0.47689232000000004"/>
-  <Proper type1="protein-O" type2="protein-C" type3="protein-2C" type4="protein-HC" periodicity1="3" phase1="0.0" k1="-1.46477656" periodicity2="2" phase2="0.0" k2="-0.54868976" periodicity3="1" phase3="0.0" k3="-6.04893432"/>
-  <Proper type1="protein-OH" type2="protein-C" type3="protein-2C" type4="protein-HC" periodicity1="2" phase1="0.0" k1="-0.38773128"/>
-  <Proper type1="protein-HO" type2="protein-OH" type3="protein-C" type4="protein-O" periodicity1="2" phase1="0.0" k1="-11.18127976" periodicity2="1" phase2="0.0" k2="1.02135624"/>
-  <Proper type1="protein-HC" type2="protein-CT" type3="protein-2C" type4="protein-3C" periodicity1="3" phase1="0.0" k1="1.15553712"/>
-  <Proper type1="protein-HC" type2="protein-CT" type3="protein-3C" type4="protein-CX" periodicity1="3" phase1="0.0" k1="0.6454238400000001"/>
-  <Proper type1="protein-CX" type2="protein-2C" type3="protein-2C" type4="protein-HC" periodicity1="3" phase1="0.0" k1="1.32394312"/>
-  <Proper type1="protein-CT" type2="protein-2C" type3="protein-3C" type4="protein-HC" periodicity1="3" phase1="0.0" k1="-0.87834712"/>
-  <Proper type1="protein-CX" type2="protein-2C" type3="protein-SH" type4="protein-HS" periodicity1="3" phase1="0.0" k1="-3.6610418399999998" periodicity2="2" phase2="0.0" k2="3.45435224" periodicity3="1" phase3="0.0" k3="-0.5719109600000001"/>
-  <Proper type1="protein-OD" type2="protein-C" type3="protein-2C" type4="protein-HC" periodicity1="3" phase1="0.0" k1="0.22179384000000002" periodicity2="2" phase2="0.0" k2="-3.2756954400000002" periodicity3="1" phase3="0.0" k3="1.00110568"/>
-  <Proper type1="protein-ND" type2="protein-C" type3="protein-2C" type4="protein-HC" periodicity1="2" phase1="0.0" k1="-3.00030456"/>
-  <Proper type1="protein-H" type2="protein-ND" type3="protein-C" type4="protein-OD" periodicity1="2" phase1="0.0" k1="-7.00246792" periodicity2="1" phase2="0.0" k2="1.65376784"/>
-  <Proper type1="protein-HC" type2="protein-CT" type3="protein-3C" type4="protein-OA" periodicity1="3" phase1="0.0" k1="0.7950018400000001" periodicity2="1" phase2="0.0" k2="1.98673056"/>
-  <Proper type1="protein-HO" type2="protein-OA" type3="protein-2C" type4="protein-H1" periodicity1="3" phase1="0.0" k1="1.7724679200000002"/>
-  <Proper type1="protein-HO" type2="protein-OA" type3="protein-3C" type4="protein-H1" periodicity1="3" phase1="0.0" k1="6.54549144"/>
-  <Proper type1="protein-CA" type2="protein-C" type3="protein-OA" type4="protein-HO" periodicity1="2" phase1="0.0" k1="-3.86752224"/>
-  <Proper type1="protein-CX" type2="protein-3C" type3="protein-OA" type4="protein-HO" periodicity1="3" phase1="0.0" k1="-2.78909624" periodicity2="2" phase2="0.0" k2="1.6904615200000002" periodicity3="1" phase3="0.0" k3="-2.36550808"/>
-  <Proper type1="protein-CT" type2="protein-3C" type3="protein-OA" type4="protein-HO" periodicity1="3" phase1="0.0" k1="-1.23884056" periodicity2="2" phase2="0.0" k2="-0.73709528" periodicity3="1" phase3="0.0" k3="2.93833952"/>
-  <Proper type1="protein-CX" type2="protein-2C" type3="protein-OA" type4="protein-HO" periodicity1="3" phase1="0.0" k1="-1.01374136" periodicity2="2" phase2="0.0" k2="1.84355408" periodicity3="1" phase3="0.0" k3="-1.05662736"/>
-  <Proper type1="protein-C8" type2="protein-C8" type3="protein-N2" type4="protein-TH" periodicity1="3" phase1="0.0" k1="-4.48072928" periodicity2="2" phase2="0.0" k2="-2.8734038400000004" periodicity3="1" phase3="0.0" k3="-3.56041664"/>
-  <Proper type1="protein-TH" type2="protein-N2" type3="protein-CA" type4="protein-N2" periodicity1="4" phase1="0.0" k1="4.809842720000001" periodicity2="2" phase2="0.0" k2="-21.000751200000003"/>
-  <Proper type1="protein-C8" type2="protein-C8" type3="protein-NL" type4="protein-H" periodicity1="3" phase1="0.0" k1="3.9152198400000002"/>
-  <Proper type1="protein-O3" type2="protein-CO" type3="protein-2C" type4="protein-HC" periodicity1="2" phase1="0.0" k1="-0.5294015200000001"/>
-  <Improper type1="protein-C" type2="" type3="" type4="protein-O" periodicity1="2" phase1="3.141592653589793" k1="43.932"/>
-  <Improper type1="protein-N" type2="" type3="" type4="protein-H" periodicity1="2" phase1="3.141592653589793" k1="4.184"/>
-  <Improper type1="protein-N2" type2="" type3="" type4="protein-H" periodicity1="2" phase1="3.141592653589793" k1="4.184"/>
-  <Improper type1="protein-NA" type2="" type3="" type4="protein-H" periodicity1="2" phase1="3.141592653589793" k1="4.184"/>
-  <Improper type1="protein-CA" type2="" type3="protein-N2" type4="protein-N2" periodicity1="2" phase1="3.141592653589793" k1="43.932"/>
-  <Improper type1="protein-N" type2="" type3="protein-CT" type4="protein-CT" periodicity1="2" phase1="3.141592653589793" k1="4.184"/>
-  <Improper type1="protein-N" type2="" type3="protein-CX" type4="protein-CT" periodicity1="2" phase1="3.141592653589793" k1="4.184"/>
-  <Improper type1="protein-CA" type2="" type3="" type4="protein-HA" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-CW" type2="" type3="" type4="protein-H4" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-CR" type2="" type3="" type4="protein-H5" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-CV" type2="" type3="" type4="protein-H4" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-CA" type2="" type3="" type4="protein-H4" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-CA" type2="" type3="" type4="protein-H5" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-CO" type2="" type3="protein-O3" type4="protein-O3" periodicity1="2" phase1="3.141592653589793" k1="43.932"/>
-  <Improper type1="protein-C" type2="" type3="" type4="protein-OD" periodicity1="2" phase1="3.141592653589793" k1="43.932"/>
-  <Improper type1="protein-ND" type2="" type3="" type4="protein-H" periodicity1="2" phase1="3.141592653589793" k1="4.184"/>
-  <Improper type1="protein-ND" type2="" type3="protein-CT" type4="protein-CT" periodicity1="2" phase1="3.141592653589793" k1="4.184"/>
-  <Improper type1="protein-ND" type2="" type3="protein-CX" type4="protein-CT" periodicity1="2" phase1="3.141592653589793" k1="4.184"/>
-  <Improper type1="protein-TN" type2="" type3="" type4="protein-H" periodicity1="2" phase1="3.141592653589793" k1="4.184"/>
-  <Improper type1="protein-TN" type2="" type3="protein-CT" type4="protein-CT" periodicity1="2" phase1="3.141592653589793" k1="4.184"/>
-  <Improper type1="protein-TN" type2="" type3="protein-CX" type4="protein-CT" periodicity1="2" phase1="3.141592653589793" k1="4.184"/>
-  <Improper type1="protein-N" type2="" type3="protein-TG" type4="protein-CT" periodicity1="2" phase1="3.141592653589793" k1="4.184"/>
-  <Improper type1="protein-N" type2="" type3="protein-TM" type4="protein-CT" periodicity1="2" phase1="3.141592653589793" k1="4.184"/>
-  <Improper type1="protein-TN" type2="" type3="protein-TM" type4="protein-CT" periodicity1="2" phase1="3.141592653589793" k1="4.184"/>
-  <Improper type1="protein-N" type2="" type3="protein-TP" type4="protein-CT" periodicity1="2" phase1="3.141592653589793" k1="4.184"/>
-  <Improper type1="protein-ND" type2="" type3="protein-TP" type4="protein-CT" periodicity1="2" phase1="3.141592653589793" k1="4.184"/>
-  <Improper type1="protein-TN" type2="" type3="protein-TP" type4="protein-CT" periodicity1="2" phase1="3.141592653589793" k1="4.184"/>
-  <Improper type1="protein-N2" type2="" type3="" type4="protein-TH" periodicity1="2" phase1="3.141592653589793" k1="4.184"/>
-  <Improper type1="protein-C" type2="protein-CT" type3="protein-O" type4="protein-OH" periodicity1="2" phase1="3.141592653589793" k1="43.932"/>
-  <Improper type1="protein-CC" type2="protein-CT" type3="protein-CV" type4="protein-NA" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-CC" type2="protein-CT" type3="protein-CW" type4="protein-NB" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-CC" type2="protein-C8" type3="protein-CW" type4="protein-NA" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-CC" type2="protein-CT" type3="protein-CW" type4="protein-NA" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-C*" type2="protein-CB" type3="protein-CT" type4="protein-CW" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-CA" type2="protein-CA" type3="protein-CA" type4="protein-CT" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-C" type2="protein-CA" type3="protein-CA" type4="protein-OH" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-CA" type2="protein-CA" type3="protein-CA" type4="protein-OH" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-C" type2="protein-H5" type3="protein-O" type4="protein-OH" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-N" type2="protein-C" type3="protein-CT" type4="protein-H" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-N" type2="protein-C" type3="protein-CX" type4="protein-H" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-N" type2="protein-C" type3="protein-CT" type4="protein-O" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-C" type2="protein-2C" type3="protein-O" type4="protein-OH" periodicity1="2" phase1="3.141592653589793" k1="43.932"/>
-  <Improper type1="protein-CA" type2="protein-2C" type3="protein-CA" type4="protein-CA" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-C" type2="protein-CT" type3="protein-OD" type4="protein-OH" periodicity1="2" phase1="3.141592653589793" k1="43.932"/>
-  <Improper type1="protein-C" type2="protein-H5" type3="protein-OD" type4="protein-OH" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-N" type2="protein-C" type3="protein-CT" type4="protein-OD" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-C" type2="protein-2C" type3="protein-OD" type4="protein-OH" periodicity1="2" phase1="3.141592653589793" k1="43.932"/>
-  <Improper type1="protein-ND" type2="protein-C" type3="protein-CT" type4="protein-H" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-ND" type2="protein-C" type3="protein-CX" type4="protein-H" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-ND" type2="protein-C" type3="protein-CT" type4="protein-O" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-ND" type2="protein-C" type3="protein-CT" type4="protein-OD" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-C" type2="protein-CT" type3="protein-O" type4="protein-OA" periodicity1="2" phase1="3.141592653589793" k1="43.932"/>
-  <Improper type1="protein-C" type2="protein-CA" type3="protein-CA" type4="protein-OA" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-CA" type2="protein-CA" type3="protein-CA" type4="protein-OA" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-C" type2="protein-H5" type3="protein-O" type4="protein-OA" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-C" type2="protein-2C" type3="protein-O" type4="protein-OA" periodicity1="2" phase1="3.141592653589793" k1="43.932"/>
-  <Improper type1="protein-C" type2="protein-CT" type3="protein-OA" type4="protein-OD" periodicity1="2" phase1="3.141592653589793" k1="43.932"/>
-  <Improper type1="protein-C" type2="protein-H5" type3="protein-OA" type4="protein-OD" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-C" type2="protein-2C" type3="protein-OA" type4="protein-OD" periodicity1="2" phase1="3.141592653589793" k1="43.932"/>
-  <Improper type1="protein-TN" type2="protein-C" type3="protein-CT" type4="protein-H" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-TN" type2="protein-C" type3="protein-CX" type4="protein-H" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-TN" type2="protein-C" type3="protein-CT" type4="protein-O" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-TN" type2="protein-C" type3="protein-CT" type4="protein-OD" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-N" type2="protein-C" type3="protein-H" type4="protein-TG" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-N" type2="protein-C" type3="protein-H" type4="protein-TM" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-TN" type2="protein-C" type3="protein-H" type4="protein-TM" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-N" type2="protein-C" type3="protein-H" type4="protein-TP" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-ND" type2="protein-C" type3="protein-H" type4="protein-TP" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-TN" type2="protein-C" type3="protein-H" type4="protein-TP" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-TN" type2="protein-C" type3="protein-CT" type4="protein-TJ" periodicity1="2" phase1="3.141592653589793" k1="4.184"/>
-  <Improper type1="protein-C" type2="protein-N" type3="protein-OD" type4="protein-TJ" periodicity1="2" phase1="3.141592653589793" k1="43.932"/>
-  <Improper type1="protein-C" type2="protein-OD" type3="protein-TJ" type4="protein-TN" periodicity1="2" phase1="3.141592653589793" k1="43.932"/>
-  <Improper type1="protein-C" type2="protein-ND" type3="protein-OD" type4="protein-TJ" periodicity1="2" phase1="3.141592653589793" k1="43.932"/>
-  <Improper type1="protein-CO" type2="protein-O3" type3="protein-O3" type4="protein-TJ" periodicity1="2" phase1="3.141592653589793" k1="43.932"/>
-  <Improper type1="protein-CC" type2="protein-CV" type3="protein-NA" type4="protein-TA" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-CC" type2="protein-CW" type3="protein-NB" type4="protein-TA" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-CA" type2="protein-CA" type3="protein-CA" type4="protein-TA" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
-  <Improper type1="protein-C*" type2="protein-CB" type3="protein-CW" type4="protein-TA" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
- </PeriodicTorsionForce>
- <NonbondedForce coulomb14scale="0.8333333333333334" lj14scale="0.5">
-  <UseAttributeFromResidue name="charge"/>
-  <Atom type="protein-C" sigma="0.3399669508423535" epsilon="0.359824"/>
-  <Atom type="protein-CA" sigma="0.3399669508423535" epsilon="0.359824"/>
-  <Atom type="protein-CB" sigma="0.3399669508423535" epsilon="0.359824"/>
-  <Atom type="protein-CC" sigma="0.3399669508423535" epsilon="0.359824"/>
-  <Atom type="protein-CN" sigma="0.3399669508423535" epsilon="0.359824"/>
-  <Atom type="protein-CR" sigma="0.3399669508423535" epsilon="0.359824"/>
-  <Atom type="protein-CT" sigma="0.3399669508423535" epsilon="0.4577296"/>
-  <Atom type="protein-CV" sigma="0.3399669508423535" epsilon="0.359824"/>
-  <Atom type="protein-CW" sigma="0.3399669508423535" epsilon="0.359824"/>
-  <Atom type="protein-C*" sigma="0.3399669508423535" epsilon="0.359824"/>
-  <Atom type="protein-CX" sigma="0.3399669508423535" epsilon="0.4577296"/>
-  <Atom type="protein-H" sigma="0.1299999409510383" epsilon="0.06568879999999999"/>
-  <Atom type="protein-HC" sigma="0.2649532787749369" epsilon="0.06568879999999999"/>
-  <Atom type="protein-H1" sigma="0.2471353044121301" epsilon="0.06568879999999999"/>
-  <Atom type="protein-HA" sigma="0.25996424595335105" epsilon="0.06276"/>
-  <Atom type="protein-H4" sigma="0.2510552587719476" epsilon="0.06276"/>
-  <Atom type="protein-H5" sigma="0.24214627159054422" epsilon="0.06276"/>
-  <Atom type="protein-HO" sigma="1.0" epsilon="0.0"/>
-  <Atom type="protein-HS" sigma="0.10690784617684071" epsilon="0.06568879999999999"/>
-  <Atom type="protein-HP" sigma="0.19599771799087468" epsilon="0.06568879999999999"/>
-  <Atom type="protein-N" sigma="0.3249998523775958" epsilon="0.7112800000000001"/>
-  <Atom type="protein-NA" sigma="0.3249998523775958" epsilon="0.7112800000000001"/>
-  <Atom type="protein-NB" sigma="0.3249998523775958" epsilon="0.7112800000000001"/>
-  <Atom type="protein-N2" sigma="0.3249998523775958" epsilon="0.7112800000000001"/>
-  <Atom type="protein-N3" sigma="0.3249998523775958" epsilon="0.7112800000000001"/>
-  <Atom type="protein-O" sigma="0.2959921901149463" epsilon="0.87864"/>
-  <Atom type="protein-OH" sigma="0.3066473387839048" epsilon="0.8803136"/>
-  <Atom type="protein-S" sigma="0.35635948725613575" epsilon="1.046"/>
-  <Atom type="protein-SH" sigma="0.35635948725613575" epsilon="1.046"/>
-  <Atom type="protein-CO" sigma="0.3399669508423535" epsilon="0.359824"/>
-  <Atom type="protein-2C" sigma="0.3399669508423535" epsilon="0.4577296"/>
-  <Atom type="protein-3C" sigma="0.3399669508423535" epsilon="0.4577296"/>
-  <Atom type="protein-C8" sigma="0.3399669508423535" epsilon="0.4577296"/>
-  <Atom type="protein-O3" sigma="0.2959921901149463" epsilon="0.87864"/>
-  <Atom type="protein-OD" sigma="0.2959921901149463" epsilon="0.87864"/>
-  <Atom type="protein-ND" sigma="0.3249998523775958" epsilon="0.7112800000000001"/>
-  <Atom type="protein-OA" sigma="0.3066473387839048" epsilon="0.8803136"/>
-  <Atom type="protein-NL" sigma="0.3249998523775958" epsilon="0.7112800000000001"/>
-  <Atom type="protein-TN" sigma="0.3249998523775958" epsilon="0.7112800000000001"/>
-  <Atom type="protein-TJ" sigma="0.3399669508423535" epsilon="0.4577296"/>
-  <Atom type="protein-TG" sigma="0.3399669508423535" epsilon="0.4577296"/>
-  <Atom type="protein-TP" sigma="0.3399669508423535" epsilon="0.4577296"/>
-  <Atom type="protein-TM" sigma="0.3399669508423535" epsilon="0.4577296"/>
-  <Atom type="protein-TH" sigma="0.15000008263405806" epsilon="0.06568879999999999"/>
-  <Atom type="protein-TA" sigma="0.3399669508423535" epsilon="0.4577296"/>
- </NonbondedForce>
+  <Info>
+    <DateGenerated>2018-03-02</DateGenerated>
+    <Source Source="leaprc.protein.ff15ipq" md5hash="b7e40247370a8e75ff03a5c9b0c3368a" sourcePackage="AmberTools" sourcePackageVersion="17.6">leaprc.protein.ff15ipq</Source>
+    <Reference>Debiec, K.T.; Cerutti, D.S.; Baker, L.R.; Gronenborn, A.M.; Case, D.A.; Chong, L.T. Further along the Road Less Traveled: AMBER ff15ipq, an Original Protein Force Field Built on a Self-Consistent Physical Model. J. Chem. Theory Comput., 2016, 12, 3926-3947.</Reference>
+  </Info>
+  <AtomTypes>
+    <Type class="C" element="C" mass="12.01" name="protein-C"/>
+    <Type class="CA" element="C" mass="12.01" name="protein-CA"/>
+    <Type class="CB" element="C" mass="12.01" name="protein-CB"/>
+    <Type class="CC" element="C" mass="12.01" name="protein-CC"/>
+    <Type class="CN" element="C" mass="12.01" name="protein-CN"/>
+    <Type class="CR" element="C" mass="12.01" name="protein-CR"/>
+    <Type class="CT" element="C" mass="12.01" name="protein-CT"/>
+    <Type class="CV" element="C" mass="12.01" name="protein-CV"/>
+    <Type class="CW" element="C" mass="12.01" name="protein-CW"/>
+    <Type class="C*" element="C" mass="12.01" name="protein-C*"/>
+    <Type class="CX" element="C" mass="12.01" name="protein-CX"/>
+    <Type class="H" element="H" mass="1.008" name="protein-H"/>
+    <Type class="HC" element="H" mass="1.008" name="protein-HC"/>
+    <Type class="H1" element="H" mass="1.008" name="protein-H1"/>
+    <Type class="HA" element="H" mass="1.008" name="protein-HA"/>
+    <Type class="H4" element="H" mass="1.008" name="protein-H4"/>
+    <Type class="H5" element="H" mass="1.008" name="protein-H5"/>
+    <Type class="HO" element="H" mass="1.008" name="protein-HO"/>
+    <Type class="HS" element="H" mass="1.008" name="protein-HS"/>
+    <Type class="HP" element="H" mass="1.008" name="protein-HP"/>
+    <Type class="N" element="N" mass="14.01" name="protein-N"/>
+    <Type class="NA" element="N" mass="14.01" name="protein-NA"/>
+    <Type class="NB" element="N" mass="14.01" name="protein-NB"/>
+    <Type class="N2" element="N" mass="14.01" name="protein-N2"/>
+    <Type class="N3" element="N" mass="14.01" name="protein-N3"/>
+    <Type class="O" element="O" mass="16.0" name="protein-O"/>
+    <Type class="OH" element="O" mass="16.0" name="protein-OH"/>
+    <Type class="S" element="S" mass="32.06" name="protein-S"/>
+    <Type class="SH" element="S" mass="32.06" name="protein-SH"/>
+    <Type class="CO" element="C" mass="12.01" name="protein-CO"/>
+    <Type class="2C" element="C" mass="12.01" name="protein-2C"/>
+    <Type class="3C" element="C" mass="12.01" name="protein-3C"/>
+    <Type class="C8" element="C" mass="12.01" name="protein-C8"/>
+    <Type class="O3" element="O" mass="16.0" name="protein-O3"/>
+    <Type class="OD" element="O" mass="16.0" name="protein-OD"/>
+    <Type class="ND" element="N" mass="14.01" name="protein-ND"/>
+    <Type class="OA" element="O" mass="16.0" name="protein-OA"/>
+    <Type class="NL" element="N" mass="14.01" name="protein-NL"/>
+    <Type class="TN" element="N" mass="14.01" name="protein-TN"/>
+    <Type class="TJ" element="C" mass="12.01" name="protein-TJ"/>
+    <Type class="TG" element="C" mass="12.01" name="protein-TG"/>
+    <Type class="TP" element="C" mass="12.01" name="protein-TP"/>
+    <Type class="TM" element="C" mass="12.01" name="protein-TM"/>
+    <Type class="TH" element="H" mass="1.008" name="protein-TH"/>
+    <Type class="TA" element="C" mass="12.01" name="protein-TA"/>
+  </AtomTypes>
+  <Residues>
+    <Residue name="ALA">
+      <Atom charge="-0.51112" name="N" type="protein-N"/>
+      <Atom charge="0.3201" name="H" type="protein-H"/>
+      <Atom charge="0.00527" name="CA" type="protein-CX"/>
+      <Atom charge="0.10041" name="HA" type="protein-H1"/>
+      <Atom charge="-0.18102" name="CB" type="protein-CT"/>
+      <Atom charge="0.07225" name="HB1" type="protein-HC"/>
+      <Atom charge="0.07225" name="HB2" type="protein-HC"/>
+      <Atom charge="0.07225" name="HB3" type="protein-HC"/>
+      <Atom charge="0.63952" name="C" type="protein-C"/>
+      <Atom charge="-0.58991" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB1"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="ARG">
+      <Atom charge="-0.3908" name="N" type="protein-N"/>
+      <Atom charge="0.31584" name="H" type="protein-H"/>
+      <Atom charge="-0.4513" name="CA" type="protein-TP"/>
+      <Atom charge="0.21173" name="HA" type="protein-H1"/>
+      <Atom charge="-0.01245" name="CB" type="protein-C8"/>
+      <Atom charge="0.06845" name="HB2" type="protein-HC"/>
+      <Atom charge="0.06845" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.02988" name="CG" type="protein-C8"/>
+      <Atom charge="0.05333" name="HG2" type="protein-HC"/>
+      <Atom charge="0.05333" name="HG3" type="protein-HC"/>
+      <Atom charge="0.06705" name="CD" type="protein-C8"/>
+      <Atom charge="0.08336" name="HD2" type="protein-H1"/>
+      <Atom charge="0.08336" name="HD3" type="protein-H1"/>
+      <Atom charge="-0.58061" name="NE" type="protein-N2"/>
+      <Atom charge="0.39559" name="HE" type="protein-TH"/>
+      <Atom charge="0.74823" name="CZ" type="protein-CA"/>
+      <Atom charge="-0.83745" name="NH1" type="protein-N2"/>
+      <Atom charge="0.4466" name="HH11" type="protein-TH"/>
+      <Atom charge="0.4466" name="HH12" type="protein-TH"/>
+      <Atom charge="-0.83745" name="NH2" type="protein-N2"/>
+      <Atom charge="0.4466" name="HH21" type="protein-TH"/>
+      <Atom charge="0.4466" name="HH22" type="protein-TH"/>
+      <Atom charge="0.8387" name="C" type="protein-C"/>
+      <Atom charge="-0.63388" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="CD"/>
+      <Bond atomName1="CD" atomName2="HD2"/>
+      <Bond atomName1="CD" atomName2="HD3"/>
+      <Bond atomName1="CD" atomName2="NE"/>
+      <Bond atomName1="NE" atomName2="HE"/>
+      <Bond atomName1="NE" atomName2="CZ"/>
+      <Bond atomName1="CZ" atomName2="NH1"/>
+      <Bond atomName1="CZ" atomName2="NH2"/>
+      <Bond atomName1="NH1" atomName2="HH11"/>
+      <Bond atomName1="NH1" atomName2="HH12"/>
+      <Bond atomName1="NH2" atomName2="HH21"/>
+      <Bond atomName1="NH2" atomName2="HH22"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="ASH">
+      <Atom charge="-0.51112" name="N" type="protein-N"/>
+      <Atom charge="0.3201" name="H" type="protein-H"/>
+      <Atom charge="0.08118" name="CA" type="protein-CX"/>
+      <Atom charge="0.07654" name="HA" type="protein-H1"/>
+      <Atom charge="-0.1463" name="CB" type="protein-2C"/>
+      <Atom charge="0.07911" name="HB2" type="protein-HC"/>
+      <Atom charge="0.07911" name="HB3" type="protein-HC"/>
+      <Atom charge="0.60797" name="CG" type="protein-C"/>
+      <Atom charge="-0.51272" name="OD1" type="protein-O"/>
+      <Atom charge="-0.53531" name="OD2" type="protein-OH"/>
+      <Atom charge="0.41183" name="HD2" type="protein-HO"/>
+      <Atom charge="0.63952" name="C" type="protein-C"/>
+      <Atom charge="-0.58991" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="OD1"/>
+      <Bond atomName1="CG" atomName2="OD2"/>
+      <Bond atomName1="OD2" atomName2="HD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="ASN">
+      <Atom charge="-0.51112" name="N" type="protein-N"/>
+      <Atom charge="0.3201" name="H" type="protein-H"/>
+      <Atom charge="0.02612" name="CA" type="protein-CX"/>
+      <Atom charge="0.10302" name="HA" type="protein-H1"/>
+      <Atom charge="-0.16039" name="CB" type="protein-2C"/>
+      <Atom charge="0.07474" name="HB2" type="protein-HC"/>
+      <Atom charge="0.07474" name="HB3" type="protein-HC"/>
+      <Atom charge="0.68612" name="CG" type="protein-C"/>
+      <Atom charge="-0.63291" name="OD1" type="protein-OD"/>
+      <Atom charge="-0.88334" name="ND2" type="protein-ND"/>
+      <Atom charge="0.44179" name="HD21" type="protein-H"/>
+      <Atom charge="0.41152" name="HD22" type="protein-H"/>
+      <Atom charge="0.63952" name="C" type="protein-C"/>
+      <Atom charge="-0.58991" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="OD1"/>
+      <Bond atomName1="CG" atomName2="ND2"/>
+      <Bond atomName1="ND2" atomName2="HD21"/>
+      <Bond atomName1="ND2" atomName2="HD22"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="ASP">
+      <Atom charge="-0.70584" name="N" type="protein-N"/>
+      <Atom charge="0.36907" name="H" type="protein-H"/>
+      <Atom charge="0.32215" name="CA" type="protein-TM"/>
+      <Atom charge="0.01602" name="HA" type="protein-H1"/>
+      <Atom charge="-0.15393" name="CB" type="protein-2C"/>
+      <Atom charge="0.02533" name="HB2" type="protein-HC"/>
+      <Atom charge="0.02533" name="HB3" type="protein-HC"/>
+      <Atom charge="0.865" name="CG" type="protein-CO"/>
+      <Atom charge="-0.85227" name="OD1" type="protein-O3"/>
+      <Atom charge="-0.85227" name="OD2" type="protein-O3"/>
+      <Atom charge="0.57227" name="C" type="protein-C"/>
+      <Atom charge="-0.63086" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="OD1"/>
+      <Bond atomName1="CG" atomName2="OD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="CYM">
+      <Atom charge="-0.70584" name="N" type="protein-N"/>
+      <Atom charge="0.36907" name="H" type="protein-H"/>
+      <Atom charge="0.31993" name="CA" type="protein-TM"/>
+      <Atom charge="-0.02358" name="HA" type="protein-H1"/>
+      <Atom charge="0.08286" name="CB" type="protein-2C"/>
+      <Atom charge="0.04444" name="HB3" type="protein-H1"/>
+      <Atom charge="0.04444" name="HB2" type="protein-H1"/>
+      <Atom charge="-1.07273" name="SG" type="protein-SH"/>
+      <Atom charge="0.57227" name="C" type="protein-C"/>
+      <Atom charge="-0.63086" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="SG"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="CYS">
+      <Atom charge="-0.51112" name="N" type="protein-N"/>
+      <Atom charge="0.3201" name="H" type="protein-H"/>
+      <Atom charge="0.02119" name="CA" type="protein-CX"/>
+      <Atom charge="0.10678" name="HA" type="protein-H1"/>
+      <Atom charge="-0.07934" name="CB" type="protein-2C"/>
+      <Atom charge="0.0996" name="HB2" type="protein-H1"/>
+      <Atom charge="0.0996" name="HB3" type="protein-H1"/>
+      <Atom charge="-0.30684" name="SG" type="protein-SH"/>
+      <Atom charge="0.20042" name="HG" type="protein-HS"/>
+      <Atom charge="0.63952" name="C" type="protein-C"/>
+      <Atom charge="-0.58991" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="SG"/>
+      <Bond atomName1="SG" atomName2="HG"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="CYX">
+      <Atom charge="-0.51112" name="N" type="protein-N"/>
+      <Atom charge="0.3201" name="H" type="protein-H"/>
+      <Atom charge="0.03547" name="CA" type="protein-CX"/>
+      <Atom charge="0.09786" name="HA" type="protein-H1"/>
+      <Atom charge="-0.06785" name="CB" type="protein-2C"/>
+      <Atom charge="0.0983" name="HB2" type="protein-H1"/>
+      <Atom charge="0.0983" name="HB3" type="protein-H1"/>
+      <Atom charge="-0.12067" name="SG" type="protein-S"/>
+      <Atom charge="0.63952" name="C" type="protein-C"/>
+      <Atom charge="-0.58991" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="SG"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="SG"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="GLH">
+      <Atom charge="-0.51112" name="N" type="protein-N"/>
+      <Atom charge="0.3201" name="H" type="protein-H"/>
+      <Atom charge="-0.00092" name="CA" type="protein-CX"/>
+      <Atom charge="0.09432" name="HA" type="protein-H1"/>
+      <Atom charge="-0.00739" name="CB" type="protein-2C"/>
+      <Atom charge="0.04578" name="HB2" type="protein-HC"/>
+      <Atom charge="0.04578" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.12492" name="CG" type="protein-2C"/>
+      <Atom charge="0.06874" name="HG2" type="protein-HC"/>
+      <Atom charge="0.06874" name="HG3" type="protein-HC"/>
+      <Atom charge="0.59294" name="CD" type="protein-C"/>
+      <Atom charge="-0.51536" name="OE1" type="protein-O"/>
+      <Atom charge="-0.5324" name="OE2" type="protein-OH"/>
+      <Atom charge="0.4061" name="HE2" type="protein-HO"/>
+      <Atom charge="0.63952" name="C" type="protein-C"/>
+      <Atom charge="-0.58991" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="CD"/>
+      <Bond atomName1="CD" atomName2="OE1"/>
+      <Bond atomName1="CD" atomName2="OE2"/>
+      <Bond atomName1="OE2" atomName2="HE2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="GLN">
+      <Atom charge="-0.51112" name="N" type="protein-N"/>
+      <Atom charge="0.3201" name="H" type="protein-H"/>
+      <Atom charge="0.00596" name="CA" type="protein-CX"/>
+      <Atom charge="0.09225" name="HA" type="protein-H1"/>
+      <Atom charge="-0.04256" name="CB" type="protein-2C"/>
+      <Atom charge="0.05021" name="HB2" type="protein-HC"/>
+      <Atom charge="0.05021" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.14598" name="CG" type="protein-2C"/>
+      <Atom charge="0.06512" name="HG2" type="protein-HC"/>
+      <Atom charge="0.06512" name="HG3" type="protein-HC"/>
+      <Atom charge="0.71341" name="CD" type="protein-C"/>
+      <Atom charge="-0.65218" name="OE1" type="protein-OD"/>
+      <Atom charge="-0.93462" name="NE2" type="protein-ND"/>
+      <Atom charge="0.45469" name="HE21" type="protein-H"/>
+      <Atom charge="0.41978" name="HE22" type="protein-H"/>
+      <Atom charge="0.63952" name="C" type="protein-C"/>
+      <Atom charge="-0.58991" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="CD"/>
+      <Bond atomName1="CD" atomName2="OE1"/>
+      <Bond atomName1="CD" atomName2="NE2"/>
+      <Bond atomName1="NE2" atomName2="HE21"/>
+      <Bond atomName1="NE2" atomName2="HE22"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="GLU">
+      <Atom charge="-0.70584" name="N" type="protein-N"/>
+      <Atom charge="0.36907" name="H" type="protein-H"/>
+      <Atom charge="0.34563" name="CA" type="protein-TM"/>
+      <Atom charge="0.00361" name="HA" type="protein-H1"/>
+      <Atom charge="-0.00837" name="CB" type="protein-2C"/>
+      <Atom charge="0.00926" name="HB2" type="protein-HC"/>
+      <Atom charge="0.00926" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.11758" name="CG" type="protein-2C"/>
+      <Atom charge="0.01714" name="HG2" type="protein-HC"/>
+      <Atom charge="0.01714" name="HG3" type="protein-HC"/>
+      <Atom charge="0.80677" name="CD" type="protein-CO"/>
+      <Atom charge="-0.84375" name="OE1" type="protein-O3"/>
+      <Atom charge="-0.84375" name="OE2" type="protein-O3"/>
+      <Atom charge="0.57227" name="C" type="protein-C"/>
+      <Atom charge="-0.63086" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="CD"/>
+      <Bond atomName1="CD" atomName2="OE1"/>
+      <Bond atomName1="CD" atomName2="OE2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="GLY">
+      <Atom charge="-0.55472" name="N" type="protein-N"/>
+      <Atom charge="0.35974" name="H" type="protein-H"/>
+      <Atom charge="-0.06028" name="CA" type="protein-TG"/>
+      <Atom charge="0.09472" name="HA2" type="protein-H1"/>
+      <Atom charge="0.09472" name="HA3" type="protein-H1"/>
+      <Atom charge="0.69468" name="C" type="protein-C"/>
+      <Atom charge="-0.62886" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA2"/>
+      <Bond atomName1="CA" atomName2="HA3"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="HID">
+      <Atom charge="-0.51112" name="N" type="protein-N"/>
+      <Atom charge="0.3201" name="H" type="protein-H"/>
+      <Atom charge="0.04495" name="CA" type="protein-CX"/>
+      <Atom charge="0.0898" name="HA" type="protein-H1"/>
+      <Atom charge="-0.11726" name="CB" type="protein-TA"/>
+      <Atom charge="0.07181" name="HB2" type="protein-HC"/>
+      <Atom charge="0.07181" name="HB3" type="protein-HC"/>
+      <Atom charge="0.09844" name="CG" type="protein-CC"/>
+      <Atom charge="-0.35736" name="ND1" type="protein-NA"/>
+      <Atom charge="0.37921" name="HD1" type="protein-H"/>
+      <Atom charge="0.19168" name="CE1" type="protein-CR"/>
+      <Atom charge="0.13308" name="HE1" type="protein-H5"/>
+      <Atom charge="-0.62533" name="NE2" type="protein-NB"/>
+      <Atom charge="0.0153" name="CD2" type="protein-CV"/>
+      <Atom charge="0.14528" name="HD2" type="protein-H4"/>
+      <Atom charge="0.63952" name="C" type="protein-C"/>
+      <Atom charge="-0.58991" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="ND1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="ND1" atomName2="HD1"/>
+      <Bond atomName1="ND1" atomName2="CE1"/>
+      <Bond atomName1="CE1" atomName2="HE1"/>
+      <Bond atomName1="CE1" atomName2="NE2"/>
+      <Bond atomName1="NE2" atomName2="CD2"/>
+      <Bond atomName1="CD2" atomName2="HD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="HIE">
+      <Atom charge="-0.51112" name="N" type="protein-N"/>
+      <Atom charge="0.3201" name="H" type="protein-H"/>
+      <Atom charge="0.01013" name="CA" type="protein-CX"/>
+      <Atom charge="0.08867" name="HA" type="protein-H1"/>
+      <Atom charge="-0.10971" name="CB" type="protein-TA"/>
+      <Atom charge="0.06614" name="HB2" type="protein-HC"/>
+      <Atom charge="0.06614" name="HB3" type="protein-HC"/>
+      <Atom charge="0.32544" name="CG" type="protein-CC"/>
+      <Atom charge="-0.61168" name="ND1" type="protein-NB"/>
+      <Atom charge="0.10547" name="CE1" type="protein-CR"/>
+      <Atom charge="0.15078" name="HE1" type="protein-H5"/>
+      <Atom charge="-0.24062" name="NE2" type="protein-NA"/>
+      <Atom charge="0.36772" name="HE2" type="protein-H"/>
+      <Atom charge="-0.25349" name="CD2" type="protein-CW"/>
+      <Atom charge="0.17642" name="HD2" type="protein-H4"/>
+      <Atom charge="0.63952" name="C" type="protein-C"/>
+      <Atom charge="-0.58991" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="ND1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="ND1" atomName2="CE1"/>
+      <Bond atomName1="CE1" atomName2="HE1"/>
+      <Bond atomName1="CE1" atomName2="NE2"/>
+      <Bond atomName1="NE2" atomName2="HE2"/>
+      <Bond atomName1="NE2" atomName2="CD2"/>
+      <Bond atomName1="CD2" atomName2="HD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="HIP">
+      <Atom charge="-0.3908" name="N" type="protein-N"/>
+      <Atom charge="0.31584" name="H" type="protein-H"/>
+      <Atom charge="-0.33237" name="CA" type="protein-TP"/>
+      <Atom charge="0.19393" name="HA" type="protein-H1"/>
+      <Atom charge="-0.11493" name="CB" type="protein-C8"/>
+      <Atom charge="0.11792" name="HB2" type="protein-HC"/>
+      <Atom charge="0.11792" name="HB3" type="protein-HC"/>
+      <Atom charge="0.11778" name="CG" type="protein-CC"/>
+      <Atom charge="-0.21073" name="ND1" type="protein-NA"/>
+      <Atom charge="0.41031" name="HD1" type="protein-H"/>
+      <Atom charge="0.01961" name="CE1" type="protein-CR"/>
+      <Atom charge="0.22037" name="HE1" type="protein-H5"/>
+      <Atom charge="-0.18173" name="NE2" type="protein-NA"/>
+      <Atom charge="0.41205" name="HE2" type="protein-H"/>
+      <Atom charge="-0.11723" name="CD2" type="protein-CW"/>
+      <Atom charge="0.21724" name="HD2" type="protein-H4"/>
+      <Atom charge="0.8387" name="C" type="protein-C"/>
+      <Atom charge="-0.63388" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="ND1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="ND1" atomName2="HD1"/>
+      <Bond atomName1="ND1" atomName2="CE1"/>
+      <Bond atomName1="CE1" atomName2="HE1"/>
+      <Bond atomName1="CE1" atomName2="NE2"/>
+      <Bond atomName1="NE2" atomName2="HE2"/>
+      <Bond atomName1="NE2" atomName2="CD2"/>
+      <Bond atomName1="CD2" atomName2="HD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="ILE">
+      <Atom charge="-0.51112" name="N" type="protein-N"/>
+      <Atom charge="0.3201" name="H" type="protein-H"/>
+      <Atom charge="-0.10079" name="CA" type="protein-CX"/>
+      <Atom charge="0.11671" name="HA" type="protein-H1"/>
+      <Atom charge="0.12718" name="CB" type="protein-3C"/>
+      <Atom charge="0.02029" name="HB" type="protein-HC"/>
+      <Atom charge="-0.2374" name="CG2" type="protein-CT"/>
+      <Atom charge="0.06565" name="HG21" type="protein-HC"/>
+      <Atom charge="0.06565" name="HG22" type="protein-HC"/>
+      <Atom charge="0.06565" name="HG23" type="protein-HC"/>
+      <Atom charge="0.01664" name="CG1" type="protein-2C"/>
+      <Atom charge="0.01464" name="HG12" type="protein-HC"/>
+      <Atom charge="0.01464" name="HG13" type="protein-HC"/>
+      <Atom charge="-0.14646" name="CD1" type="protein-CT"/>
+      <Atom charge="0.03967" name="HD11" type="protein-HC"/>
+      <Atom charge="0.03967" name="HD12" type="protein-HC"/>
+      <Atom charge="0.03967" name="HD13" type="protein-HC"/>
+      <Atom charge="0.63952" name="C" type="protein-C"/>
+      <Atom charge="-0.58991" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB"/>
+      <Bond atomName1="CB" atomName2="CG2"/>
+      <Bond atomName1="CB" atomName2="CG1"/>
+      <Bond atomName1="CG2" atomName2="HG21"/>
+      <Bond atomName1="CG2" atomName2="HG22"/>
+      <Bond atomName1="CG2" atomName2="HG23"/>
+      <Bond atomName1="CG1" atomName2="HG12"/>
+      <Bond atomName1="CG1" atomName2="HG13"/>
+      <Bond atomName1="CG1" atomName2="CD1"/>
+      <Bond atomName1="CD1" atomName2="HD11"/>
+      <Bond atomName1="CD1" atomName2="HD12"/>
+      <Bond atomName1="CD1" atomName2="HD13"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="LEU">
+      <Atom charge="-0.51112" name="N" type="protein-N"/>
+      <Atom charge="0.3201" name="H" type="protein-H"/>
+      <Atom charge="-0.03749" name="CA" type="protein-CX"/>
+      <Atom charge="0.09578" name="HA" type="protein-H1"/>
+      <Atom charge="-0.08167" name="CB" type="protein-2C"/>
+      <Atom charge="0.04459" name="HB2" type="protein-HC"/>
+      <Atom charge="0.04459" name="HB3" type="protein-HC"/>
+      <Atom charge="0.2285" name="CG" type="protein-3C"/>
+      <Atom charge="0.00131" name="HG" type="protein-HC"/>
+      <Atom charge="-0.28977" name="CD1" type="protein-CT"/>
+      <Atom charge="0.07089" name="HD11" type="protein-HC"/>
+      <Atom charge="0.07089" name="HD12" type="protein-HC"/>
+      <Atom charge="0.07089" name="HD13" type="protein-HC"/>
+      <Atom charge="-0.28977" name="CD2" type="protein-CT"/>
+      <Atom charge="0.07089" name="HD21" type="protein-HC"/>
+      <Atom charge="0.07089" name="HD22" type="protein-HC"/>
+      <Atom charge="0.07089" name="HD23" type="protein-HC"/>
+      <Atom charge="0.63952" name="C" type="protein-C"/>
+      <Atom charge="-0.58991" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG"/>
+      <Bond atomName1="CG" atomName2="CD1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="CD1" atomName2="HD11"/>
+      <Bond atomName1="CD1" atomName2="HD12"/>
+      <Bond atomName1="CD1" atomName2="HD13"/>
+      <Bond atomName1="CD2" atomName2="HD21"/>
+      <Bond atomName1="CD2" atomName2="HD22"/>
+      <Bond atomName1="CD2" atomName2="HD23"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="LYN">
+      <Atom charge="-0.51112" name="N" type="protein-N"/>
+      <Atom charge="0.3201" name="H" type="protein-H"/>
+      <Atom charge="-0.04468" name="CA" type="protein-CX"/>
+      <Atom charge="0.1021" name="HA" type="protein-H1"/>
+      <Atom charge="-0.02592" name="CB" type="protein-2C"/>
+      <Atom charge="0.0409" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0409" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.04379" name="CG" type="protein-2C"/>
+      <Atom charge="0.03042" name="HG2" type="protein-HC"/>
+      <Atom charge="0.03042" name="HG3" type="protein-HC"/>
+      <Atom charge="-0.08662" name="CD" type="protein-2C"/>
+      <Atom charge="0.03059" name="HD2" type="protein-HC"/>
+      <Atom charge="0.03059" name="HD3" type="protein-HC"/>
+      <Atom charge="0.34331" name="CE" type="protein-2C"/>
+      <Atom charge="-0.01326" name="HE2" type="protein-HC"/>
+      <Atom charge="-0.01326" name="HE3" type="protein-HC"/>
+      <Atom charge="-1.01071" name="NZ" type="protein-N3"/>
+      <Atom charge="0.36521" name="HZ2" type="protein-H"/>
+      <Atom charge="0.36521" name="HZ3" type="protein-H"/>
+      <Atom charge="0.63952" name="C" type="protein-C"/>
+      <Atom charge="-0.58991" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="CD"/>
+      <Bond atomName1="CD" atomName2="HD2"/>
+      <Bond atomName1="CD" atomName2="HD3"/>
+      <Bond atomName1="CD" atomName2="CE"/>
+      <Bond atomName1="CE" atomName2="HE2"/>
+      <Bond atomName1="CE" atomName2="HE3"/>
+      <Bond atomName1="CE" atomName2="NZ"/>
+      <Bond atomName1="NZ" atomName2="HZ2"/>
+      <Bond atomName1="NZ" atomName2="HZ3"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="LYS">
+      <Atom charge="-0.3908" name="N" type="protein-N"/>
+      <Atom charge="0.31584" name="H" type="protein-H"/>
+      <Atom charge="-0.42095" name="CA" type="protein-TP"/>
+      <Atom charge="0.20346" name="HA" type="protein-H1"/>
+      <Atom charge="-0.11104" name="CB" type="protein-C8"/>
+      <Atom charge="0.10105" name="HB2" type="protein-HC"/>
+      <Atom charge="0.10105" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.10962" name="CG" type="protein-C8"/>
+      <Atom charge="0.07462" name="HG2" type="protein-HC"/>
+      <Atom charge="0.07462" name="HG3" type="protein-HC"/>
+      <Atom charge="-0.03747" name="CD" type="protein-C8"/>
+      <Atom charge="0.05631" name="HD2" type="protein-HC"/>
+      <Atom charge="0.05631" name="HD3" type="protein-HC"/>
+      <Atom charge="0.07491" name="CE" type="protein-C8"/>
+      <Atom charge="0.09294" name="HE2" type="protein-HP"/>
+      <Atom charge="0.09294" name="HE3" type="protein-HP"/>
+      <Atom charge="-0.56996" name="NZ" type="protein-NL"/>
+      <Atom charge="0.39699" name="HZ1" type="protein-H"/>
+      <Atom charge="0.39699" name="HZ2" type="protein-H"/>
+      <Atom charge="0.39699" name="HZ3" type="protein-H"/>
+      <Atom charge="0.8387" name="C" type="protein-C"/>
+      <Atom charge="-0.63388" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="CD"/>
+      <Bond atomName1="CD" atomName2="HD2"/>
+      <Bond atomName1="CD" atomName2="HD3"/>
+      <Bond atomName1="CD" atomName2="CE"/>
+      <Bond atomName1="CE" atomName2="HE2"/>
+      <Bond atomName1="CE" atomName2="HE3"/>
+      <Bond atomName1="CE" atomName2="NZ"/>
+      <Bond atomName1="NZ" atomName2="HZ1"/>
+      <Bond atomName1="NZ" atomName2="HZ2"/>
+      <Bond atomName1="NZ" atomName2="HZ3"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="MET">
+      <Atom charge="-0.51112" name="N" type="protein-N"/>
+      <Atom charge="0.3201" name="H" type="protein-H"/>
+      <Atom charge="-0.03103" name="CA" type="protein-CX"/>
+      <Atom charge="0.10635" name="HA" type="protein-H1"/>
+      <Atom charge="4e-05" name="CB" type="protein-2C"/>
+      <Atom charge="0.05248" name="HB2" type="protein-HC"/>
+      <Atom charge="0.05248" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.15683" name="CG" type="protein-2C"/>
+      <Atom charge="0.11147" name="HG2" type="protein-H1"/>
+      <Atom charge="0.11147" name="HG3" type="protein-H1"/>
+      <Atom charge="-0.22249" name="SD" type="protein-S"/>
+      <Atom charge="-0.21658" name="CE" type="protein-CT"/>
+      <Atom charge="0.11135" name="HE1" type="protein-H1"/>
+      <Atom charge="0.11135" name="HE2" type="protein-H1"/>
+      <Atom charge="0.11135" name="HE3" type="protein-H1"/>
+      <Atom charge="0.63952" name="C" type="protein-C"/>
+      <Atom charge="-0.58991" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="SD"/>
+      <Bond atomName1="SD" atomName2="CE"/>
+      <Bond atomName1="CE" atomName2="HE1"/>
+      <Bond atomName1="CE" atomName2="HE2"/>
+      <Bond atomName1="CE" atomName2="HE3"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="MTB">
+      <Atom charge="-0.14504" name="SG" type="protein-S"/>
+      <Atom charge="-0.12613" name="CB" type="protein-2C"/>
+      <Atom charge="0.09039" name="HB1" type="protein-H1"/>
+      <Atom charge="0.09039" name="HB2" type="protein-H1"/>
+      <Atom charge="0.09039" name="HB3" type="protein-H1"/>
+      <Bond atomName1="SG" atomName2="CB"/>
+      <Bond atomName1="CB" atomName2="HB1"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <ExternalBond atomName="SG"/>
+    </Residue>
+    <Residue name="NLE">
+      <Atom charge="-0.51112" name="N" type="protein-N"/>
+      <Atom charge="0.3201" name="H" type="protein-H"/>
+      <Atom charge="-0.04079" name="CA" type="protein-CX"/>
+      <Atom charge="0.09081" name="HA" type="protein-H1"/>
+      <Atom charge="-0.01837" name="CB" type="protein-2C"/>
+      <Atom charge="0.03482" name="HB2" type="protein-HC"/>
+      <Atom charge="0.03482" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.0275" name="CG" type="protein-2C"/>
+      <Atom charge="0.02284" name="HG2" type="protein-HC"/>
+      <Atom charge="0.02284" name="HG3" type="protein-HC"/>
+      <Atom charge="0.07349" name="CD" type="protein-2C"/>
+      <Atom charge="-0.00321" name="HD2" type="protein-HC"/>
+      <Atom charge="-0.00321" name="HD3" type="protein-HC"/>
+      <Atom charge="-0.1597" name="CE" type="protein-CT"/>
+      <Atom charge="0.03819" name="HE1" type="protein-HC"/>
+      <Atom charge="0.03819" name="HE2" type="protein-HC"/>
+      <Atom charge="0.03819" name="HE3" type="protein-HC"/>
+      <Atom charge="0.63952" name="C" type="protein-C"/>
+      <Atom charge="-0.58991" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="CD"/>
+      <Bond atomName1="CD" atomName2="HD2"/>
+      <Bond atomName1="CD" atomName2="HD3"/>
+      <Bond atomName1="CD" atomName2="CE"/>
+      <Bond atomName1="CE" atomName2="HE1"/>
+      <Bond atomName1="CE" atomName2="HE2"/>
+      <Bond atomName1="CE" atomName2="HE3"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="PHE">
+      <Atom charge="-0.51112" name="N" type="protein-N"/>
+      <Atom charge="0.3201" name="H" type="protein-H"/>
+      <Atom charge="0.01752" name="CA" type="protein-CX"/>
+      <Atom charge="0.0931" name="HA" type="protein-H1"/>
+      <Atom charge="-0.09016" name="CB" type="protein-TA"/>
+      <Atom charge="0.06224" name="HB2" type="protein-HC"/>
+      <Atom charge="0.06224" name="HB3" type="protein-HC"/>
+      <Atom charge="0.07328" name="CG" type="protein-CA"/>
+      <Atom charge="-0.16749" name="CD1" type="protein-CA"/>
+      <Atom charge="0.14146" name="HD1" type="protein-HA"/>
+      <Atom charge="-0.16359" name="CE1" type="protein-CA"/>
+      <Atom charge="0.14752" name="HE1" type="protein-HA"/>
+      <Atom charge="-0.12634" name="CZ" type="protein-CA"/>
+      <Atom charge="0.13373" name="HZ" type="protein-HA"/>
+      <Atom charge="-0.16359" name="CE2" type="protein-CA"/>
+      <Atom charge="0.14752" name="HE2" type="protein-HA"/>
+      <Atom charge="-0.16749" name="CD2" type="protein-CA"/>
+      <Atom charge="0.14146" name="HD2" type="protein-HA"/>
+      <Atom charge="0.63952" name="C" type="protein-C"/>
+      <Atom charge="-0.58991" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="CD1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="CD1" atomName2="HD1"/>
+      <Bond atomName1="CD1" atomName2="CE1"/>
+      <Bond atomName1="CE1" atomName2="HE1"/>
+      <Bond atomName1="CE1" atomName2="CZ"/>
+      <Bond atomName1="CZ" atomName2="HZ"/>
+      <Bond atomName1="CZ" atomName2="CE2"/>
+      <Bond atomName1="CE2" atomName2="HE2"/>
+      <Bond atomName1="CE2" atomName2="CD2"/>
+      <Bond atomName1="CD2" atomName2="HD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="PRO">
+      <Atom charge="-0.35181" name="N" type="protein-TN"/>
+      <Atom charge="0.04619" name="CD" type="protein-CT"/>
+      <Atom charge="0.05638" name="HD2" type="protein-H1"/>
+      <Atom charge="0.05638" name="HD3" type="protein-H1"/>
+      <Atom charge="-0.04145" name="CG" type="protein-CT"/>
+      <Atom charge="0.04628" name="HG2" type="protein-HC"/>
+      <Atom charge="0.04628" name="HG3" type="protein-HC"/>
+      <Atom charge="-0.06018" name="CB" type="protein-CT"/>
+      <Atom charge="0.05925" name="HB2" type="protein-HC"/>
+      <Atom charge="0.05925" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.08538" name="CA" type="protein-TJ"/>
+      <Atom charge="0.1044" name="HA" type="protein-H1"/>
+      <Atom charge="0.67582" name="C" type="protein-C"/>
+      <Atom charge="-0.61141" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="CD"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CD" atomName2="HD2"/>
+      <Bond atomName1="CD" atomName2="HD3"/>
+      <Bond atomName1="CD" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="CB"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="SER">
+      <Atom charge="-0.51112" name="N" type="protein-N"/>
+      <Atom charge="0.3201" name="H" type="protein-H"/>
+      <Atom charge="-0.00012" name="CA" type="protein-CX"/>
+      <Atom charge="0.09398" name="HA" type="protein-H1"/>
+      <Atom charge="0.12377" name="CB" type="protein-2C"/>
+      <Atom charge="0.05373" name="HB2" type="protein-H1"/>
+      <Atom charge="0.05373" name="HB3" type="protein-H1"/>
+      <Atom charge="-0.56858" name="OG" type="protein-OA"/>
+      <Atom charge="0.3849" name="HG" type="protein-HO"/>
+      <Atom charge="0.63952" name="C" type="protein-C"/>
+      <Atom charge="-0.58991" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="OG"/>
+      <Bond atomName1="OG" atomName2="HG"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="THR">
+      <Atom charge="-0.51112" name="N" type="protein-N"/>
+      <Atom charge="0.3201" name="H" type="protein-H"/>
+      <Atom charge="0.01035" name="CA" type="protein-CX"/>
+      <Atom charge="0.08532" name="HA" type="protein-H1"/>
+      <Atom charge="0.20161" name="CB" type="protein-3C"/>
+      <Atom charge="0.05224" name="HB" type="protein-H1"/>
+      <Atom charge="-0.2416" name="CG2" type="protein-CT"/>
+      <Atom charge="0.07861" name="HG21" type="protein-HC"/>
+      <Atom charge="0.07861" name="HG22" type="protein-HC"/>
+      <Atom charge="0.07861" name="HG23" type="protein-HC"/>
+      <Atom charge="-0.57965" name="OG1" type="protein-OA"/>
+      <Atom charge="0.37731" name="HG1" type="protein-HO"/>
+      <Atom charge="0.63952" name="C" type="protein-C"/>
+      <Atom charge="-0.58991" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB"/>
+      <Bond atomName1="CB" atomName2="CG2"/>
+      <Bond atomName1="CB" atomName2="OG1"/>
+      <Bond atomName1="CG2" atomName2="HG21"/>
+      <Bond atomName1="CG2" atomName2="HG22"/>
+      <Bond atomName1="CG2" atomName2="HG23"/>
+      <Bond atomName1="OG1" atomName2="HG1"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="TRP">
+      <Atom charge="-0.51112" name="N" type="protein-N"/>
+      <Atom charge="0.3201" name="H" type="protein-H"/>
+      <Atom charge="-0.01666" name="CA" type="protein-CX"/>
+      <Atom charge="0.10372" name="HA" type="protein-H1"/>
+      <Atom charge="-0.06181" name="CB" type="protein-TA"/>
+      <Atom charge="0.07351" name="HB2" type="protein-HC"/>
+      <Atom charge="0.07351" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.14967" name="CG" type="protein-C*"/>
+      <Atom charge="-0.08613" name="CD1" type="protein-CW"/>
+      <Atom charge="0.17345" name="HD1" type="protein-H4"/>
+      <Atom charge="-0.46227" name="NE1" type="protein-NA"/>
+      <Atom charge="0.40212" name="HE1" type="protein-H"/>
+      <Atom charge="0.24827" name="CE2" type="protein-CN"/>
+      <Atom charge="-0.29494" name="CZ2" type="protein-CA"/>
+      <Atom charge="0.16633" name="HZ2" type="protein-HA"/>
+      <Atom charge="-0.16017" name="CH2" type="protein-CA"/>
+      <Atom charge="0.15706" name="HH2" type="protein-HA"/>
+      <Atom charge="-0.19582" name="CZ3" type="protein-CA"/>
+      <Atom charge="0.15158" name="HZ3" type="protein-HA"/>
+      <Atom charge="-0.26689" name="CE3" type="protein-CA"/>
+      <Atom charge="0.172" name="HE3" type="protein-HA"/>
+      <Atom charge="0.11422" name="CD2" type="protein-CB"/>
+      <Atom charge="0.63952" name="C" type="protein-C"/>
+      <Atom charge="-0.58991" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="CD1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="CD1" atomName2="HD1"/>
+      <Bond atomName1="CD1" atomName2="NE1"/>
+      <Bond atomName1="NE1" atomName2="HE1"/>
+      <Bond atomName1="NE1" atomName2="CE2"/>
+      <Bond atomName1="CE2" atomName2="CZ2"/>
+      <Bond atomName1="CE2" atomName2="CD2"/>
+      <Bond atomName1="CZ2" atomName2="HZ2"/>
+      <Bond atomName1="CZ2" atomName2="CH2"/>
+      <Bond atomName1="CH2" atomName2="HH2"/>
+      <Bond atomName1="CH2" atomName2="CZ3"/>
+      <Bond atomName1="CZ3" atomName2="HZ3"/>
+      <Bond atomName1="CZ3" atomName2="CE3"/>
+      <Bond atomName1="CE3" atomName2="HE3"/>
+      <Bond atomName1="CE3" atomName2="CD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="TYR">
+      <Atom charge="-0.51112" name="N" type="protein-N"/>
+      <Atom charge="0.3201" name="H" type="protein-H"/>
+      <Atom charge="0.00087" name="CA" type="protein-CX"/>
+      <Atom charge="0.09398" name="HA" type="protein-H1"/>
+      <Atom charge="-0.08145" name="CB" type="protein-TA"/>
+      <Atom charge="0.06108" name="HB2" type="protein-HC"/>
+      <Atom charge="0.06108" name="HB3" type="protein-HC"/>
+      <Atom charge="0.08621" name="CG" type="protein-CA"/>
+      <Atom charge="-0.21395" name="CD1" type="protein-CA"/>
+      <Atom charge="0.16867" name="HD1" type="protein-HA"/>
+      <Atom charge="-0.29415" name="CE1" type="protein-CA"/>
+      <Atom charge="0.18565" name="HE1" type="protein-HA"/>
+      <Atom charge="0.38943" name="CZ" type="protein-C"/>
+      <Atom charge="-0.5524" name="OH" type="protein-OA"/>
+      <Atom charge="0.39017" name="HH" type="protein-HO"/>
+      <Atom charge="-0.29415" name="CE2" type="protein-CA"/>
+      <Atom charge="0.18565" name="HE2" type="protein-HA"/>
+      <Atom charge="-0.21395" name="CD2" type="protein-CA"/>
+      <Atom charge="0.16867" name="HD2" type="protein-HA"/>
+      <Atom charge="0.63952" name="C" type="protein-C"/>
+      <Atom charge="-0.58991" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="CD1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="CD1" atomName2="HD1"/>
+      <Bond atomName1="CD1" atomName2="CE1"/>
+      <Bond atomName1="CE1" atomName2="HE1"/>
+      <Bond atomName1="CE1" atomName2="CZ"/>
+      <Bond atomName1="CZ" atomName2="OH"/>
+      <Bond atomName1="CZ" atomName2="CE2"/>
+      <Bond atomName1="OH" atomName2="HH"/>
+      <Bond atomName1="CE2" atomName2="HE2"/>
+      <Bond atomName1="CE2" atomName2="CD2"/>
+      <Bond atomName1="CD2" atomName2="HD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="VAL">
+      <Atom charge="-0.51112" name="N" type="protein-N"/>
+      <Atom charge="0.3201" name="H" type="protein-H"/>
+      <Atom charge="-0.0939" name="CA" type="protein-CX"/>
+      <Atom charge="0.1119" name="HA" type="protein-H1"/>
+      <Atom charge="0.20616" name="CB" type="protein-3C"/>
+      <Atom charge="0.02749" name="HB" type="protein-HC"/>
+      <Atom charge="-0.3055" name="CG1" type="protein-CT"/>
+      <Atom charge="0.08346" name="HG11" type="protein-HC"/>
+      <Atom charge="0.08346" name="HG12" type="protein-HC"/>
+      <Atom charge="0.08346" name="HG13" type="protein-HC"/>
+      <Atom charge="-0.3055" name="CG2" type="protein-CT"/>
+      <Atom charge="0.08346" name="HG21" type="protein-HC"/>
+      <Atom charge="0.08346" name="HG22" type="protein-HC"/>
+      <Atom charge="0.08346" name="HG23" type="protein-HC"/>
+      <Atom charge="0.63952" name="C" type="protein-C"/>
+      <Atom charge="-0.58991" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB"/>
+      <Bond atomName1="CB" atomName2="CG1"/>
+      <Bond atomName1="CB" atomName2="CG2"/>
+      <Bond atomName1="CG1" atomName2="HG11"/>
+      <Bond atomName1="CG1" atomName2="HG12"/>
+      <Bond atomName1="CG1" atomName2="HG13"/>
+      <Bond atomName1="CG2" atomName2="HG21"/>
+      <Bond atomName1="CG2" atomName2="HG22"/>
+      <Bond atomName1="CG2" atomName2="HG23"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="CALA">
+      <Atom charge="-0.74668" name="N" type="protein-N"/>
+      <Atom charge="0.37486" name="H" type="protein-H"/>
+      <Atom charge="0.29792" name="CA" type="protein-CX"/>
+      <Atom charge="-0.01563" name="HA" type="protein-H1"/>
+      <Atom charge="-0.18128" name="CB" type="protein-CT"/>
+      <Atom charge="0.04532" name="HB1" type="protein-HC"/>
+      <Atom charge="0.04532" name="HB2" type="protein-HC"/>
+      <Atom charge="0.04532" name="HB3" type="protein-HC"/>
+      <Atom charge="0.75823" name="C" type="protein-CO"/>
+      <Atom charge="-0.81169" name="O" type="protein-O3"/>
+      <Atom charge="-0.81169" name="OXT" type="protein-O3"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB1"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CARG">
+      <Atom charge="-0.64105" name="N" type="protein-N"/>
+      <Atom charge="0.35488" name="H" type="protein-H"/>
+      <Atom charge="0.06866" name="CA" type="protein-TP"/>
+      <Atom charge="0.07475" name="HA" type="protein-H1"/>
+      <Atom charge="-0.08607" name="CB" type="protein-C8"/>
+      <Atom charge="0.03747" name="HB2" type="protein-HC"/>
+      <Atom charge="0.03747" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.01181" name="CG" type="protein-C8"/>
+      <Atom charge="0.02632" name="HG2" type="protein-HC"/>
+      <Atom charge="0.02632" name="HG3" type="protein-HC"/>
+      <Atom charge="0.19254" name="CD" type="protein-C8"/>
+      <Atom charge="0.04767" name="HD2" type="protein-H1"/>
+      <Atom charge="0.04767" name="HD3" type="protein-H1"/>
+      <Atom charge="-0.63781" name="NE" type="protein-N2"/>
+      <Atom charge="0.39629" name="HE" type="protein-TH"/>
+      <Atom charge="0.7736" name="CZ" type="protein-CA"/>
+      <Atom charge="-0.84909" name="NH1" type="protein-N2"/>
+      <Atom charge="0.44406" name="HH11" type="protein-TH"/>
+      <Atom charge="0.44406" name="HH12" type="protein-TH"/>
+      <Atom charge="-0.84909" name="NH2" type="protein-N2"/>
+      <Atom charge="0.44406" name="HH21" type="protein-TH"/>
+      <Atom charge="0.44406" name="HH22" type="protein-TH"/>
+      <Atom charge="0.85422" name="C" type="protein-CO"/>
+      <Atom charge="-0.81959" name="O" type="protein-O3"/>
+      <Atom charge="-0.81959" name="OXT" type="protein-O3"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="CD"/>
+      <Bond atomName1="CD" atomName2="HD2"/>
+      <Bond atomName1="CD" atomName2="HD3"/>
+      <Bond atomName1="CD" atomName2="NE"/>
+      <Bond atomName1="NE" atomName2="HE"/>
+      <Bond atomName1="NE" atomName2="CZ"/>
+      <Bond atomName1="CZ" atomName2="NH1"/>
+      <Bond atomName1="CZ" atomName2="NH2"/>
+      <Bond atomName1="NH1" atomName2="HH11"/>
+      <Bond atomName1="NH1" atomName2="HH12"/>
+      <Bond atomName1="NH2" atomName2="HH21"/>
+      <Bond atomName1="NH2" atomName2="HH22"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CASH">
+      <Atom charge="-0.74668" name="N" type="protein-N"/>
+      <Atom charge="0.37486" name="H" type="protein-H"/>
+      <Atom charge="0.36397" name="CA" type="protein-CX"/>
+      <Atom charge="-0.0108" name="HA" type="protein-H1"/>
+      <Atom charge="-0.16493" name="CB" type="protein-2C"/>
+      <Atom charge="0.06085" name="HB2" type="protein-HC"/>
+      <Atom charge="0.06085" name="HB3" type="protein-HC"/>
+      <Atom charge="0.61304" name="CG" type="protein-C"/>
+      <Atom charge="-0.55431" name="OD1" type="protein-O"/>
+      <Atom charge="-0.5455" name="OD2" type="protein-OH"/>
+      <Atom charge="0.4138" name="HD1" type="protein-HO"/>
+      <Atom charge="0.75823" name="C" type="protein-CO"/>
+      <Atom charge="-0.81169" name="O" type="protein-O3"/>
+      <Atom charge="-0.81169" name="OXT" type="protein-O3"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="OD1"/>
+      <Bond atomName1="CG" atomName2="OD2"/>
+      <Bond atomName1="OD2" atomName2="HD1"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CASN">
+      <Atom charge="-0.74668" name="N" type="protein-N"/>
+      <Atom charge="0.37486" name="H" type="protein-H"/>
+      <Atom charge="0.32941" name="CA" type="protein-CX"/>
+      <Atom charge="0.01485" name="HA" type="protein-H1"/>
+      <Atom charge="-0.16997" name="CB" type="protein-2C"/>
+      <Atom charge="0.04656" name="HB2" type="protein-HC"/>
+      <Atom charge="0.04656" name="HB3" type="protein-HC"/>
+      <Atom charge="0.66875" name="CG" type="protein-C"/>
+      <Atom charge="-0.61807" name="OD1" type="protein-OD"/>
+      <Atom charge="-0.93688" name="ND2" type="protein-ND"/>
+      <Atom charge="0.44446" name="HD21" type="protein-H"/>
+      <Atom charge="0.4113" name="HD22" type="protein-H"/>
+      <Atom charge="0.75823" name="C" type="protein-CO"/>
+      <Atom charge="-0.81169" name="O" type="protein-O3"/>
+      <Atom charge="-0.81169" name="OXT" type="protein-O3"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="OD1"/>
+      <Bond atomName1="CG" atomName2="ND2"/>
+      <Bond atomName1="ND2" atomName2="HD21"/>
+      <Bond atomName1="ND2" atomName2="HD22"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CASP">
+      <Atom charge="-0.88855" name="N" type="protein-N"/>
+      <Atom charge="0.38566" name="H" type="protein-H"/>
+      <Atom charge="0.57052" name="CA" type="protein-TM"/>
+      <Atom charge="-0.05917" name="HA" type="protein-H1"/>
+      <Atom charge="-0.20865" name="CB" type="protein-2C"/>
+      <Atom charge="0.01254" name="HB2" type="protein-HC"/>
+      <Atom charge="0.01254" name="HB3" type="protein-HC"/>
+      <Atom charge="0.77865" name="CG" type="protein-CO"/>
+      <Atom charge="-0.83313" name="OD1" type="protein-O3"/>
+      <Atom charge="-0.83313" name="OD2" type="protein-O3"/>
+      <Atom charge="0.69002" name="C" type="protein-CO"/>
+      <Atom charge="-0.81365" name="O" type="protein-O3"/>
+      <Atom charge="-0.81365" name="OXT" type="protein-O3"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="OD1"/>
+      <Bond atomName1="CG" atomName2="OD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CCYM">
+      <Atom charge="-0.88855" name="N" type="protein-N"/>
+      <Atom charge="0.38566" name="H" type="protein-H"/>
+      <Atom charge="0.49737" name="CA" type="protein-TM"/>
+      <Atom charge="-0.09211" name="HA" type="protein-H1"/>
+      <Atom charge="0.32515" name="CB" type="protein-2C"/>
+      <Atom charge="-0.06626" name="HB2" type="protein-H1"/>
+      <Atom charge="-0.06626" name="HB3" type="protein-H1"/>
+      <Atom charge="-1.15772" name="SG" type="protein-SH"/>
+      <Atom charge="0.69002" name="C" type="protein-CO"/>
+      <Atom charge="-0.81365" name="O" type="protein-O3"/>
+      <Atom charge="-0.81365" name="OXT" type="protein-O3"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="SG"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CCYS">
+      <Atom charge="-0.74668" name="N" type="protein-N"/>
+      <Atom charge="0.37486" name="H" type="protein-H"/>
+      <Atom charge="0.34587" name="CA" type="protein-CX"/>
+      <Atom charge="0.01124" name="HA" type="protein-H1"/>
+      <Atom charge="-0.10495" name="CB" type="protein-2C"/>
+      <Atom charge="0.08031" name="HB2" type="protein-H1"/>
+      <Atom charge="0.08031" name="HB3" type="protein-H1"/>
+      <Atom charge="-0.37231" name="SG" type="protein-SH"/>
+      <Atom charge="0.1965" name="HG" type="protein-HS"/>
+      <Atom charge="0.75823" name="C" type="protein-CO"/>
+      <Atom charge="-0.81169" name="O" type="protein-O3"/>
+      <Atom charge="-0.81169" name="OXT" type="protein-O3"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="SG"/>
+      <Bond atomName1="SG" atomName2="HG"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CCYX">
+      <Atom charge="-0.74668" name="N" type="protein-N"/>
+      <Atom charge="0.37486" name="H" type="protein-H"/>
+      <Atom charge="0.36185" name="CA" type="protein-CX"/>
+      <Atom charge="-0.00831" name="HA" type="protein-H1"/>
+      <Atom charge="-0.09676" name="CB" type="protein-2C"/>
+      <Atom charge="0.07884" name="HB2" type="protein-H1"/>
+      <Atom charge="0.07884" name="HB3" type="protein-H1"/>
+      <Atom charge="-0.17749" name="SG" type="protein-S"/>
+      <Atom charge="0.75823" name="C" type="protein-CO"/>
+      <Atom charge="-0.81169" name="O" type="protein-O3"/>
+      <Atom charge="-0.81169" name="OXT" type="protein-O3"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="SG"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="SG"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CGLH">
+      <Atom charge="-0.74668" name="N" type="protein-N"/>
+      <Atom charge="0.37486" name="H" type="protein-H"/>
+      <Atom charge="0.3131" name="CA" type="protein-CX"/>
+      <Atom charge="-0.00019" name="HA" type="protein-H1"/>
+      <Atom charge="-0.0685" name="CB" type="protein-2C"/>
+      <Atom charge="0.02808" name="HB2" type="protein-HC"/>
+      <Atom charge="0.02808" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.11145" name="CG" type="protein-2C"/>
+      <Atom charge="0.06094" name="HG2" type="protein-HC"/>
+      <Atom charge="0.06094" name="HG3" type="protein-HC"/>
+      <Atom charge="0.6033" name="CD" type="protein-C"/>
+      <Atom charge="-0.54267" name="OE1" type="protein-O"/>
+      <Atom charge="-0.5401" name="OE2" type="protein-OH"/>
+      <Atom charge="0.40544" name="HE2" type="protein-HO"/>
+      <Atom charge="0.75823" name="C" type="protein-CO"/>
+      <Atom charge="-0.81169" name="O" type="protein-O3"/>
+      <Atom charge="-0.81169" name="OXT" type="protein-O3"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="CD"/>
+      <Bond atomName1="CD" atomName2="OE1"/>
+      <Bond atomName1="CD" atomName2="OE2"/>
+      <Bond atomName1="OE2" atomName2="HE2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CGLN">
+      <Atom charge="-0.74668" name="N" type="protein-N"/>
+      <Atom charge="0.37486" name="H" type="protein-H"/>
+      <Atom charge="0.27269" name="CA" type="protein-CX"/>
+      <Atom charge="0.02646" name="HA" type="protein-H1"/>
+      <Atom charge="-0.07248" name="CB" type="protein-2C"/>
+      <Atom charge="0.04016" name="HB2" type="protein-HC"/>
+      <Atom charge="0.04016" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.12201" name="CG" type="protein-2C"/>
+      <Atom charge="0.04893" name="HG2" type="protein-HC"/>
+      <Atom charge="0.04893" name="HG3" type="protein-HC"/>
+      <Atom charge="0.6567" name="CD" type="protein-C"/>
+      <Atom charge="-0.63641" name="OE1" type="protein-OD"/>
+      <Atom charge="-0.88906" name="NE2" type="protein-ND"/>
+      <Atom charge="0.42983" name="HE21" type="protein-H"/>
+      <Atom charge="0.39307" name="HE22" type="protein-H"/>
+      <Atom charge="0.75823" name="C" type="protein-CO"/>
+      <Atom charge="-0.81169" name="O" type="protein-O3"/>
+      <Atom charge="-0.81169" name="OXT" type="protein-O3"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="CD"/>
+      <Bond atomName1="CD" atomName2="OE1"/>
+      <Bond atomName1="CD" atomName2="NE2"/>
+      <Bond atomName1="NE2" atomName2="HE21"/>
+      <Bond atomName1="NE2" atomName2="HE22"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CGLU">
+      <Atom charge="-0.88855" name="N" type="protein-N"/>
+      <Atom charge="0.38566" name="H" type="protein-H"/>
+      <Atom charge="0.53062" name="CA" type="protein-TM"/>
+      <Atom charge="-0.0591" name="HA" type="protein-H1"/>
+      <Atom charge="0.01319" name="CB" type="protein-2C"/>
+      <Atom charge="-0.01557" name="HB2" type="protein-HC"/>
+      <Atom charge="-0.01557" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.144" name="CG" type="protein-2C"/>
+      <Atom charge="4e-05" name="HG2" type="protein-HC"/>
+      <Atom charge="4e-05" name="HG3" type="protein-HC"/>
+      <Atom charge="0.9041" name="CD" type="protein-CO"/>
+      <Atom charge="-0.88679" name="OE1" type="protein-O3"/>
+      <Atom charge="-0.88679" name="OE2" type="protein-O3"/>
+      <Atom charge="0.69002" name="C" type="protein-CO"/>
+      <Atom charge="-0.81365" name="O" type="protein-O3"/>
+      <Atom charge="-0.81365" name="OXT" type="protein-O3"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="CD"/>
+      <Bond atomName1="CD" atomName2="OE1"/>
+      <Bond atomName1="CD" atomName2="OE2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CGLY">
+      <Atom charge="-0.68544" name="N" type="protein-N"/>
+      <Atom charge="0.36253" name="H" type="protein-H"/>
+      <Atom charge="0.09536" name="CA" type="protein-TG"/>
+      <Atom charge="0.03088" name="HA2" type="protein-H1"/>
+      <Atom charge="0.03088" name="HA3" type="protein-H1"/>
+      <Atom charge="0.84935" name="C" type="protein-CO"/>
+      <Atom charge="-0.84178" name="O" type="protein-O3"/>
+      <Atom charge="-0.84178" name="OXT" type="protein-O3"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA2"/>
+      <Bond atomName1="CA" atomName2="HA3"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CHID">
+      <Atom charge="-0.74668" name="N" type="protein-N"/>
+      <Atom charge="0.37486" name="H" type="protein-H"/>
+      <Atom charge="0.34684" name="CA" type="protein-CX"/>
+      <Atom charge="0.00586" name="HA" type="protein-H1"/>
+      <Atom charge="-0.15541" name="CB" type="protein-TA"/>
+      <Atom charge="0.0436" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0436" name="HB3" type="protein-HC"/>
+      <Atom charge="0.11292" name="CG" type="protein-CC"/>
+      <Atom charge="-0.3423" name="ND1" type="protein-NA"/>
+      <Atom charge="0.36875" name="HD1" type="protein-H"/>
+      <Atom charge="0.16555" name="CE1" type="protein-CR"/>
+      <Atom charge="0.12674" name="HE1" type="protein-H5"/>
+      <Atom charge="-0.63855" name="NE2" type="protein-NB"/>
+      <Atom charge="0.02318" name="CD2" type="protein-CV"/>
+      <Atom charge="0.13619" name="HD2" type="protein-H4"/>
+      <Atom charge="0.75823" name="C" type="protein-CO"/>
+      <Atom charge="-0.81169" name="O" type="protein-O3"/>
+      <Atom charge="-0.81169" name="OXT" type="protein-O3"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="ND1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="ND1" atomName2="HD1"/>
+      <Bond atomName1="ND1" atomName2="CE1"/>
+      <Bond atomName1="CE1" atomName2="HE1"/>
+      <Bond atomName1="CE1" atomName2="NE2"/>
+      <Bond atomName1="NE2" atomName2="CD2"/>
+      <Bond atomName1="CD2" atomName2="HD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CHIE">
+      <Atom charge="-0.74668" name="N" type="protein-N"/>
+      <Atom charge="0.37486" name="H" type="protein-H"/>
+      <Atom charge="0.31047" name="CA" type="protein-CX"/>
+      <Atom charge="0.01525" name="HA" type="protein-H1"/>
+      <Atom charge="-0.17163" name="CB" type="protein-TA"/>
+      <Atom charge="0.04436" name="HB2" type="protein-HC"/>
+      <Atom charge="0.04436" name="HB3" type="protein-HC"/>
+      <Atom charge="0.38429" name="CG" type="protein-CC"/>
+      <Atom charge="-0.60136" name="ND1" type="protein-NB"/>
+      <Atom charge="0.08553" name="CE1" type="protein-CR"/>
+      <Atom charge="0.13624" name="HE1" type="protein-H5"/>
+      <Atom charge="-0.22972" name="NE2" type="protein-NA"/>
+      <Atom charge="0.3472" name="HE2" type="protein-H"/>
+      <Atom charge="-0.31378" name="CD2" type="protein-CW"/>
+      <Atom charge="0.18576" name="HD2" type="protein-H4"/>
+      <Atom charge="0.75823" name="C" type="protein-CO"/>
+      <Atom charge="-0.81169" name="O" type="protein-O3"/>
+      <Atom charge="-0.81169" name="OXT" type="protein-O3"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="ND1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="ND1" atomName2="CE1"/>
+      <Bond atomName1="CE1" atomName2="HE1"/>
+      <Bond atomName1="CE1" atomName2="NE2"/>
+      <Bond atomName1="NE2" atomName2="HE2"/>
+      <Bond atomName1="NE2" atomName2="CD2"/>
+      <Bond atomName1="CD2" atomName2="HD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CHIP">
+      <Atom charge="-0.64105" name="N" type="protein-N"/>
+      <Atom charge="0.35488" name="H" type="protein-H"/>
+      <Atom charge="0.17779" name="CA" type="protein-TP"/>
+      <Atom charge="0.05782" name="HA" type="protein-H1"/>
+      <Atom charge="-0.18367" name="CB" type="protein-C8"/>
+      <Atom charge="0.10205" name="HB2" type="protein-HC"/>
+      <Atom charge="0.10205" name="HB3" type="protein-HC"/>
+      <Atom charge="0.09697" name="CG" type="protein-CC"/>
+      <Atom charge="-0.20953" name="ND1" type="protein-NA"/>
+      <Atom charge="0.40107" name="HD1" type="protein-H"/>
+      <Atom charge="0.02601" name="CE1" type="protein-CR"/>
+      <Atom charge="0.20803" name="HE1" type="protein-H5"/>
+      <Atom charge="-0.21692" name="NE2" type="protein-NA"/>
+      <Atom charge="0.40807" name="HE2" type="protein-H"/>
+      <Atom charge="-0.10478" name="CD2" type="protein-CW"/>
+      <Atom charge="0.20617" name="HD2" type="protein-H4"/>
+      <Atom charge="0.85422" name="C" type="protein-CO"/>
+      <Atom charge="-0.81959" name="O" type="protein-O3"/>
+      <Atom charge="-0.81959" name="OXT" type="protein-O3"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="ND1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="ND1" atomName2="HD1"/>
+      <Bond atomName1="ND1" atomName2="CE1"/>
+      <Bond atomName1="CE1" atomName2="HE1"/>
+      <Bond atomName1="CE1" atomName2="NE2"/>
+      <Bond atomName1="NE2" atomName2="HE2"/>
+      <Bond atomName1="NE2" atomName2="CD2"/>
+      <Bond atomName1="CD2" atomName2="HD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CILE">
+      <Atom charge="-0.74668" name="N" type="protein-N"/>
+      <Atom charge="0.37486" name="H" type="protein-H"/>
+      <Atom charge="0.23853" name="CA" type="protein-CX"/>
+      <Atom charge="0.02293" name="HA" type="protein-H1"/>
+      <Atom charge="0.03868" name="CB" type="protein-3C"/>
+      <Atom charge="0.0195" name="HB" type="protein-HC"/>
+      <Atom charge="-0.29405" name="CG2" type="protein-CT"/>
+      <Atom charge="0.07297" name="HG21" type="protein-HC"/>
+      <Atom charge="0.07297" name="HG22" type="protein-HC"/>
+      <Atom charge="0.07297" name="HG23" type="protein-HC"/>
+      <Atom charge="0.05173" name="CG1" type="protein-2C"/>
+      <Atom charge="-0.00325" name="HG12" type="protein-HC"/>
+      <Atom charge="-0.00325" name="HG13" type="protein-HC"/>
+      <Atom charge="-0.12542" name="CD1" type="protein-CT"/>
+      <Atom charge="0.02422" name="HD11" type="protein-HC"/>
+      <Atom charge="0.02422" name="HD12" type="protein-HC"/>
+      <Atom charge="0.02422" name="HD13" type="protein-HC"/>
+      <Atom charge="0.75823" name="C" type="protein-CO"/>
+      <Atom charge="-0.81169" name="O" type="protein-O3"/>
+      <Atom charge="-0.81169" name="OXT" type="protein-O3"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB"/>
+      <Bond atomName1="CB" atomName2="CG2"/>
+      <Bond atomName1="CB" atomName2="CG1"/>
+      <Bond atomName1="CG2" atomName2="HG21"/>
+      <Bond atomName1="CG2" atomName2="HG22"/>
+      <Bond atomName1="CG2" atomName2="HG23"/>
+      <Bond atomName1="CG1" atomName2="HG12"/>
+      <Bond atomName1="CG1" atomName2="HG13"/>
+      <Bond atomName1="CG1" atomName2="CD1"/>
+      <Bond atomName1="CD1" atomName2="HD11"/>
+      <Bond atomName1="CD1" atomName2="HD12"/>
+      <Bond atomName1="CD1" atomName2="HD13"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CLEU">
+      <Atom charge="-0.74668" name="N" type="protein-N"/>
+      <Atom charge="0.37486" name="H" type="protein-H"/>
+      <Atom charge="0.25731" name="CA" type="protein-CX"/>
+      <Atom charge="0.0213" name="HA" type="protein-H1"/>
+      <Atom charge="-0.12052" name="CB" type="protein-2C"/>
+      <Atom charge="0.02334" name="HB2" type="protein-HC"/>
+      <Atom charge="0.02334" name="HB3" type="protein-HC"/>
+      <Atom charge="0.25569" name="CG" type="protein-3C"/>
+      <Atom charge="-0.01341" name="HG" type="protein-HC"/>
+      <Atom charge="-0.26758" name="CD1" type="protein-CT"/>
+      <Atom charge="0.05418" name="HD11" type="protein-HC"/>
+      <Atom charge="0.05418" name="HD12" type="protein-HC"/>
+      <Atom charge="0.05418" name="HD13" type="protein-HC"/>
+      <Atom charge="-0.26758" name="CD2" type="protein-CT"/>
+      <Atom charge="0.05418" name="HD21" type="protein-HC"/>
+      <Atom charge="0.05418" name="HD22" type="protein-HC"/>
+      <Atom charge="0.05418" name="HD23" type="protein-HC"/>
+      <Atom charge="0.75823" name="C" type="protein-CO"/>
+      <Atom charge="-0.81169" name="O" type="protein-O3"/>
+      <Atom charge="-0.81169" name="OXT" type="protein-O3"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG"/>
+      <Bond atomName1="CG" atomName2="CD1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="CD1" atomName2="HD11"/>
+      <Bond atomName1="CD1" atomName2="HD12"/>
+      <Bond atomName1="CD1" atomName2="HD13"/>
+      <Bond atomName1="CD2" atomName2="HD21"/>
+      <Bond atomName1="CD2" atomName2="HD22"/>
+      <Bond atomName1="CD2" atomName2="HD23"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CLYN">
+      <Atom charge="-0.74668" name="N" type="protein-N"/>
+      <Atom charge="0.37486" name="H" type="protein-H"/>
+      <Atom charge="0.28573" name="CA" type="protein-CX"/>
+      <Atom charge="-0.00064" name="HA" type="protein-H1"/>
+      <Atom charge="-0.14981" name="CB" type="protein-2C"/>
+      <Atom charge="0.04224" name="HB2" type="protein-HC"/>
+      <Atom charge="0.04224" name="HB3" type="protein-HC"/>
+      <Atom charge="0.0431" name="CG" type="protein-2C"/>
+      <Atom charge="0.00501" name="HG2" type="protein-HC"/>
+      <Atom charge="0.00501" name="HG3" type="protein-HC"/>
+      <Atom charge="-0.0935" name="CD" type="protein-2C"/>
+      <Atom charge="0.02565" name="HD2" type="protein-HC"/>
+      <Atom charge="0.02565" name="HD3" type="protein-HC"/>
+      <Atom charge="0.31815" name="CE" type="protein-2C"/>
+      <Atom charge="-0.01422" name="HE2" type="protein-HC"/>
+      <Atom charge="-0.01422" name="HE3" type="protein-HC"/>
+      <Atom charge="-1.01418" name="NZ" type="protein-N3"/>
+      <Atom charge="0.36538" name="HZ2" type="protein-H"/>
+      <Atom charge="0.36538" name="HZ3" type="protein-H"/>
+      <Atom charge="0.75823" name="C" type="protein-CO"/>
+      <Atom charge="-0.81169" name="O" type="protein-O3"/>
+      <Atom charge="-0.81169" name="OXT" type="protein-O3"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="CD"/>
+      <Bond atomName1="CD" atomName2="HD2"/>
+      <Bond atomName1="CD" atomName2="HD3"/>
+      <Bond atomName1="CD" atomName2="CE"/>
+      <Bond atomName1="CE" atomName2="HE2"/>
+      <Bond atomName1="CE" atomName2="HE3"/>
+      <Bond atomName1="CE" atomName2="NZ"/>
+      <Bond atomName1="NZ" atomName2="HZ2"/>
+      <Bond atomName1="NZ" atomName2="HZ3"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CLYS">
+      <Atom charge="-0.64105" name="N" type="protein-N"/>
+      <Atom charge="0.35488" name="H" type="protein-H"/>
+      <Atom charge="0.0548" name="CA" type="protein-TP"/>
+      <Atom charge="0.0733" name="HA" type="protein-H1"/>
+      <Atom charge="-0.12611" name="CB" type="protein-C8"/>
+      <Atom charge="0.04989" name="HB2" type="protein-HC"/>
+      <Atom charge="0.04989" name="HB3" type="protein-HC"/>
+      <Atom charge="0.01562" name="CG" type="protein-C8"/>
+      <Atom charge="0.02232" name="HG2" type="protein-HC"/>
+      <Atom charge="0.02232" name="HG3" type="protein-HC"/>
+      <Atom charge="-0.04107" name="CD" type="protein-C8"/>
+      <Atom charge="0.04925" name="HD2" type="protein-HC"/>
+      <Atom charge="0.04925" name="HD3" type="protein-HC"/>
+      <Atom charge="0.03253" name="CE" type="protein-C8"/>
+      <Atom charge="0.10238" name="HE2" type="protein-HP"/>
+      <Atom charge="0.10238" name="HE3" type="protein-HP"/>
+      <Atom charge="-0.5999" name="NZ" type="protein-NL"/>
+      <Atom charge="0.40476" name="HZ1" type="protein-H"/>
+      <Atom charge="0.40476" name="HZ2" type="protein-H"/>
+      <Atom charge="0.40476" name="HZ3" type="protein-H"/>
+      <Atom charge="0.85422" name="C" type="protein-CO"/>
+      <Atom charge="-0.81959" name="O" type="protein-O3"/>
+      <Atom charge="-0.81959" name="OXT" type="protein-O3"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="CD"/>
+      <Bond atomName1="CD" atomName2="HD2"/>
+      <Bond atomName1="CD" atomName2="HD3"/>
+      <Bond atomName1="CD" atomName2="CE"/>
+      <Bond atomName1="CE" atomName2="HE2"/>
+      <Bond atomName1="CE" atomName2="HE3"/>
+      <Bond atomName1="CE" atomName2="NZ"/>
+      <Bond atomName1="NZ" atomName2="HZ1"/>
+      <Bond atomName1="NZ" atomName2="HZ2"/>
+      <Bond atomName1="NZ" atomName2="HZ3"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CMET">
+      <Atom charge="-0.74668" name="N" type="protein-N"/>
+      <Atom charge="0.37486" name="H" type="protein-H"/>
+      <Atom charge="0.27366" name="CA" type="protein-CX"/>
+      <Atom charge="0.01571" name="HA" type="protein-H1"/>
+      <Atom charge="-0.02484" name="CB" type="protein-2C"/>
+      <Atom charge="0.02296" name="HB2" type="protein-HC"/>
+      <Atom charge="0.02296" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.06965" name="CG" type="protein-2C"/>
+      <Atom charge="0.07399" name="HG2" type="protein-H1"/>
+      <Atom charge="0.07399" name="HG3" type="protein-H1"/>
+      <Atom charge="-0.23587" name="SD" type="protein-S"/>
+      <Atom charge="-0.27522" name="CE" type="protein-CT"/>
+      <Atom charge="0.11976" name="HE1" type="protein-H1"/>
+      <Atom charge="0.11976" name="HE2" type="protein-H1"/>
+      <Atom charge="0.11976" name="HE3" type="protein-H1"/>
+      <Atom charge="0.75823" name="C" type="protein-CO"/>
+      <Atom charge="-0.81169" name="O" type="protein-O3"/>
+      <Atom charge="-0.81169" name="OXT" type="protein-O3"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="SD"/>
+      <Bond atomName1="SD" atomName2="CE"/>
+      <Bond atomName1="CE" atomName2="HE1"/>
+      <Bond atomName1="CE" atomName2="HE2"/>
+      <Bond atomName1="CE" atomName2="HE3"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CNLE">
+      <Atom charge="-0.74668" name="N" type="protein-N"/>
+      <Atom charge="0.37486" name="H" type="protein-H"/>
+      <Atom charge="0.27757" name="CA" type="protein-CX"/>
+      <Atom charge="-0.0051" name="HA" type="protein-H1"/>
+      <Atom charge="-0.0709" name="CB" type="protein-2C"/>
+      <Atom charge="0.0106" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0106" name="HB3" type="protein-HC"/>
+      <Atom charge="0.05418" name="CG" type="protein-2C"/>
+      <Atom charge="-0.01331" name="HG2" type="protein-HC"/>
+      <Atom charge="-0.01331" name="HG3" type="protein-HC"/>
+      <Atom charge="0.09953" name="CD" type="protein-2C"/>
+      <Atom charge="-0.02455" name="HD2" type="protein-HC"/>
+      <Atom charge="-0.02455" name="HD3" type="protein-HC"/>
+      <Atom charge="-0.11953" name="CE" type="protein-CT"/>
+      <Atom charge="0.01858" name="HE1" type="protein-HC"/>
+      <Atom charge="0.01858" name="HE2" type="protein-HC"/>
+      <Atom charge="0.01858" name="HE3" type="protein-HC"/>
+      <Atom charge="0.75823" name="C" type="protein-CO"/>
+      <Atom charge="-0.81169" name="O" type="protein-O3"/>
+      <Atom charge="-0.81169" name="OXT" type="protein-O3"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="CD"/>
+      <Bond atomName1="CD" atomName2="HD2"/>
+      <Bond atomName1="CD" atomName2="HD3"/>
+      <Bond atomName1="CD" atomName2="CE"/>
+      <Bond atomName1="CE" atomName2="HE1"/>
+      <Bond atomName1="CE" atomName2="HE2"/>
+      <Bond atomName1="CE" atomName2="HE3"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CPHE">
+      <Atom charge="-0.74668" name="N" type="protein-N"/>
+      <Atom charge="0.37486" name="H" type="protein-H"/>
+      <Atom charge="0.32" name="CA" type="protein-CX"/>
+      <Atom charge="0.01647" name="HA" type="protein-H1"/>
+      <Atom charge="-0.17986" name="CB" type="protein-TA"/>
+      <Atom charge="0.05244" name="HB2" type="protein-HC"/>
+      <Atom charge="0.05244" name="HB3" type="protein-HC"/>
+      <Atom charge="0.10524" name="CG" type="protein-CA"/>
+      <Atom charge="-0.16273" name="CD1" type="protein-CA"/>
+      <Atom charge="0.14536" name="HD1" type="protein-HA"/>
+      <Atom charge="-0.18895" name="CE1" type="protein-CA"/>
+      <Atom charge="0.14296" name="HE1" type="protein-HA"/>
+      <Atom charge="-0.12517" name="CZ" type="protein-CA"/>
+      <Atom charge="0.12213" name="HZ" type="protein-HA"/>
+      <Atom charge="-0.18895" name="CE2" type="protein-CA"/>
+      <Atom charge="0.14296" name="HE2" type="protein-HA"/>
+      <Atom charge="-0.16273" name="CD2" type="protein-CA"/>
+      <Atom charge="0.14536" name="HD2" type="protein-HA"/>
+      <Atom charge="0.75823" name="C" type="protein-CO"/>
+      <Atom charge="-0.81169" name="O" type="protein-O3"/>
+      <Atom charge="-0.81169" name="OXT" type="protein-O3"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="CD1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="CD1" atomName2="HD1"/>
+      <Bond atomName1="CD1" atomName2="CE1"/>
+      <Bond atomName1="CE1" atomName2="HE1"/>
+      <Bond atomName1="CE1" atomName2="CZ"/>
+      <Bond atomName1="CZ" atomName2="HZ"/>
+      <Bond atomName1="CZ" atomName2="CE2"/>
+      <Bond atomName1="CE2" atomName2="HE2"/>
+      <Bond atomName1="CE2" atomName2="CD2"/>
+      <Bond atomName1="CD2" atomName2="HD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CPRO">
+      <Atom charge="-0.51659" name="N" type="protein-TN"/>
+      <Atom charge="0.12764" name="CD" type="protein-CT"/>
+      <Atom charge="0.00676" name="HD2" type="protein-H1"/>
+      <Atom charge="0.00676" name="HD3" type="protein-H1"/>
+      <Atom charge="0.01993" name="CG" type="protein-CT"/>
+      <Atom charge="0.00443" name="HG2" type="protein-HC"/>
+      <Atom charge="0.00443" name="HG3" type="protein-HC"/>
+      <Atom charge="-0.00483" name="CB" type="protein-CT"/>
+      <Atom charge="-0.00183" name="HB2" type="protein-HC"/>
+      <Atom charge="-0.00183" name="HB3" type="protein-HC"/>
+      <Atom charge="0.29691" name="CA" type="protein-TJ"/>
+      <Atom charge="-0.04305" name="HA" type="protein-H1"/>
+      <Atom charge="0.68077" name="C" type="protein-CO"/>
+      <Atom charge="-0.78975" name="O" type="protein-O3"/>
+      <Atom charge="-0.78975" name="OXT" type="protein-O3"/>
+      <Bond atomName1="N" atomName2="CD"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CD" atomName2="HD2"/>
+      <Bond atomName1="CD" atomName2="HD3"/>
+      <Bond atomName1="CD" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="CB"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CSER">
+      <Atom charge="-0.74668" name="N" type="protein-N"/>
+      <Atom charge="0.37486" name="H" type="protein-H"/>
+      <Atom charge="0.294" name="CA" type="protein-CX"/>
+      <Atom charge="0.02507" name="HA" type="protein-H1"/>
+      <Atom charge="0.03129" name="CB" type="protein-2C"/>
+      <Atom charge="0.05251" name="HB2" type="protein-H1"/>
+      <Atom charge="0.05251" name="HB3" type="protein-H1"/>
+      <Atom charge="-0.59434" name="OG" type="protein-OA"/>
+      <Atom charge="0.37593" name="HG" type="protein-HO"/>
+      <Atom charge="0.75823" name="C" type="protein-CO"/>
+      <Atom charge="-0.81169" name="O" type="protein-O3"/>
+      <Atom charge="-0.81169" name="OXT" type="protein-O3"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="OG"/>
+      <Bond atomName1="OG" atomName2="HG"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CTHR">
+      <Atom charge="-0.74668" name="N" type="protein-N"/>
+      <Atom charge="0.37486" name="H" type="protein-H"/>
+      <Atom charge="0.33829" name="CA" type="protein-CX"/>
+      <Atom charge="0.00468" name="HA" type="protein-H1"/>
+      <Atom charge="0.11114" name="CB" type="protein-3C"/>
+      <Atom charge="0.04005" name="HB" type="protein-H1"/>
+      <Atom charge="-0.28595" name="CG2" type="protein-CT"/>
+      <Atom charge="0.08492" name="HG21" type="protein-HC"/>
+      <Atom charge="0.08492" name="HG22" type="protein-HC"/>
+      <Atom charge="0.08492" name="HG23" type="protein-HC"/>
+      <Atom charge="-0.58562" name="OG1" type="protein-OA"/>
+      <Atom charge="0.35962" name="HG1" type="protein-HO"/>
+      <Atom charge="0.75823" name="C" type="protein-CO"/>
+      <Atom charge="-0.81169" name="O" type="protein-O3"/>
+      <Atom charge="-0.81169" name="OXT" type="protein-O3"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB"/>
+      <Bond atomName1="CB" atomName2="CG2"/>
+      <Bond atomName1="CB" atomName2="OG1"/>
+      <Bond atomName1="CG2" atomName2="HG21"/>
+      <Bond atomName1="CG2" atomName2="HG22"/>
+      <Bond atomName1="CG2" atomName2="HG23"/>
+      <Bond atomName1="OG1" atomName2="HG1"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CTRP">
+      <Atom charge="-0.74668" name="N" type="protein-N"/>
+      <Atom charge="0.37486" name="H" type="protein-H"/>
+      <Atom charge="0.33157" name="CA" type="protein-CX"/>
+      <Atom charge="0.01203" name="HA" type="protein-H1"/>
+      <Atom charge="-0.21601" name="CB" type="protein-TA"/>
+      <Atom charge="0.07021" name="HB2" type="protein-HC"/>
+      <Atom charge="0.07021" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.05669" name="CG" type="protein-C*"/>
+      <Atom charge="-0.12723" name="CD1" type="protein-CW"/>
+      <Atom charge="0.18894" name="HD1" type="protein-H4"/>
+      <Atom charge="-0.48884" name="NE1" type="protein-NA"/>
+      <Atom charge="0.39422" name="HE1" type="protein-H"/>
+      <Atom charge="0.26453" name="CE2" type="protein-CN"/>
+      <Atom charge="-0.34562" name="CZ2" type="protein-CA"/>
+      <Atom charge="0.16875" name="HZ2" type="protein-HA"/>
+      <Atom charge="-0.13992" name="CH2" type="protein-CA"/>
+      <Atom charge="0.14149" name="HH2" type="protein-HA"/>
+      <Atom charge="-0.21557" name="CZ3" type="protein-CA"/>
+      <Atom charge="0.14771" name="HZ3" type="protein-HA"/>
+      <Atom charge="-0.24421" name="CE3" type="protein-CA"/>
+      <Atom charge="0.17347" name="HE3" type="protein-HA"/>
+      <Atom charge="0.10793" name="CD2" type="protein-CB"/>
+      <Atom charge="0.75823" name="C" type="protein-CO"/>
+      <Atom charge="-0.81169" name="O" type="protein-O3"/>
+      <Atom charge="-0.81169" name="OXT" type="protein-O3"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="CD1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="CD1" atomName2="HD1"/>
+      <Bond atomName1="CD1" atomName2="NE1"/>
+      <Bond atomName1="NE1" atomName2="HE1"/>
+      <Bond atomName1="NE1" atomName2="CE2"/>
+      <Bond atomName1="CE2" atomName2="CZ2"/>
+      <Bond atomName1="CE2" atomName2="CD2"/>
+      <Bond atomName1="CZ2" atomName2="HZ2"/>
+      <Bond atomName1="CZ2" atomName2="CH2"/>
+      <Bond atomName1="CH2" atomName2="HH2"/>
+      <Bond atomName1="CH2" atomName2="CZ3"/>
+      <Bond atomName1="CZ3" atomName2="HZ3"/>
+      <Bond atomName1="CZ3" atomName2="CE3"/>
+      <Bond atomName1="CE3" atomName2="HE3"/>
+      <Bond atomName1="CE3" atomName2="CD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CTYR">
+      <Atom charge="-0.74668" name="N" type="protein-N"/>
+      <Atom charge="0.37486" name="H" type="protein-H"/>
+      <Atom charge="0.33041" name="CA" type="protein-CX"/>
+      <Atom charge="0.01476" name="HA" type="protein-H1"/>
+      <Atom charge="-0.2414" name="CB" type="protein-TA"/>
+      <Atom charge="0.07357" name="HB2" type="protein-HC"/>
+      <Atom charge="0.07357" name="HB3" type="protein-HC"/>
+      <Atom charge="0.11599" name="CG" type="protein-CA"/>
+      <Atom charge="-0.20615" name="CD1" type="protein-CA"/>
+      <Atom charge="0.1669" name="HD1" type="protein-HA"/>
+      <Atom charge="-0.28454" name="CE1" type="protein-CA"/>
+      <Atom charge="0.17573" name="HE1" type="protein-HA"/>
+      <Atom charge="0.32748" name="CZ" type="protein-C"/>
+      <Atom charge="-0.53026" name="OH" type="protein-OA"/>
+      <Atom charge="0.36897" name="HH" type="protein-HO"/>
+      <Atom charge="-0.28454" name="CE2" type="protein-CA"/>
+      <Atom charge="0.17573" name="HE2" type="protein-HA"/>
+      <Atom charge="-0.20615" name="CD2" type="protein-CA"/>
+      <Atom charge="0.1669" name="HD2" type="protein-HA"/>
+      <Atom charge="0.75823" name="C" type="protein-CO"/>
+      <Atom charge="-0.81169" name="O" type="protein-O3"/>
+      <Atom charge="-0.81169" name="OXT" type="protein-O3"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="CD1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="CD1" atomName2="HD1"/>
+      <Bond atomName1="CD1" atomName2="CE1"/>
+      <Bond atomName1="CE1" atomName2="HE1"/>
+      <Bond atomName1="CE1" atomName2="CZ"/>
+      <Bond atomName1="CZ" atomName2="OH"/>
+      <Bond atomName1="CZ" atomName2="CE2"/>
+      <Bond atomName1="OH" atomName2="HH"/>
+      <Bond atomName1="CE2" atomName2="HE2"/>
+      <Bond atomName1="CE2" atomName2="CD2"/>
+      <Bond atomName1="CD2" atomName2="HD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CVAL">
+      <Atom charge="-0.74668" name="N" type="protein-N"/>
+      <Atom charge="0.37486" name="H" type="protein-H"/>
+      <Atom charge="0.23649" name="CA" type="protein-CX"/>
+      <Atom charge="0.0253" name="HA" type="protein-H1"/>
+      <Atom charge="0.14515" name="CB" type="protein-3C"/>
+      <Atom charge="0.00761" name="HB" type="protein-HC"/>
+      <Atom charge="-0.29771" name="CG1" type="protein-CT"/>
+      <Atom charge="0.06964" name="HG11" type="protein-HC"/>
+      <Atom charge="0.06964" name="HG12" type="protein-HC"/>
+      <Atom charge="0.06964" name="HG13" type="protein-HC"/>
+      <Atom charge="-0.29771" name="CG2" type="protein-CT"/>
+      <Atom charge="0.06964" name="HG21" type="protein-HC"/>
+      <Atom charge="0.06964" name="HG22" type="protein-HC"/>
+      <Atom charge="0.06964" name="HG23" type="protein-HC"/>
+      <Atom charge="0.75823" name="C" type="protein-CO"/>
+      <Atom charge="-0.81169" name="O" type="protein-O3"/>
+      <Atom charge="-0.81169" name="OXT" type="protein-O3"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB"/>
+      <Bond atomName1="CB" atomName2="CG1"/>
+      <Bond atomName1="CB" atomName2="CG2"/>
+      <Bond atomName1="CG1" atomName2="HG11"/>
+      <Bond atomName1="CG1" atomName2="HG12"/>
+      <Bond atomName1="CG1" atomName2="HG13"/>
+      <Bond atomName1="CG2" atomName2="HG21"/>
+      <Bond atomName1="CG2" atomName2="HG22"/>
+      <Bond atomName1="CG2" atomName2="HG23"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="NHE">
+      <Atom charge="-0.79352" name="N" type="protein-ND"/>
+      <Atom charge="0.39676" name="HN1" type="protein-H"/>
+      <Atom charge="0.39676" name="HN2" type="protein-H"/>
+      <Bond atomName1="N" atomName2="HN1"/>
+      <Bond atomName1="N" atomName2="HN2"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="NME">
+      <Atom charge="-0.55366" name="N" type="protein-N"/>
+      <Atom charge="0.33672" name="H" type="protein-H"/>
+      <Atom charge="-0.01295" name="CH3" type="protein-CT"/>
+      <Atom charge="0.07663" name="HH31" type="protein-H1"/>
+      <Atom charge="0.07663" name="HH32" type="protein-H1"/>
+      <Atom charge="0.07663" name="HH33" type="protein-H1"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CH3"/>
+      <Bond atomName1="CH3" atomName2="HH31"/>
+      <Bond atomName1="CH3" atomName2="HH32"/>
+      <Bond atomName1="CH3" atomName2="HH33"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="ACE">
+      <Atom charge="0.02217" name="HH31" type="protein-HC"/>
+      <Atom charge="-0.0163" name="CH3" type="protein-CT"/>
+      <Atom charge="0.02217" name="HH32" type="protein-HC"/>
+      <Atom charge="0.02217" name="HH33" type="protein-HC"/>
+      <Atom charge="0.52664" name="C" type="protein-C"/>
+      <Atom charge="-0.57685" name="O" type="protein-OD"/>
+      <Bond atomName1="HH31" atomName2="CH3"/>
+      <Bond atomName1="CH3" atomName2="HH32"/>
+      <Bond atomName1="CH3" atomName2="HH33"/>
+      <Bond atomName1="CH3" atomName2="C"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NALA">
+      <Atom charge="-0.57901" name="N" type="protein-NL"/>
+      <Atom charge="0.41726" name="H1" type="protein-H"/>
+      <Atom charge="0.41726" name="H2" type="protein-H"/>
+      <Atom charge="0.41726" name="H3" type="protein-H"/>
+      <Atom charge="-0.30687" name="CA" type="protein-CX"/>
+      <Atom charge="0.19632" name="HA" type="protein-HP"/>
+      <Atom charge="-0.04614" name="CB" type="protein-CT"/>
+      <Atom charge="0.07255" name="HB1" type="protein-HC"/>
+      <Atom charge="0.07255" name="HB2" type="protein-HC"/>
+      <Atom charge="0.07255" name="HB3" type="protein-HC"/>
+      <Atom charge="0.86628" name="C" type="protein-C"/>
+      <Atom charge="-0.60001" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB1"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NARG">
+      <Atom charge="-0.55563" name="N" type="protein-NL"/>
+      <Atom charge="0.42068" name="H1" type="protein-H"/>
+      <Atom charge="0.42068" name="H2" type="protein-H"/>
+      <Atom charge="0.42068" name="H3" type="protein-H"/>
+      <Atom charge="-0.43574" name="CA" type="protein-TP"/>
+      <Atom charge="0.22117" name="HA" type="protein-HP"/>
+      <Atom charge="0.02261" name="CB" type="protein-C8"/>
+      <Atom charge="0.06652" name="HB2" type="protein-HC"/>
+      <Atom charge="0.06652" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.09031" name="CG" type="protein-C8"/>
+      <Atom charge="0.07565" name="HG2" type="protein-HC"/>
+      <Atom charge="0.07565" name="HG3" type="protein-HC"/>
+      <Atom charge="0.00155" name="CD" type="protein-C8"/>
+      <Atom charge="0.12163" name="HD2" type="protein-H1"/>
+      <Atom charge="0.12163" name="HD3" type="protein-H1"/>
+      <Atom charge="-0.55169" name="NE" type="protein-N2"/>
+      <Atom charge="0.39503" name="HE" type="protein-TH"/>
+      <Atom charge="0.68974" name="CZ" type="protein-CA"/>
+      <Atom charge="-0.78519" name="NH1" type="protein-N2"/>
+      <Atom charge="0.43756" name="HH11" type="protein-TH"/>
+      <Atom charge="0.43756" name="HH12" type="protein-TH"/>
+      <Atom charge="-0.78519" name="NH2" type="protein-N2"/>
+      <Atom charge="0.43756" name="HH21" type="protein-TH"/>
+      <Atom charge="0.43756" name="HH22" type="protein-TH"/>
+      <Atom charge="0.93375" name="C" type="protein-C"/>
+      <Atom charge="-0.59998" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="CD"/>
+      <Bond atomName1="CD" atomName2="HD2"/>
+      <Bond atomName1="CD" atomName2="HD3"/>
+      <Bond atomName1="CD" atomName2="NE"/>
+      <Bond atomName1="NE" atomName2="HE"/>
+      <Bond atomName1="NE" atomName2="CZ"/>
+      <Bond atomName1="CZ" atomName2="NH1"/>
+      <Bond atomName1="CZ" atomName2="NH2"/>
+      <Bond atomName1="NH1" atomName2="HH11"/>
+      <Bond atomName1="NH1" atomName2="HH12"/>
+      <Bond atomName1="NH2" atomName2="HH21"/>
+      <Bond atomName1="NH2" atomName2="HH22"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NASH">
+      <Atom charge="-0.57901" name="N" type="protein-NL"/>
+      <Atom charge="0.41726" name="H1" type="protein-H"/>
+      <Atom charge="0.41726" name="H2" type="protein-H"/>
+      <Atom charge="0.41726" name="H3" type="protein-H"/>
+      <Atom charge="-0.28453" name="CA" type="protein-CX"/>
+      <Atom charge="0.19375" name="HA" type="protein-HP"/>
+      <Atom charge="-0.04657" name="CB" type="protein-2C"/>
+      <Atom charge="0.09891" name="HB2" type="protein-HC"/>
+      <Atom charge="0.09891" name="HB3" type="protein-HC"/>
+      <Atom charge="0.61332" name="CG" type="protein-C"/>
+      <Atom charge="-0.51422" name="OD1" type="protein-O"/>
+      <Atom charge="-0.57065" name="OD2" type="protein-OH"/>
+      <Atom charge="0.47204" name="HD2" type="protein-HO"/>
+      <Atom charge="0.86628" name="C" type="protein-C"/>
+      <Atom charge="-0.60001" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="OD1"/>
+      <Bond atomName1="CG" atomName2="OD2"/>
+      <Bond atomName1="OD2" atomName2="HD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NASN">
+      <Atom charge="-0.57901" name="N" type="protein-NL"/>
+      <Atom charge="0.41726" name="H1" type="protein-H"/>
+      <Atom charge="0.41726" name="H2" type="protein-H"/>
+      <Atom charge="0.41726" name="H3" type="protein-H"/>
+      <Atom charge="-0.28854" name="CA" type="protein-CX"/>
+      <Atom charge="0.19917" name="HA" type="protein-HP"/>
+      <Atom charge="-0.14198" name="CB" type="protein-2C"/>
+      <Atom charge="0.10577" name="HB2" type="protein-HC"/>
+      <Atom charge="0.10577" name="HB3" type="protein-HC"/>
+      <Atom charge="0.68363" name="CG" type="protein-C"/>
+      <Atom charge="-0.57945" name="OD1" type="protein-OD"/>
+      <Atom charge="-0.90315" name="ND2" type="protein-ND"/>
+      <Atom charge="0.46825" name="HD21" type="protein-H"/>
+      <Atom charge="0.41149" name="HD22" type="protein-H"/>
+      <Atom charge="0.86628" name="C" type="protein-C"/>
+      <Atom charge="-0.60001" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="OD1"/>
+      <Bond atomName1="CG" atomName2="ND2"/>
+      <Bond atomName1="ND2" atomName2="HD21"/>
+      <Bond atomName1="ND2" atomName2="HD22"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NASP">
+      <Atom charge="-0.67824" name="N" type="protein-NL"/>
+      <Atom charge="0.4245" name="H1" type="protein-H"/>
+      <Atom charge="0.4245" name="H2" type="protein-H"/>
+      <Atom charge="0.4245" name="H3" type="protein-H"/>
+      <Atom charge="-0.14531" name="CA" type="protein-TM"/>
+      <Atom charge="0.1356" name="HA" type="protein-HP"/>
+      <Atom charge="-0.01341" name="CB" type="protein-2C"/>
+      <Atom charge="0.02837" name="HB2" type="protein-HC"/>
+      <Atom charge="0.02837" name="HB3" type="protein-HC"/>
+      <Atom charge="0.75101" name="CG" type="protein-CO"/>
+      <Atom charge="-0.77122" name="OD1" type="protein-O3"/>
+      <Atom charge="-0.77122" name="OD2" type="protein-O3"/>
+      <Atom charge="0.78778" name="C" type="protein-C"/>
+      <Atom charge="-0.62523" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="OD1"/>
+      <Bond atomName1="CG" atomName2="OD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NCYM">
+      <Atom charge="-0.67824" name="N" type="protein-NL"/>
+      <Atom charge="0.4245" name="H1" type="protein-H"/>
+      <Atom charge="0.4245" name="H2" type="protein-H"/>
+      <Atom charge="0.4245" name="H3" type="protein-H"/>
+      <Atom charge="-0.14692" name="CA" type="protein-TM"/>
+      <Atom charge="0.1501" name="HA" type="protein-HP"/>
+      <Atom charge="-0.05731" name="CB" type="protein-2C"/>
+      <Atom charge="0.12089" name="HB2" type="protein-H1"/>
+      <Atom charge="0.12089" name="HB3" type="protein-H1"/>
+      <Atom charge="-0.94546" name="SG" type="protein-SH"/>
+      <Atom charge="0.78778" name="C" type="protein-C"/>
+      <Atom charge="-0.62523" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="SG"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NCYS">
+      <Atom charge="-0.57901" name="N" type="protein-NL"/>
+      <Atom charge="0.41726" name="H1" type="protein-H"/>
+      <Atom charge="0.41726" name="H2" type="protein-H"/>
+      <Atom charge="0.41726" name="H3" type="protein-H"/>
+      <Atom charge="-0.26817" name="CA" type="protein-CX"/>
+      <Atom charge="0.18603" name="HA" type="protein-HP"/>
+      <Atom charge="-0.09826" name="CB" type="protein-2C"/>
+      <Atom charge="0.13404" name="HB2" type="protein-H1"/>
+      <Atom charge="0.13404" name="HB3" type="protein-H1"/>
+      <Atom charge="-0.24071" name="SG" type="protein-SH"/>
+      <Atom charge="0.21399" name="HG" type="protein-HS"/>
+      <Atom charge="0.86628" name="C" type="protein-C"/>
+      <Atom charge="-0.60001" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="SG"/>
+      <Bond atomName1="SG" atomName2="HG"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NCYX">
+      <Atom charge="-0.57901" name="N" type="protein-NL"/>
+      <Atom charge="0.41726" name="H1" type="protein-H"/>
+      <Atom charge="0.41726" name="H2" type="protein-H"/>
+      <Atom charge="0.41726" name="H3" type="protein-H"/>
+      <Atom charge="-0.32888" name="CA" type="protein-CX"/>
+      <Atom charge="0.21969" name="HA" type="protein-HP"/>
+      <Atom charge="-0.1221" name="CB" type="protein-2C"/>
+      <Atom charge="0.14205" name="HB2" type="protein-H1"/>
+      <Atom charge="0.14205" name="HB3" type="protein-H1"/>
+      <Atom charge="0.00815" name="SG" type="protein-S"/>
+      <Atom charge="0.86628" name="C" type="protein-C"/>
+      <Atom charge="-0.60001" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="SG"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="SG"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NGLH">
+      <Atom charge="-0.57901" name="N" type="protein-NL"/>
+      <Atom charge="0.41726" name="H1" type="protein-H"/>
+      <Atom charge="0.41726" name="H2" type="protein-H"/>
+      <Atom charge="0.41726" name="H3" type="protein-H"/>
+      <Atom charge="-0.35065" name="CA" type="protein-CX"/>
+      <Atom charge="0.21783" name="HA" type="protein-HP"/>
+      <Atom charge="-0.00802" name="CB" type="protein-2C"/>
+      <Atom charge="0.08233" name="HB2" type="protein-HC"/>
+      <Atom charge="0.08233" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.13715" name="CG" type="protein-2C"/>
+      <Atom charge="0.09906" name="HG2" type="protein-HC"/>
+      <Atom charge="0.09906" name="HG3" type="protein-HC"/>
+      <Atom charge="0.61666" name="CD" type="protein-C"/>
+      <Atom charge="-0.53525" name="OE1" type="protein-O"/>
+      <Atom charge="-0.58775" name="OE2" type="protein-OH"/>
+      <Atom charge="0.48251" name="HE2" type="protein-HO"/>
+      <Atom charge="0.86628" name="C" type="protein-C"/>
+      <Atom charge="-0.60001" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="CD"/>
+      <Bond atomName1="CD" atomName2="OE1"/>
+      <Bond atomName1="CD" atomName2="OE2"/>
+      <Bond atomName1="OE2" atomName2="HE2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NGLN">
+      <Atom charge="-0.57901" name="N" type="protein-NL"/>
+      <Atom charge="0.41726" name="H1" type="protein-H"/>
+      <Atom charge="0.41726" name="H2" type="protein-H"/>
+      <Atom charge="0.41726" name="H3" type="protein-H"/>
+      <Atom charge="-0.33009" name="CA" type="protein-CX"/>
+      <Atom charge="0.19043" name="HA" type="protein-HP"/>
+      <Atom charge="0.00168" name="CB" type="protein-2C"/>
+      <Atom charge="0.07453" name="HB2" type="protein-HC"/>
+      <Atom charge="0.07453" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.09634" name="CG" type="protein-2C"/>
+      <Atom charge="0.06339" name="HG2" type="protein-HC"/>
+      <Atom charge="0.06339" name="HG3" type="protein-HC"/>
+      <Atom charge="0.62545" name="CD" type="protein-C"/>
+      <Atom charge="-0.57948" name="OE1" type="protein-OD"/>
+      <Atom charge="-0.88146" name="NE2" type="protein-ND"/>
+      <Atom charge="0.45328" name="HE21" type="protein-H"/>
+      <Atom charge="0.40165" name="HE22" type="protein-H"/>
+      <Atom charge="0.86628" name="C" type="protein-C"/>
+      <Atom charge="-0.60001" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="CD"/>
+      <Bond atomName1="CD" atomName2="OE1"/>
+      <Bond atomName1="CD" atomName2="NE2"/>
+      <Bond atomName1="NE2" atomName2="HE21"/>
+      <Bond atomName1="NE2" atomName2="HE22"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NGLU">
+      <Atom charge="-0.67824" name="N" type="protein-NL"/>
+      <Atom charge="0.4245" name="H1" type="protein-H"/>
+      <Atom charge="0.4245" name="H2" type="protein-H"/>
+      <Atom charge="0.4245" name="H3" type="protein-H"/>
+      <Atom charge="-0.14956" name="CA" type="protein-TM"/>
+      <Atom charge="0.15153" name="HA" type="protein-HP"/>
+      <Atom charge="0.01587" name="CB" type="protein-2C"/>
+      <Atom charge="0.05517" name="HB2" type="protein-HC"/>
+      <Atom charge="0.05517" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.20791" name="CG" type="protein-2C"/>
+      <Atom charge="0.05222" name="HG2" type="protein-HC"/>
+      <Atom charge="0.05222" name="HG3" type="protein-HC"/>
+      <Atom charge="0.81958" name="CD" type="protein-CO"/>
+      <Atom charge="-0.80105" name="OE1" type="protein-O3"/>
+      <Atom charge="-0.80105" name="OE2" type="protein-O3"/>
+      <Atom charge="0.78778" name="C" type="protein-C"/>
+      <Atom charge="-0.62523" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="CD"/>
+      <Bond atomName1="CD" atomName2="OE1"/>
+      <Bond atomName1="CD" atomName2="OE2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NGLY">
+      <Atom charge="-0.34343" name="N" type="protein-NL"/>
+      <Atom charge="0.36841" name="H1" type="protein-H"/>
+      <Atom charge="0.36841" name="H2" type="protein-H"/>
+      <Atom charge="0.36841" name="H3" type="protein-H"/>
+      <Atom charge="-0.45131" name="CA" type="protein-TG"/>
+      <Atom charge="0.21061" name="HA2" type="protein-HP"/>
+      <Atom charge="0.21061" name="HA3" type="protein-HP"/>
+      <Atom charge="0.90833" name="C" type="protein-C"/>
+      <Atom charge="-0.64004" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA2"/>
+      <Bond atomName1="CA" atomName2="HA3"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NHID">
+      <Atom charge="-0.57901" name="N" type="protein-NL"/>
+      <Atom charge="0.41726" name="H1" type="protein-H"/>
+      <Atom charge="0.41726" name="H2" type="protein-H"/>
+      <Atom charge="0.41726" name="H3" type="protein-H"/>
+      <Atom charge="-0.29585" name="CA" type="protein-CX"/>
+      <Atom charge="0.18815" name="HA" type="protein-HP"/>
+      <Atom charge="-0.05104" name="CB" type="protein-TA"/>
+      <Atom charge="0.09588" name="HB2" type="protein-HC"/>
+      <Atom charge="0.09588" name="HB3" type="protein-HC"/>
+      <Atom charge="0.01667" name="CG" type="protein-CC"/>
+      <Atom charge="-0.3541" name="ND1" type="protein-NA"/>
+      <Atom charge="0.36984" name="HD1" type="protein-H"/>
+      <Atom charge="0.22082" name="CE1" type="protein-CR"/>
+      <Atom charge="0.13389" name="HE1" type="protein-H5"/>
+      <Atom charge="-0.55994" name="NE2" type="protein-NB"/>
+      <Atom charge="0.07247" name="CD2" type="protein-CV"/>
+      <Atom charge="0.12829" name="HD2" type="protein-H4"/>
+      <Atom charge="0.86628" name="C" type="protein-C"/>
+      <Atom charge="-0.60001" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="ND1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="ND1" atomName2="HD1"/>
+      <Bond atomName1="ND1" atomName2="CE1"/>
+      <Bond atomName1="CE1" atomName2="HE1"/>
+      <Bond atomName1="CE1" atomName2="NE2"/>
+      <Bond atomName1="NE2" atomName2="CD2"/>
+      <Bond atomName1="CD2" atomName2="HD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NHIE">
+      <Atom charge="-0.57901" name="N" type="protein-NL"/>
+      <Atom charge="0.41726" name="H1" type="protein-H"/>
+      <Atom charge="0.41726" name="H2" type="protein-H"/>
+      <Atom charge="0.41726" name="H3" type="protein-H"/>
+      <Atom charge="-0.31328" name="CA" type="protein-CX"/>
+      <Atom charge="0.19723" name="HA" type="protein-HP"/>
+      <Atom charge="-0.09251" name="CB" type="protein-TA"/>
+      <Atom charge="0.10035" name="HB2" type="protein-HC"/>
+      <Atom charge="0.10035" name="HB3" type="protein-HC"/>
+      <Atom charge="0.28206" name="CG" type="protein-CC"/>
+      <Atom charge="-0.57714" name="ND1" type="protein-NB"/>
+      <Atom charge="0.12112" name="CE1" type="protein-CR"/>
+      <Atom charge="0.15646" name="HE1" type="protein-H5"/>
+      <Atom charge="-0.19794" name="NE2" type="protein-NA"/>
+      <Atom charge="0.36647" name="HE2" type="protein-H"/>
+      <Atom charge="-0.26707" name="CD2" type="protein-CW"/>
+      <Atom charge="0.18486" name="HD2" type="protein-H4"/>
+      <Atom charge="0.86628" name="C" type="protein-C"/>
+      <Atom charge="-0.60001" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="ND1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="ND1" atomName2="CE1"/>
+      <Bond atomName1="CE1" atomName2="HE1"/>
+      <Bond atomName1="CE1" atomName2="NE2"/>
+      <Bond atomName1="NE2" atomName2="HE2"/>
+      <Bond atomName1="NE2" atomName2="CD2"/>
+      <Bond atomName1="CD2" atomName2="HD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NHIP">
+      <Atom charge="-0.55563" name="N" type="protein-NL"/>
+      <Atom charge="0.42068" name="H1" type="protein-H"/>
+      <Atom charge="0.42068" name="H2" type="protein-H"/>
+      <Atom charge="0.42068" name="H3" type="protein-H"/>
+      <Atom charge="-0.35744" name="CA" type="protein-TP"/>
+      <Atom charge="0.20599" name="HA" type="protein-HP"/>
+      <Atom charge="-0.02917" name="CB" type="protein-C8"/>
+      <Atom charge="0.12825" name="HB2" type="protein-HC"/>
+      <Atom charge="0.12825" name="HB3" type="protein-HC"/>
+      <Atom charge="0.00654" name="CG" type="protein-CC"/>
+      <Atom charge="-0.18032" name="ND1" type="protein-NA"/>
+      <Atom charge="0.40428" name="HD1" type="protein-H"/>
+      <Atom charge="0.03759" name="CE1" type="protein-CR"/>
+      <Atom charge="0.23242" name="HE1" type="protein-H5"/>
+      <Atom charge="-0.18237" name="NE2" type="protein-NA"/>
+      <Atom charge="0.42563" name="HE2" type="protein-H"/>
+      <Atom charge="-0.07402" name="CD2" type="protein-CW"/>
+      <Atom charge="0.21419" name="HD2" type="protein-H4"/>
+      <Atom charge="0.93375" name="C" type="protein-C"/>
+      <Atom charge="-0.59998" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="ND1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="ND1" atomName2="HD1"/>
+      <Bond atomName1="ND1" atomName2="CE1"/>
+      <Bond atomName1="CE1" atomName2="HE1"/>
+      <Bond atomName1="CE1" atomName2="NE2"/>
+      <Bond atomName1="NE2" atomName2="HE2"/>
+      <Bond atomName1="NE2" atomName2="CD2"/>
+      <Bond atomName1="CD2" atomName2="HD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NILE">
+      <Atom charge="-0.57901" name="N" type="protein-NL"/>
+      <Atom charge="0.41726" name="H1" type="protein-H"/>
+      <Atom charge="0.41726" name="H2" type="protein-H"/>
+      <Atom charge="0.41726" name="H3" type="protein-H"/>
+      <Atom charge="-0.40513" name="CA" type="protein-CX"/>
+      <Atom charge="0.2071" name="HA" type="protein-HP"/>
+      <Atom charge="0.06954" name="CB" type="protein-3C"/>
+      <Atom charge="0.07681" name="HB" type="protein-HC"/>
+      <Atom charge="-0.16834" name="CG2" type="protein-CT"/>
+      <Atom charge="0.06868" name="HG21" type="protein-HC"/>
+      <Atom charge="0.06868" name="HG22" type="protein-HC"/>
+      <Atom charge="0.06868" name="HG23" type="protein-HC"/>
+      <Atom charge="-0.03372" name="CG1" type="protein-2C"/>
+      <Atom charge="0.04739" name="HG12" type="protein-HC"/>
+      <Atom charge="0.04739" name="HG13" type="protein-HC"/>
+      <Atom charge="-0.17404" name="CD1" type="protein-CT"/>
+      <Atom charge="0.06264" name="HD11" type="protein-HC"/>
+      <Atom charge="0.06264" name="HD12" type="protein-HC"/>
+      <Atom charge="0.06264" name="HD13" type="protein-HC"/>
+      <Atom charge="0.86628" name="C" type="protein-C"/>
+      <Atom charge="-0.60001" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB"/>
+      <Bond atomName1="CB" atomName2="CG2"/>
+      <Bond atomName1="CB" atomName2="CG1"/>
+      <Bond atomName1="CG2" atomName2="HG21"/>
+      <Bond atomName1="CG2" atomName2="HG22"/>
+      <Bond atomName1="CG2" atomName2="HG23"/>
+      <Bond atomName1="CG1" atomName2="HG12"/>
+      <Bond atomName1="CG1" atomName2="HG13"/>
+      <Bond atomName1="CG1" atomName2="CD1"/>
+      <Bond atomName1="CD1" atomName2="HD11"/>
+      <Bond atomName1="CD1" atomName2="HD12"/>
+      <Bond atomName1="CD1" atomName2="HD13"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NLEU">
+      <Atom charge="-0.57901" name="N" type="protein-NL"/>
+      <Atom charge="0.41726" name="H1" type="protein-H"/>
+      <Atom charge="0.41726" name="H2" type="protein-H"/>
+      <Atom charge="0.41726" name="H3" type="protein-H"/>
+      <Atom charge="-0.32093" name="CA" type="protein-CX"/>
+      <Atom charge="0.18089" name="HA" type="protein-HP"/>
+      <Atom charge="-0.09217" name="CB" type="protein-2C"/>
+      <Atom charge="0.07706" name="HB2" type="protein-HC"/>
+      <Atom charge="0.07706" name="HB3" type="protein-HC"/>
+      <Atom charge="0.18051" name="CG" type="protein-3C"/>
+      <Atom charge="0.02512" name="HG" type="protein-HC"/>
+      <Atom charge="-0.27194" name="CD1" type="protein-CT"/>
+      <Atom charge="0.07955" name="HD11" type="protein-HC"/>
+      <Atom charge="0.07955" name="HD12" type="protein-HC"/>
+      <Atom charge="0.07955" name="HD13" type="protein-HC"/>
+      <Atom charge="-0.27194" name="CD2" type="protein-CT"/>
+      <Atom charge="0.07955" name="HD21" type="protein-HC"/>
+      <Atom charge="0.07955" name="HD22" type="protein-HC"/>
+      <Atom charge="0.07955" name="HD23" type="protein-HC"/>
+      <Atom charge="0.86628" name="C" type="protein-C"/>
+      <Atom charge="-0.60001" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG"/>
+      <Bond atomName1="CG" atomName2="CD1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="CD1" atomName2="HD11"/>
+      <Bond atomName1="CD1" atomName2="HD12"/>
+      <Bond atomName1="CD1" atomName2="HD13"/>
+      <Bond atomName1="CD2" atomName2="HD21"/>
+      <Bond atomName1="CD2" atomName2="HD22"/>
+      <Bond atomName1="CD2" atomName2="HD23"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NLYS">
+      <Atom charge="-0.55563" name="N" type="protein-NL"/>
+      <Atom charge="0.42068" name="H1" type="protein-H"/>
+      <Atom charge="0.42068" name="H2" type="protein-H"/>
+      <Atom charge="0.42068" name="H3" type="protein-H"/>
+      <Atom charge="-0.45822" name="CA" type="protein-TP"/>
+      <Atom charge="0.23746" name="HA" type="protein-HP"/>
+      <Atom charge="0.02634" name="CB" type="protein-C8"/>
+      <Atom charge="0.06984" name="HB2" type="protein-HC"/>
+      <Atom charge="0.06984" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.11736" name="CG" type="protein-C8"/>
+      <Atom charge="0.06991" name="HG2" type="protein-HC"/>
+      <Atom charge="0.06991" name="HG3" type="protein-HC"/>
+      <Atom charge="-0.11969" name="CD" type="protein-C8"/>
+      <Atom charge="0.09094" name="HD2" type="protein-HC"/>
+      <Atom charge="0.09094" name="HD3" type="protein-HC"/>
+      <Atom charge="0.09556" name="CE" type="protein-C8"/>
+      <Atom charge="0.10189" name="HE2" type="protein-HP"/>
+      <Atom charge="0.10189" name="HE3" type="protein-HP"/>
+      <Atom charge="-0.61902" name="NZ" type="protein-NL"/>
+      <Atom charge="0.41653" name="HZ1" type="protein-H"/>
+      <Atom charge="0.41653" name="HZ2" type="protein-H"/>
+      <Atom charge="0.41653" name="HZ3" type="protein-H"/>
+      <Atom charge="0.93375" name="C" type="protein-C"/>
+      <Atom charge="-0.59998" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="CD"/>
+      <Bond atomName1="CD" atomName2="HD2"/>
+      <Bond atomName1="CD" atomName2="HD3"/>
+      <Bond atomName1="CD" atomName2="CE"/>
+      <Bond atomName1="CE" atomName2="HE2"/>
+      <Bond atomName1="CE" atomName2="HE3"/>
+      <Bond atomName1="CE" atomName2="NZ"/>
+      <Bond atomName1="NZ" atomName2="HZ1"/>
+      <Bond atomName1="NZ" atomName2="HZ2"/>
+      <Bond atomName1="NZ" atomName2="HZ3"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NMET">
+      <Atom charge="-0.57901" name="N" type="protein-NL"/>
+      <Atom charge="0.41726" name="H1" type="protein-H"/>
+      <Atom charge="0.41726" name="H2" type="protein-H"/>
+      <Atom charge="0.41726" name="H3" type="protein-H"/>
+      <Atom charge="-0.30797" name="CA" type="protein-CX"/>
+      <Atom charge="0.17882" name="HA" type="protein-HP"/>
+      <Atom charge="-0.03297" name="CB" type="protein-2C"/>
+      <Atom charge="0.0973" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0973" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.21549" name="CG" type="protein-2C"/>
+      <Atom charge="0.13432" name="HG2" type="protein-H1"/>
+      <Atom charge="0.13432" name="HG3" type="protein-H1"/>
+      <Atom charge="-0.16731" name="SD" type="protein-S"/>
+      <Atom charge="-0.20119" name="CE" type="protein-CT"/>
+      <Atom charge="0.11461" name="HE1" type="protein-H1"/>
+      <Atom charge="0.11461" name="HE2" type="protein-H1"/>
+      <Atom charge="0.11461" name="HE3" type="protein-H1"/>
+      <Atom charge="0.86628" name="C" type="protein-C"/>
+      <Atom charge="-0.60001" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="SD"/>
+      <Bond atomName1="SD" atomName2="CE"/>
+      <Bond atomName1="CE" atomName2="HE1"/>
+      <Bond atomName1="CE" atomName2="HE2"/>
+      <Bond atomName1="CE" atomName2="HE3"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NNLE">
+      <Atom charge="-0.57901" name="N" type="protein-NL"/>
+      <Atom charge="0.41726" name="H1" type="protein-H"/>
+      <Atom charge="0.41726" name="H2" type="protein-H"/>
+      <Atom charge="0.41726" name="H3" type="protein-H"/>
+      <Atom charge="-0.35466" name="CA" type="protein-CX"/>
+      <Atom charge="0.20584" name="HA" type="protein-HP"/>
+      <Atom charge="0.0077" name="CB" type="protein-2C"/>
+      <Atom charge="0.06216" name="HB2" type="protein-HC"/>
+      <Atom charge="0.06216" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.07442" name="CG" type="protein-2C"/>
+      <Atom charge="0.04402" name="HG2" type="protein-HC"/>
+      <Atom charge="0.04402" name="HG3" type="protein-HC"/>
+      <Atom charge="0.03153" name="CD" type="protein-2C"/>
+      <Atom charge="0.02363" name="HD2" type="protein-HC"/>
+      <Atom charge="0.02363" name="HD3" type="protein-HC"/>
+      <Atom charge="-0.18901" name="CE" type="protein-CT"/>
+      <Atom charge="0.05812" name="HE1" type="protein-HC"/>
+      <Atom charge="0.05812" name="HE2" type="protein-HC"/>
+      <Atom charge="0.05812" name="HE3" type="protein-HC"/>
+      <Atom charge="0.86628" name="C" type="protein-C"/>
+      <Atom charge="-0.60001" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="CD"/>
+      <Bond atomName1="CD" atomName2="HD2"/>
+      <Bond atomName1="CD" atomName2="HD3"/>
+      <Bond atomName1="CD" atomName2="CE"/>
+      <Bond atomName1="CE" atomName2="HE1"/>
+      <Bond atomName1="CE" atomName2="HE2"/>
+      <Bond atomName1="CE" atomName2="HE3"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NPHE">
+      <Atom charge="-0.57901" name="N" type="protein-NL"/>
+      <Atom charge="0.41726" name="H1" type="protein-H"/>
+      <Atom charge="0.41726" name="H2" type="protein-H"/>
+      <Atom charge="0.41726" name="H3" type="protein-H"/>
+      <Atom charge="-0.32727" name="CA" type="protein-CX"/>
+      <Atom charge="0.18909" name="HA" type="protein-HP"/>
+      <Atom charge="-0.00037" name="CB" type="protein-TA"/>
+      <Atom charge="0.0813" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0813" name="HB3" type="protein-HC"/>
+      <Atom charge="0.03317" name="CG" type="protein-CA"/>
+      <Atom charge="-0.20939" name="CD1" type="protein-CA"/>
+      <Atom charge="0.15366" name="HD1" type="protein-HA"/>
+      <Atom charge="-0.09256" name="CE1" type="protein-CA"/>
+      <Atom charge="0.1421" name="HE1" type="protein-HA"/>
+      <Atom charge="-0.12612" name="CZ" type="protein-CA"/>
+      <Atom charge="0.14224" name="HZ" type="protein-HA"/>
+      <Atom charge="-0.09256" name="CE2" type="protein-CA"/>
+      <Atom charge="0.1421" name="HE2" type="protein-HA"/>
+      <Atom charge="-0.20939" name="CD2" type="protein-CA"/>
+      <Atom charge="0.15366" name="HD2" type="protein-HA"/>
+      <Atom charge="0.86628" name="C" type="protein-C"/>
+      <Atom charge="-0.60001" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="CD1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="CD1" atomName2="HD1"/>
+      <Bond atomName1="CD1" atomName2="CE1"/>
+      <Bond atomName1="CE1" atomName2="HE1"/>
+      <Bond atomName1="CE1" atomName2="CZ"/>
+      <Bond atomName1="CZ" atomName2="HZ"/>
+      <Bond atomName1="CZ" atomName2="CE2"/>
+      <Bond atomName1="CE2" atomName2="HE2"/>
+      <Bond atomName1="CE2" atomName2="CD2"/>
+      <Bond atomName1="CD2" atomName2="HD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NPRO">
+      <Atom charge="-0.3526" name="N" type="protein-NL"/>
+      <Atom charge="0.38149" name="H2" type="protein-H"/>
+      <Atom charge="0.38149" name="H3" type="protein-H"/>
+      <Atom charge="0.02496" name="CD" type="protein-CT"/>
+      <Atom charge="0.09922" name="HD2" type="protein-HP"/>
+      <Atom charge="0.09922" name="HD3" type="protein-HP"/>
+      <Atom charge="0.02186" name="CG" type="protein-CT"/>
+      <Atom charge="0.04637" name="HG2" type="protein-HC"/>
+      <Atom charge="0.04637" name="HG3" type="protein-HC"/>
+      <Atom charge="0.05785" name="CB" type="protein-CT"/>
+      <Atom charge="0.04675" name="HB2" type="protein-HC"/>
+      <Atom charge="0.04675" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.32656" name="CA" type="protein-TJ"/>
+      <Atom charge="0.18205" name="HA" type="protein-HP"/>
+      <Atom charge="0.83604" name="C" type="protein-C"/>
+      <Atom charge="-0.59126" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CD"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CD" atomName2="HD2"/>
+      <Bond atomName1="CD" atomName2="HD3"/>
+      <Bond atomName1="CD" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="CB"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NSER">
+      <Atom charge="-0.57901" name="N" type="protein-NL"/>
+      <Atom charge="0.41726" name="H1" type="protein-H"/>
+      <Atom charge="0.41726" name="H2" type="protein-H"/>
+      <Atom charge="0.41726" name="H3" type="protein-H"/>
+      <Atom charge="-0.28106" name="CA" type="protein-CX"/>
+      <Atom charge="0.19248" name="HA" type="protein-HP"/>
+      <Atom charge="0.11779" name="CB" type="protein-2C"/>
+      <Atom charge="0.07536" name="HB2" type="protein-H1"/>
+      <Atom charge="0.07536" name="HB3" type="protein-H1"/>
+      <Atom charge="-0.52119" name="OG" type="protein-OA"/>
+      <Atom charge="0.40222" name="HG" type="protein-HO"/>
+      <Atom charge="0.86628" name="C" type="protein-C"/>
+      <Atom charge="-0.60001" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="OG"/>
+      <Bond atomName1="OG" atomName2="HG"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NTHR">
+      <Atom charge="-0.57901" name="N" type="protein-NL"/>
+      <Atom charge="0.41726" name="H1" type="protein-H"/>
+      <Atom charge="0.41726" name="H2" type="protein-H"/>
+      <Atom charge="0.41726" name="H3" type="protein-H"/>
+      <Atom charge="-0.31466" name="CA" type="protein-CX"/>
+      <Atom charge="0.20462" name="HA" type="protein-HP"/>
+      <Atom charge="0.19475" name="CB" type="protein-3C"/>
+      <Atom charge="0.07213" name="HB" type="protein-H1"/>
+      <Atom charge="-0.23337" name="CG2" type="protein-CT"/>
+      <Atom charge="0.09063" name="HG21" type="protein-HC"/>
+      <Atom charge="0.09063" name="HG22" type="protein-HC"/>
+      <Atom charge="0.09063" name="HG23" type="protein-HC"/>
+      <Atom charge="-0.54959" name="OG1" type="protein-OA"/>
+      <Atom charge="0.41519" name="HG1" type="protein-HO"/>
+      <Atom charge="0.86628" name="C" type="protein-C"/>
+      <Atom charge="-0.60001" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB"/>
+      <Bond atomName1="CB" atomName2="CG2"/>
+      <Bond atomName1="CB" atomName2="OG1"/>
+      <Bond atomName1="CG2" atomName2="HG21"/>
+      <Bond atomName1="CG2" atomName2="HG22"/>
+      <Bond atomName1="CG2" atomName2="HG23"/>
+      <Bond atomName1="OG1" atomName2="HG1"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NTRP">
+      <Atom charge="-0.57901" name="N" type="protein-NL"/>
+      <Atom charge="0.41726" name="H1" type="protein-H"/>
+      <Atom charge="0.41726" name="H2" type="protein-H"/>
+      <Atom charge="0.41726" name="H3" type="protein-H"/>
+      <Atom charge="-0.33508" name="CA" type="protein-CX"/>
+      <Atom charge="0.19667" name="HA" type="protein-HP"/>
+      <Atom charge="0.00121" name="CB" type="protein-TA"/>
+      <Atom charge="0.09575" name="HB2" type="protein-HC"/>
+      <Atom charge="0.09575" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.20804" name="CG" type="protein-C*"/>
+      <Atom charge="-0.12845" name="CD1" type="protein-CW"/>
+      <Atom charge="0.19461" name="HD1" type="protein-H4"/>
+      <Atom charge="-0.40094" name="NE1" type="protein-NA"/>
+      <Atom charge="0.39352" name="HE1" type="protein-H"/>
+      <Atom charge="0.19128" name="CE2" type="protein-CN"/>
+      <Atom charge="-0.24187" name="CZ2" type="protein-CA"/>
+      <Atom charge="0.16613" name="HZ2" type="protein-HA"/>
+      <Atom charge="-0.14844" name="CH2" type="protein-CA"/>
+      <Atom charge="0.15364" name="HH2" type="protein-HA"/>
+      <Atom charge="-0.11849" name="CZ3" type="protein-CA"/>
+      <Atom charge="0.14765" name="HZ3" type="protein-HA"/>
+      <Atom charge="-0.35016" name="CE3" type="protein-CA"/>
+      <Atom charge="0.18149" name="HE3" type="protein-HA"/>
+      <Atom charge="0.17473" name="CD2" type="protein-CB"/>
+      <Atom charge="0.86628" name="C" type="protein-C"/>
+      <Atom charge="-0.60001" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="CD1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="CD1" atomName2="HD1"/>
+      <Bond atomName1="CD1" atomName2="NE1"/>
+      <Bond atomName1="NE1" atomName2="HE1"/>
+      <Bond atomName1="NE1" atomName2="CE2"/>
+      <Bond atomName1="CE2" atomName2="CZ2"/>
+      <Bond atomName1="CE2" atomName2="CD2"/>
+      <Bond atomName1="CZ2" atomName2="HZ2"/>
+      <Bond atomName1="CZ2" atomName2="CH2"/>
+      <Bond atomName1="CH2" atomName2="HH2"/>
+      <Bond atomName1="CH2" atomName2="CZ3"/>
+      <Bond atomName1="CZ3" atomName2="HZ3"/>
+      <Bond atomName1="CZ3" atomName2="CE3"/>
+      <Bond atomName1="CE3" atomName2="HE3"/>
+      <Bond atomName1="CE3" atomName2="CD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NTYR">
+      <Atom charge="-0.57901" name="N" type="protein-NL"/>
+      <Atom charge="0.41726" name="H1" type="protein-H"/>
+      <Atom charge="0.41726" name="H2" type="protein-H"/>
+      <Atom charge="0.41726" name="H3" type="protein-H"/>
+      <Atom charge="-0.3337" name="CA" type="protein-CX"/>
+      <Atom charge="0.19467" name="HA" type="protein-HP"/>
+      <Atom charge="-0.00442" name="CB" type="protein-TA"/>
+      <Atom charge="0.08352" name="HB2" type="protein-HC"/>
+      <Atom charge="0.08352" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.02908" name="CG" type="protein-CA"/>
+      <Atom charge="-0.14186" name="CD1" type="protein-CA"/>
+      <Atom charge="0.14215" name="HD1" type="protein-HA"/>
+      <Atom charge="-0.29982" name="CE1" type="protein-CA"/>
+      <Atom charge="0.19254" name="HE1" type="protein-HA"/>
+      <Atom charge="0.40303" name="CZ" type="protein-C"/>
+      <Atom charge="-0.51327" name="OH" type="protein-OA"/>
+      <Atom charge="0.39067" name="HH" type="protein-HO"/>
+      <Atom charge="-0.29982" name="CE2" type="protein-CA"/>
+      <Atom charge="0.19254" name="HE2" type="protein-HA"/>
+      <Atom charge="-0.14186" name="CD2" type="protein-CA"/>
+      <Atom charge="0.14215" name="HD2" type="protein-HA"/>
+      <Atom charge="0.86628" name="C" type="protein-C"/>
+      <Atom charge="-0.60001" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="CD1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="CD1" atomName2="HD1"/>
+      <Bond atomName1="CD1" atomName2="CE1"/>
+      <Bond atomName1="CE1" atomName2="HE1"/>
+      <Bond atomName1="CE1" atomName2="CZ"/>
+      <Bond atomName1="CZ" atomName2="OH"/>
+      <Bond atomName1="CZ" atomName2="CE2"/>
+      <Bond atomName1="OH" atomName2="HH"/>
+      <Bond atomName1="CE2" atomName2="HE2"/>
+      <Bond atomName1="CE2" atomName2="CD2"/>
+      <Bond atomName1="CD2" atomName2="HD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NVAL">
+      <Atom charge="-0.57901" name="N" type="protein-NL"/>
+      <Atom charge="0.41726" name="H1" type="protein-H"/>
+      <Atom charge="0.41726" name="H2" type="protein-H"/>
+      <Atom charge="0.41726" name="H3" type="protein-H"/>
+      <Atom charge="-0.41747" name="CA" type="protein-CX"/>
+      <Atom charge="0.21719" name="HA" type="protein-HP"/>
+      <Atom charge="0.18748" name="CB" type="protein-3C"/>
+      <Atom charge="0.06114" name="HB" type="protein-HC"/>
+      <Atom charge="-0.26546" name="CG1" type="protein-CT"/>
+      <Atom charge="0.09059" name="HG11" type="protein-HC"/>
+      <Atom charge="0.09059" name="HG12" type="protein-HC"/>
+      <Atom charge="0.09059" name="HG13" type="protein-HC"/>
+      <Atom charge="-0.26546" name="CG2" type="protein-CT"/>
+      <Atom charge="0.09059" name="HG21" type="protein-HC"/>
+      <Atom charge="0.09059" name="HG22" type="protein-HC"/>
+      <Atom charge="0.09059" name="HG23" type="protein-HC"/>
+      <Atom charge="0.86628" name="C" type="protein-C"/>
+      <Atom charge="-0.60001" name="O" type="protein-OD"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB"/>
+      <Bond atomName1="CB" atomName2="CG1"/>
+      <Bond atomName1="CB" atomName2="CG2"/>
+      <Bond atomName1="CG1" atomName2="HG11"/>
+      <Bond atomName1="CG1" atomName2="HG12"/>
+      <Bond atomName1="CG1" atomName2="HG13"/>
+      <Bond atomName1="CG2" atomName2="HG21"/>
+      <Bond atomName1="CG2" atomName2="HG22"/>
+      <Bond atomName1="CG2" atomName2="HG23"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+  </Residues>
+  <HarmonicBondForce>
+    <Bond k="259407.99999999994" length="0.1525" type1="protein-C" type2="protein-C"/>
+    <Bond k="374049.5999999999" length="0.1419" type1="protein-C" type2="protein-CB"/>
+    <Bond k="349782.3999999999" length="0.1388" type1="protein-C" type2="protein-NA"/>
+    <Bond k="476975.9999999999" length="0.12290000000000001" type1="protein-C" type2="protein-O"/>
+    <Bond k="376559.99999999994" length="0.13640000000000002" type1="protein-C" type2="protein-OH"/>
+    <Bond k="307105.5999999999" length="0.10800000000000001" type1="protein-C" type2="protein-H4"/>
+    <Bond k="307105.5999999999" length="0.10800000000000001" type1="protein-C" type2="protein-H5"/>
+    <Bond k="307105.5999999999" length="0.10800000000000001" type1="protein-CA" type2="protein-H4"/>
+    <Bond k="357313.5999999999" length="0.1381" type1="protein-CA" type2="protein-NA"/>
+    <Bond k="376559.99999999994" length="0.13640000000000002" type1="protein-CA" type2="protein-OH"/>
+    <Bond k="435135.99999999994" length="0.137" type1="protein-CB" type2="protein-CB"/>
+    <Bond k="346435.19999999995" length="0.1391" type1="protein-CB" type2="protein-NB"/>
+    <Bond k="282001.5999999999" length="0.1463" type1="protein-CT" type2="protein-N2"/>
+    <Bond k="267775.99999999994" length="0.141" type1="protein-CT" type2="protein-OH"/>
+    <Bond k="307105.5999999999" length="0.10800000000000001" type1="protein-C*" type2="protein-HC"/>
+    <Bond k="307105.5999999999" length="0.1471" type1="protein-CT" type2="protein-N3"/>
+    <Bond k="198321.59999999998" length="0.18100000000000002" type1="protein-CT" type2="protein-SH"/>
+    <Bond k="363171.19999999995" length="0.101" type1="protein-H" type2="protein-N3"/>
+    <Bond k="462750.3999999999" length="0.096" type1="protein-HO" type2="protein-OH"/>
+    <Bond k="363171.19999999995" length="0.101" type1="protein-N2" type2="protein-H"/>
+    <Bond k="410031.99999999994" length="0.1335" type1="protein-C" type2="protein-N"/>
+    <Bond k="410031.99999999994" length="0.1335" type1="protein-C" type2="protein-TN"/>
+    <Bond k="363171.19999999995" length="0.101" type1="protein-H" type2="protein-N"/>
+    <Bond k="363171.19999999995" length="0.101" type1="protein-H" type2="protein-NL"/>
+    <Bond k="282001.5999999999" length="0.1449" type1="protein-N" type2="protein-CX"/>
+    <Bond k="282001.5999999999" length="0.1449" type1="protein-TN" type2="protein-TJ"/>
+    <Bond k="282001.5999999999" length="0.1449" type1="protein-N" type2="protein-TG"/>
+    <Bond k="282001.5999999999" length="0.1449" type1="protein-N" type2="protein-TP"/>
+    <Bond k="282001.5999999999" length="0.1449" type1="protein-N" type2="protein-TM"/>
+    <Bond k="282001.5999999999" length="0.1449" type1="protein-N" type2="protein-CT"/>
+    <Bond k="307105.5999999999" length="0.1471" type1="protein-NL" type2="protein-CX"/>
+    <Bond k="307105.5999999999" length="0.1471" type1="protein-NL" type2="protein-TJ"/>
+    <Bond k="307105.5999999999" length="0.1471" type1="protein-NL" type2="protein-TG"/>
+    <Bond k="307105.5999999999" length="0.1471" type1="protein-NL" type2="protein-TP"/>
+    <Bond k="307105.5999999999" length="0.1471" type1="protein-NL" type2="protein-TM"/>
+    <Bond k="282001.5999999999" length="0.1449" type1="protein-TN" type2="protein-CT"/>
+    <Bond k="307105.5999999999" length="0.1471" type1="protein-NL" type2="protein-CT"/>
+    <Bond k="259407.99999999994" length="0.1526" type1="protein-CX" type2="protein-CT"/>
+    <Bond k="259407.99999999994" length="0.1526" type1="protein-CX" type2="protein-2C"/>
+    <Bond k="259407.99999999994" length="0.1526" type1="protein-CX" type2="protein-3C"/>
+    <Bond k="259407.99999999994" length="0.1526" type1="protein-CX" type2="protein-TA"/>
+    <Bond k="259407.99999999994" length="0.1526" type1="protein-TJ" type2="protein-CT"/>
+    <Bond k="259407.99999999994" length="0.1526" type1="protein-TP" type2="protein-C8"/>
+    <Bond k="259407.99999999994" length="0.1526" type1="protein-TM" type2="protein-2C"/>
+    <Bond k="284511.99999999994" length="0.10900000000000001" type1="protein-CX" type2="protein-H1"/>
+    <Bond k="284511.99999999994" length="0.10900000000000001" type1="protein-TJ" type2="protein-H1"/>
+    <Bond k="284511.99999999994" length="0.10900000000000001" type1="protein-TG" type2="protein-H1"/>
+    <Bond k="284511.99999999994" length="0.10900000000000001" type1="protein-TP" type2="protein-H1"/>
+    <Bond k="284511.99999999994" length="0.10900000000000001" type1="protein-TM" type2="protein-H1"/>
+    <Bond k="284511.99999999994" length="0.10900000000000001" type1="protein-CX" type2="protein-HP"/>
+    <Bond k="284511.99999999994" length="0.10900000000000001" type1="protein-TJ" type2="protein-HP"/>
+    <Bond k="284511.99999999994" length="0.10900000000000001" type1="protein-TG" type2="protein-HP"/>
+    <Bond k="284511.99999999994" length="0.10900000000000001" type1="protein-TP" type2="protein-HP"/>
+    <Bond k="284511.99999999994" length="0.10900000000000001" type1="protein-TM" type2="protein-HP"/>
+    <Bond k="265265.6" length="0.1522" type1="protein-CX" type2="protein-C"/>
+    <Bond k="265265.6" length="0.1522" type1="protein-TJ" type2="protein-C"/>
+    <Bond k="265265.6" length="0.1522" type1="protein-TG" type2="protein-C"/>
+    <Bond k="265265.6" length="0.1522" type1="protein-TP" type2="protein-C"/>
+    <Bond k="265265.6" length="0.1522" type1="protein-TM" type2="protein-C"/>
+    <Bond k="265265.6" length="0.1522" type1="protein-CT" type2="protein-C"/>
+    <Bond k="265265.6" length="0.1522" type1="protein-CX" type2="protein-CO"/>
+    <Bond k="265265.6" length="0.1522" type1="protein-TJ" type2="protein-CO"/>
+    <Bond k="265265.6" length="0.1522" type1="protein-TG" type2="protein-CO"/>
+    <Bond k="265265.6" length="0.1522" type1="protein-TP" type2="protein-CO"/>
+    <Bond k="265265.6" length="0.1522" type1="protein-TM" type2="protein-CO"/>
+    <Bond k="476975.9999999999" length="0.12290000000000001" type1="protein-C" type2="protein-OD"/>
+    <Bond k="548940.7999999999" length="0.125" type1="protein-CO" type2="protein-O3"/>
+    <Bond k="410031.99999999994" length="0.1335" type1="protein-C" type2="protein-ND"/>
+    <Bond k="363171.19999999995" length="0.101" type1="protein-ND" type2="protein-H"/>
+    <Bond k="284511.99999999994" length="0.10900000000000001" type1="protein-CT" type2="protein-HC"/>
+    <Bond k="284511.99999999994" length="0.10900000000000001" type1="protein-CT" type2="protein-H1"/>
+    <Bond k="284511.99999999994" length="0.10900000000000001" type1="protein-CT" type2="protein-HP"/>
+    <Bond k="259407.99999999994" length="0.1526" type1="protein-CT" type2="protein-CT"/>
+    <Bond k="189953.59999999998" length="0.18100000000000002" type1="protein-CT" type2="protein-S"/>
+    <Bond k="259407.99999999994" length="0.1526" type1="protein-2C" type2="protein-CT"/>
+    <Bond k="284511.99999999994" length="0.10900000000000001" type1="protein-2C" type2="protein-HC"/>
+    <Bond k="284511.99999999994" length="0.10900000000000001" type1="protein-2C" type2="protein-H1"/>
+    <Bond k="265265.6" length="0.1522" type1="protein-2C" type2="protein-C"/>
+    <Bond k="265265.6" length="0.1522" type1="protein-2C" type2="protein-CO"/>
+    <Bond k="198321.59999999998" length="0.18100000000000002" type1="protein-2C" type2="protein-SH"/>
+    <Bond k="189953.59999999998" length="0.18100000000000002" type1="protein-2C" type2="protein-S"/>
+    <Bond k="259407.99999999994" length="0.1526" type1="protein-2C" type2="protein-3C"/>
+    <Bond k="267775.99999999994" length="0.141" type1="protein-2C" type2="protein-OA"/>
+    <Bond k="307105.5999999999" length="0.1471" type1="protein-2C" type2="protein-N3"/>
+    <Bond k="259407.99999999994" length="0.1526" type1="protein-2C" type2="protein-2C"/>
+    <Bond k="229283.19999999995" length="0.13360000000000002" type1="protein-SH" type2="protein-HS"/>
+    <Bond k="138908.79999999996" length="0.20379999999999998" type1="protein-S" type2="protein-S"/>
+    <Bond k="462750.3999999999" length="0.096" type1="protein-OA" type2="protein-HO"/>
+    <Bond k="259407.99999999994" length="0.1526" type1="protein-3C" type2="protein-CT"/>
+    <Bond k="284511.99999999994" length="0.10900000000000001" type1="protein-3C" type2="protein-HC"/>
+    <Bond k="284511.99999999994" length="0.10900000000000001" type1="protein-3C" type2="protein-H1"/>
+    <Bond k="267775.99999999994" length="0.141" type1="protein-3C" type2="protein-OA"/>
+    <Bond k="284511.99999999994" length="0.10900000000000001" type1="protein-TA" type2="protein-HC"/>
+    <Bond k="265265.6" length="0.1504" type1="protein-TA" type2="protein-CC"/>
+    <Bond k="428441.5999999999" length="0.1375" type1="protein-CC" type2="protein-CV"/>
+    <Bond k="433462.3999999999" length="0.1371" type1="protein-CC" type2="protein-CW"/>
+    <Bond k="353129.5999999999" length="0.1385" type1="protein-CC" type2="protein-NA"/>
+    <Bond k="343087.99999999994" length="0.1394" type1="protein-CC" type2="protein-NB"/>
+    <Bond k="343087.99999999994" length="0.1394" type1="protein-CV" type2="protein-NB"/>
+    <Bond k="357313.5999999999" length="0.1381" type1="protein-CW" type2="protein-NA"/>
+    <Bond k="399153.5999999999" length="0.1343" type1="protein-CR" type2="protein-NA"/>
+    <Bond k="408358.3999999999" length="0.1335" type1="protein-CR" type2="protein-NB"/>
+    <Bond k="307105.5999999999" length="0.10800000000000001" type1="protein-CV" type2="protein-H4"/>
+    <Bond k="307105.5999999999" length="0.10800000000000001" type1="protein-CW" type2="protein-H4"/>
+    <Bond k="307105.5999999999" length="0.10800000000000001" type1="protein-CR" type2="protein-H5"/>
+    <Bond k="363171.19999999995" length="0.101" type1="protein-NA" type2="protein-H"/>
+    <Bond k="265265.6" length="0.15100000000000002" type1="protein-TA" type2="protein-CA"/>
+    <Bond k="392459.19999999995" length="0.13999999999999999" type1="protein-CA" type2="protein-CA"/>
+    <Bond k="307105.5999999999" length="0.10800000000000001" type1="protein-CA" type2="protein-HA"/>
+    <Bond k="265265.6" length="0.14950000000000002" type1="protein-TA" type2="protein-C*"/>
+    <Bond k="392459.19999999995" length="0.1404" type1="protein-CA" type2="protein-CB"/>
+    <Bond k="324678.39999999997" length="0.1459" type1="protein-C*" type2="protein-CB"/>
+    <Bond k="456892.79999999993" length="0.13520000000000001" type1="protein-C*" type2="protein-CW"/>
+    <Bond k="374049.5999999999" length="0.1419" type1="protein-CB" type2="protein-CN"/>
+    <Bond k="358150.3999999999" length="0.13799999999999998" type1="protein-CN" type2="protein-NA"/>
+    <Bond k="392459.19999999995" length="0.13999999999999999" type1="protein-CA" type2="protein-CN"/>
+    <Bond k="376559.99999999994" length="0.13640000000000002" type1="protein-C" type2="protein-OA"/>
+    <Bond k="392459.19999999995" length="0.1409" type1="protein-CA" type2="protein-C"/>
+    <Bond k="259407.99999999994" length="0.1526" type1="protein-C8" type2="protein-C8"/>
+    <Bond k="265265.6" length="0.1504" type1="protein-C8" type2="protein-CC"/>
+    <Bond k="282001.5999999999" length="0.1463" type1="protein-C8" type2="protein-N2"/>
+    <Bond k="307105.5999999999" length="0.1471" type1="protein-C8" type2="protein-NL"/>
+    <Bond k="402500.79999999993" length="0.134" type1="protein-N2" type2="protein-CA"/>
+    <Bond k="284511.99999999994" length="0.10900000000000001" type1="protein-C8" type2="protein-HC"/>
+    <Bond k="284511.99999999994" length="0.10900000000000001" type1="protein-C8" type2="protein-H1"/>
+    <Bond k="284511.99999999994" length="0.10900000000000001" type1="protein-C8" type2="protein-HP"/>
+    <Bond k="363171.19999999995" length="0.101" type1="protein-N2" type2="protein-TH"/>
+  </HarmonicBondForce>
+  <HarmonicAngleForce>
+    <Angle angle="2.0943951023931953" k="669.44" type1="protein-C" type2="protein-C" type3="protein-O"/>
+    <Angle angle="2.0943951023931953" k="669.44" type1="protein-C" type2="protein-C" type3="protein-OH"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-CA" type2="protein-C" type3="protein-OH"/>
+    <Angle angle="1.9425514574696887" k="585.76" type1="protein-CB" type2="protein-C" type3="protein-NA"/>
+    <Angle angle="2.2479840765686965" k="669.44" type1="protein-CB" type2="protein-C" type3="protein-O"/>
+    <Angle angle="2.101376419401173" k="669.44" type1="protein-CT" type2="protein-C" type3="protein-O"/>
+    <Angle angle="2.0420352248333655" k="527.184" type1="protein-CT" type2="protein-C" type3="protein-CT"/>
+    <Angle angle="1.9198621771937625" k="669.44" type1="protein-CT" type2="protein-C" type3="protein-OH"/>
+    <Angle angle="2.1048670779051615" k="669.44" type1="protein-NA" type2="protein-C" type3="protein-O"/>
+    <Angle angle="2.1450096507010312" k="669.44" type1="protein-N" type2="protein-C" type3="protein-O"/>
+    <Angle angle="2.199114857512855" k="669.44" type1="protein-O" type2="protein-C" type3="protein-O"/>
+    <Angle angle="2.0943951023931953" k="669.44" type1="protein-O" type2="protein-C" type3="protein-OH"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-H4" type2="protein-C" type3="protein-C"/>
+    <Angle angle="2.007128639793479" k="418.40000000000003" type1="protein-H4" type2="protein-C" type3="protein-CT"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-H4" type2="protein-C" type3="protein-O"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-H4" type2="protein-C" type3="protein-OH"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-H5" type2="protein-C" type3="protein-N"/>
+    <Angle angle="2.076941809873252" k="418.40000000000003" type1="protein-H5" type2="protein-C" type3="protein-O"/>
+    <Angle angle="1.8675022996339325" k="418.40000000000003" type1="protein-H5" type2="protein-C" type3="protein-OH"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-CA" type2="protein-CA" type3="protein-H4"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-CA" type2="protein-CA" type3="protein-OH"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-CB" type2="protein-CA" type3="protein-H4"/>
+    <Angle angle="2.155481626212997" k="585.76" type1="protein-CB" type2="protein-CA" type3="protein-N2"/>
+    <Angle angle="2.0245819323134224" k="585.76" type1="protein-N2" type2="protein-CA" type3="protein-NA"/>
+    <Angle angle="2.080432468377241" k="527.184" type1="protein-C" type2="protein-CB" type3="protein-CB"/>
+    <Angle angle="2.2689280275926285" k="585.76" type1="protein-C" type2="protein-CB" type3="protein-NB"/>
+    <Angle angle="2.0472712125893486" k="527.184" type1="protein-CA" type2="protein-CB" type3="protein-CB"/>
+    <Angle angle="2.3108159296404924" k="585.76" type1="protein-CA" type2="protein-CB" type3="protein-NB"/>
+    <Angle angle="1.9268434942017398" k="585.76" type1="protein-CB" type2="protein-CB" type3="protein-NB"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-H1" type2="protein-CT" type3="protein-OH"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-H1" type2="protein-CT" type3="protein-S"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-H1" type2="protein-CT" type3="protein-SH"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-H1" type2="protein-CT" type3="protein-N2"/>
+    <Angle angle="1.911135530933791" k="292.88" type1="protein-HP" type2="protein-CT" type3="protein-HP"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-HP" type2="protein-CT" type3="protein-N3"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-C" type2="protein-CT" type3="protein-H1"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-C" type2="protein-CT" type3="protein-HP"/>
+    <Angle angle="1.9216075064457567" k="527.184" type1="protein-C" type2="protein-CT" type3="protein-N"/>
+    <Angle angle="1.9408061282176945" k="669.44" type1="protein-C" type2="protein-CT" type3="protein-N3"/>
+    <Angle angle="1.9390607989657" k="527.184" type1="protein-C" type2="protein-CT" type3="protein-CT"/>
+    <Angle angle="1.9739673840055867" k="527.184" type1="protein-CC" type2="protein-CT" type3="protein-CT"/>
+    <Angle angle="1.911135530933791" k="334.72" type1="protein-CT" type2="protein-CT" type3="protein-CT"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CT" type2="protein-CT" type3="protein-HC"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CT" type2="protein-CT" type3="protein-H1"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CT" type2="protein-CT" type3="protein-HP"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CT" type2="protein-CT" type3="protein-OH"/>
+    <Angle angle="2.0018926520374962" k="418.40000000000003" type1="protein-CT" type2="protein-CT" type3="protein-S"/>
+    <Angle angle="1.8954275676658419" k="418.40000000000003" type1="protein-CT" type2="protein-CT" type3="protein-SH"/>
+    <Angle angle="1.9896753472735358" k="527.184" type1="protein-CT" type2="protein-CT" type3="protein-CA"/>
+    <Angle angle="1.9408061282176945" k="669.44" type1="protein-CT" type2="protein-CT" type3="protein-N2"/>
+    <Angle angle="1.9146261894377796" k="669.44" type1="protein-CT" type2="protein-CT" type3="protein-N"/>
+    <Angle angle="1.9408061282176945" k="669.44" type1="protein-CT" type2="protein-CT" type3="protein-N3"/>
+    <Angle angle="2.0176006153054447" k="527.184" type1="protein-C*" type2="protein-CT" type3="protein-CT"/>
+    <Angle angle="2.1275563581810877" k="418.40000000000003" type1="protein-C" type2="protein-N" type3="protein-CT"/>
+    <Angle angle="2.0601866490541068" k="418.40000000000003" type1="protein-CT" type2="protein-N" type3="protein-H"/>
+    <Angle angle="2.059488517353309" k="418.40000000000003" type1="protein-CT" type2="protein-N" type3="protein-CT"/>
+    <Angle angle="2.0943951023931953" k="292.88" type1="protein-H" type2="protein-N" type3="protein-H"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-CA" type2="protein-N2" type3="protein-H"/>
+    <Angle angle="2.150245638457014" k="418.40000000000003" type1="protein-CA" type2="protein-N2" type3="protein-CT"/>
+    <Angle angle="2.0664698343612864" k="418.40000000000003" type1="protein-CT" type2="protein-N2" type3="protein-H"/>
+    <Angle angle="2.0943951023931953" k="292.88" type1="protein-H" type2="protein-N2" type3="protein-H"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CT" type2="protein-N3" type3="protein-H"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CT" type2="protein-N3" type3="protein-CT"/>
+    <Angle angle="1.911135530933791" k="292.88" type1="protein-H" type2="protein-N3" type3="protein-H"/>
+    <Angle angle="2.2060961745208325" k="585.76" type1="protein-C" type2="protein-NA" type3="protein-C"/>
+    <Angle angle="2.1851522234969005" k="585.76" type1="protein-C" type2="protein-NA" type3="protein-CA"/>
+    <Angle angle="2.038544566329377" k="418.40000000000003" type1="protein-C" type2="protein-NA" type3="protein-H"/>
+    <Angle angle="2.059488517353309" k="418.40000000000003" type1="protein-CA" type2="protein-NA" type3="protein-H"/>
+    <Angle angle="1.9722220547535925" k="418.40000000000003" type1="protein-C" type2="protein-OH" type3="protein-HO"/>
+    <Angle angle="1.9722220547535925" k="418.40000000000003" type1="protein-CA" type2="protein-OH" type3="protein-HO"/>
+    <Angle angle="1.8936822384138476" k="460.24" type1="protein-CT" type2="protein-OH" type3="protein-HO"/>
+    <Angle angle="1.726130630222392" k="518.816" type1="protein-CT" type2="protein-S" type3="protein-CT"/>
+    <Angle angle="1.8099064343181197" k="569.024" type1="protein-CT" type2="protein-S" type3="protein-S"/>
+    <Angle angle="1.6755160819145565" k="359.824" type1="protein-CT" type2="protein-SH" type3="protein-HS"/>
+    <Angle angle="1.6069246423111792" k="292.88" type1="protein-HS" type2="protein-SH" type3="protein-HS"/>
+    <Angle angle="2.035053907825388" k="585.76" type1="protein-N" type2="protein-C" type3="protein-2C"/>
+    <Angle angle="2.101376419401173" k="669.44" type1="protein-O" type2="protein-C" type3="protein-2C"/>
+    <Angle angle="1.9198621771937625" k="669.44" type1="protein-OH" type2="protein-C" type3="protein-2C"/>
+    <Angle angle="2.2444934180647076" k="585.76" type1="protein-CB" type2="protein-C*" type3="protein-2C"/>
+    <Angle angle="2.181661564992912" k="585.76" type1="protein-CW" type2="protein-C*" type3="protein-2C"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-CA" type2="protein-CA" type3="protein-2C"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-CV" type2="protein-CC" type3="protein-2C"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-CW" type2="protein-CC" type3="protein-2C"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-NA" type2="protein-CC" type3="protein-2C"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-NB" type2="protein-CC" type3="protein-2C"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-HC" type2="protein-CT" type3="protein-2C"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-HC" type2="protein-CT" type3="protein-3C"/>
+    <Angle angle="1.8936822384138476" k="460.24" type1="protein-HO" type2="protein-OH" type3="protein-2C"/>
+    <Angle angle="1.8936822384138476" k="460.24" type1="protein-HO" type2="protein-OH" type3="protein-3C"/>
+    <Angle angle="1.726130630222392" k="518.816" type1="protein-CT" type2="protein-S" type3="protein-2C"/>
+    <Angle angle="1.8099064343181197" k="569.024" type1="protein-2C" type2="protein-S" type3="protein-S"/>
+    <Angle angle="1.6755160819145565" k="359.824" type1="protein-HS" type2="protein-SH" type3="protein-2C"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-C" type2="protein-2C" type3="protein-HC"/>
+    <Angle angle="1.9390607989657" k="527.184" type1="protein-C" type2="protein-2C" type3="protein-2C"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-C*" type2="protein-2C" type3="protein-HC"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CA" type2="protein-2C" type3="protein-HC"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CC" type2="protein-2C" type3="protein-HC"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CO" type2="protein-2C" type3="protein-HC"/>
+    <Angle angle="1.9390607989657" k="527.184" type1="protein-CO" type2="protein-2C" type3="protein-2C"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CT" type2="protein-2C" type3="protein-HC"/>
+    <Angle angle="1.911135530933791" k="334.72" type1="protein-CT" type2="protein-2C" type3="protein-3C"/>
+    <Angle angle="1.911135530933791" k="292.88" type1="protein-H1" type2="protein-2C" type3="protein-H1"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-H1" type2="protein-2C" type3="protein-OH"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-H1" type2="protein-2C" type3="protein-S"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-H1" type2="protein-2C" type3="protein-SH"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-H1" type2="protein-2C" type3="protein-2C"/>
+    <Angle angle="1.911135530933791" k="292.88" type1="protein-HC" type2="protein-2C" type3="protein-HC"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-HC" type2="protein-2C" type3="protein-2C"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-HC" type2="protein-2C" type3="protein-3C"/>
+    <Angle angle="2.0018926520374962" k="418.40000000000003" type1="protein-S" type2="protein-2C" type3="protein-2C"/>
+    <Angle angle="1.911135530933791" k="334.72" type1="protein-CT" type2="protein-3C" type3="protein-CT"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CT" type2="protein-3C" type3="protein-H1"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CT" type2="protein-3C" type3="protein-HC"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CT" type2="protein-3C" type3="protein-OH"/>
+    <Angle angle="1.911135530933791" k="334.72" type1="protein-CT" type2="protein-3C" type3="protein-2C"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-H1" type2="protein-3C" type3="protein-OH"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-HC" type2="protein-3C" type3="protein-2C"/>
+    <Angle angle="2.1771237089377267" k="667.4835616" type1="protein-OD" type2="protein-C" type3="protein-N"/>
+    <Angle angle="2.1450096507010312" k="669.44" type1="protein-OD" type2="protein-C" type3="protein-TN"/>
+    <Angle angle="2.1450096507010312" k="669.44" type1="protein-OD" type2="protein-C" type3="protein-ND"/>
+    <Angle angle="2.0875883183104174" k="411.090552" type1="protein-C" type2="protein-N" type3="protein-CX"/>
+    <Angle angle="2.1275563581810877" k="418.40000000000003" type1="protein-C" type2="protein-TN" type3="protein-TJ"/>
+    <Angle angle="2.0074777056438777" k="369.1702192" type1="protein-C" type2="protein-N" type3="protein-TG"/>
+    <Angle angle="2.026850860341015" k="370.3107776" type1="protein-C" type2="protein-N" type3="protein-TP"/>
+    <Angle angle="2.1390755312442504" k="376.0570832" type1="protein-C" type2="protein-N" type3="protein-TM"/>
+    <Angle angle="2.1275563581810877" k="418.40000000000003" type1="protein-C" type2="protein-TN" type3="protein-CT"/>
+    <Angle angle="2.0968385633459876" k="408.8169664" type1="protein-C" type2="protein-N" type3="protein-H"/>
+    <Angle angle="2.0355775066009865" k="405.5233216" type1="protein-H" type2="protein-N" type3="protein-CX"/>
+    <Angle angle="2.026501794490616" k="343.0227296" type1="protein-H" type2="protein-N" type3="protein-TG"/>
+    <Angle angle="1.9697785938008003" k="335.648848" type1="protein-H" type2="protein-N" type3="protein-TP"/>
+    <Angle angle="2.016378884829049" k="363.6406448" type1="protein-H" type2="protein-N" type3="protein-TM"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-H" type2="protein-NL" type3="protein-CX"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-H" type2="protein-NL" type3="protein-TJ"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-H" type2="protein-NL" type3="protein-TG"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-H" type2="protein-NL" type3="protein-TP"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-H" type2="protein-NL" type3="protein-TM"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-H" type2="protein-NL" type3="protein-CT"/>
+    <Angle angle="1.911135530933791" k="292.88" type1="protein-H" type2="protein-NL" type3="protein-H"/>
+    <Angle angle="2.059488517353309" k="418.40000000000003" type1="protein-CT" type2="protein-TN" type3="protein-TJ"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CT" type2="protein-NL" type3="protein-TJ"/>
+    <Angle angle="1.8715165569135197" k="521.364056" type1="protein-N" type2="protein-CX" type3="protein-C"/>
+    <Angle angle="1.8856537238546738" k="518.7356672000001" type1="protein-TN" type2="protein-TJ" type3="protein-C"/>
+    <Angle angle="1.879021472697095" k="524.5865728" type1="protein-N" type2="protein-TG" type3="protein-C"/>
+    <Angle angle="1.8505726058895877" k="470.93514080000006" type1="protein-N" type2="protein-TP" type3="protein-C"/>
+    <Angle angle="1.8404496962280206" k="516.3399088" type1="protein-N" type2="protein-TM" type3="protein-C"/>
+    <Angle angle="1.9408061282176945" k="669.44" type1="protein-NL" type2="protein-CX" type3="protein-C"/>
+    <Angle angle="1.9408061282176945" k="669.44" type1="protein-NL" type2="protein-TJ" type3="protein-C"/>
+    <Angle angle="1.9408061282176945" k="669.44" type1="protein-NL" type2="protein-TG" type3="protein-C"/>
+    <Angle angle="1.9408061282176945" k="669.44" type1="protein-NL" type2="protein-TP" type3="protein-C"/>
+    <Angle angle="1.9408061282176945" k="669.44" type1="protein-NL" type2="protein-TM" type3="protein-C"/>
+    <Angle angle="1.9216075064457567" k="527.184" type1="protein-N" type2="protein-CX" type3="protein-CO"/>
+    <Angle angle="1.9216075064457567" k="527.184" type1="protein-TN" type2="protein-TJ" type3="protein-CO"/>
+    <Angle angle="1.9216075064457567" k="527.184" type1="protein-N" type2="protein-TG" type3="protein-CO"/>
+    <Angle angle="1.9216075064457567" k="527.184" type1="protein-N" type2="protein-TP" type3="protein-CO"/>
+    <Angle angle="1.9216075064457567" k="527.184" type1="protein-N" type2="protein-TM" type3="protein-CO"/>
+    <Angle angle="1.9603538158400309" k="669.5370688" type1="protein-N" type2="protein-CX" type3="protein-CT"/>
+    <Angle angle="1.943773187946085" k="659.8971328" type1="protein-N" type2="protein-CX" type3="protein-TA"/>
+    <Angle angle="1.9401079965168966" k="662.6836768000001" type1="protein-N" type2="protein-CX" type3="protein-2C"/>
+    <Angle angle="1.9395843977412983" k="658.4084656000001" type1="protein-N" type2="protein-CX" type3="protein-3C"/>
+    <Angle angle="1.8807668019490895" k="659.9105216" type1="protein-TN" type2="protein-TJ" type3="protein-CT"/>
+    <Angle angle="1.9134044589613834" k="647.1258912" type1="protein-N" type2="protein-TP" type3="protein-C8"/>
+    <Angle angle="1.9401079965168966" k="676.5712096" type1="protein-N" type2="protein-TM" type3="protein-2C"/>
+    <Angle angle="1.9408061282176945" k="669.44" type1="protein-NL" type2="protein-CX" type3="protein-CT"/>
+    <Angle angle="1.9408061282176945" k="669.44" type1="protein-NL" type2="protein-CX" type3="protein-2C"/>
+    <Angle angle="1.9408061282176945" k="669.44" type1="protein-NL" type2="protein-CX" type3="protein-3C"/>
+    <Angle angle="1.9408061282176945" k="669.44" type1="protein-NL" type2="protein-CX" type3="protein-TA"/>
+    <Angle angle="1.9408061282176945" k="669.44" type1="protein-NL" type2="protein-TJ" type3="protein-CT"/>
+    <Angle angle="1.9408061282176945" k="669.44" type1="protein-NL" type2="protein-TM" type3="protein-2C"/>
+    <Angle angle="1.9408061282176945" k="669.44" type1="protein-NL" type2="protein-TP" type3="protein-C8"/>
+    <Angle angle="1.9336502782845177" k="420.5689856" type1="protein-N" type2="protein-CX" type3="protein-H1"/>
+    <Angle angle="1.92981055393013" k="408.03121120000003" type1="protein-TN" type2="protein-TJ" type3="protein-H1"/>
+    <Angle angle="1.924400033248948" k="436.8313568" type1="protein-N" type2="protein-TG" type3="protein-H1"/>
+    <Angle angle="1.9352210746113125" k="403.2673088" type1="protein-N" type2="protein-TP" type3="protein-H1"/>
+    <Angle angle="1.9603538158400309" k="442.4262016" type1="protein-N" type2="protein-TM" type3="protein-H1"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-N" type2="protein-CT" type3="protein-H1"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-NL" type2="protein-CX" type3="protein-HP"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-NL" type2="protein-TJ" type3="protein-HP"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-NL" type2="protein-TG" type3="protein-HP"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-NL" type2="protein-TP" type3="protein-HP"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-NL" type2="protein-TM" type3="protein-HP"/>
+    <Angle angle="1.9146261894377796" k="669.44" type1="protein-TN" type2="protein-CT" type3="protein-CT"/>
+    <Angle angle="1.9408061282176945" k="669.44" type1="protein-NL" type2="protein-CT" type3="protein-CT"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-TN" type2="protein-CT" type3="protein-H1"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-NL" type2="protein-CT" type3="protein-HP"/>
+    <Angle angle="1.9734437852299882" k="419.90791360000003" type1="protein-CT" type2="protein-CX" type3="protein-H1"/>
+    <Angle angle="1.9568631573360424" k="420.9262992" type1="protein-2C" type2="protein-CX" type3="protein-H1"/>
+    <Angle angle="1.9671605999228088" k="422.0835936" type1="protein-3C" type2="protein-CX" type3="protein-H1"/>
+    <Angle angle="1.9617500792416265" k="429.0599952" type1="protein-TA" type2="protein-CX" type3="protein-H1"/>
+    <Angle angle="1.9528489000564553" k="420.140544" type1="protein-CT" type2="protein-TJ" type3="protein-H1"/>
+    <Angle angle="1.9168951174653721" k="431.5645376" type1="protein-C8" type2="protein-TP" type3="protein-H1"/>
+    <Angle angle="1.92370190154815" k="427.1997888" type1="protein-2C" type2="protein-TM" type3="protein-H1"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CT" type2="protein-CX" type3="protein-HP"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-2C" type2="protein-CX" type3="protein-HP"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-3C" type2="protein-CX" type3="protein-HP"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-TA" type2="protein-CX" type3="protein-HP"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CT" type2="protein-TJ" type3="protein-HP"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-C8" type2="protein-TP" type3="protein-HP"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-2C" type2="protein-TM" type3="protein-HP"/>
+    <Angle angle="1.9385372001901018" k="316.04680800000006" type1="protein-H1" type2="protein-TG" type3="protein-H1"/>
+    <Angle angle="1.911135530933791" k="292.88" type1="protein-HP" type2="protein-TG" type3="protein-HP"/>
+    <Angle angle="1.9509290378792616" k="523.8309424" type1="protein-CT" type2="protein-CX" type3="protein-C"/>
+    <Angle angle="1.9308577514813268" k="521.0377040000001" type1="protein-2C" type2="protein-CX" type3="protein-C"/>
+    <Angle angle="1.9409806611428937" k="518.5222832000001" type1="protein-3C" type2="protein-CX" type3="protein-C"/>
+    <Angle angle="1.9364428050877087" k="514.878856" type1="protein-TA" type2="protein-CX" type3="protein-C"/>
+    <Angle angle="1.9198621771937625" k="477.81447360000004" type1="protein-CT" type2="protein-TJ" type3="protein-C"/>
+    <Angle angle="1.9481365110760707" k="505.64309440000005" type1="protein-C8" type2="protein-TP" type3="protein-C"/>
+    <Angle angle="1.9420278586940904" k="501.9829312" type1="protein-2C" type2="protein-TM" type3="protein-C"/>
+    <Angle angle="1.9390607989657" k="527.184" type1="protein-CT" type2="protein-CX" type3="protein-CO"/>
+    <Angle angle="1.9390607989657" k="527.184" type1="protein-2C" type2="protein-CX" type3="protein-CO"/>
+    <Angle angle="1.9390607989657" k="527.184" type1="protein-3C" type2="protein-CX" type3="protein-CO"/>
+    <Angle angle="1.9390607989657" k="527.184" type1="protein-TA" type2="protein-CX" type3="protein-CO"/>
+    <Angle angle="1.9390607989657" k="527.184" type1="protein-CT" type2="protein-TJ" type3="protein-CO"/>
+    <Angle angle="1.9390607989657" k="527.184" type1="protein-C8" type2="protein-TP" type3="protein-CO"/>
+    <Angle angle="1.9390607989657" k="527.184" type1="protein-2C" type2="protein-TM" type3="protein-CO"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-HC" type2="protein-CT" type3="protein-C"/>
+    <Angle angle="1.9505799720288628" k="417.36738880000007" type1="protein-H1" type2="protein-CX" type3="protein-C"/>
+    <Angle angle="1.8894934482090613" k="382.296264" type1="protein-H1" type2="protein-TJ" type3="protein-C"/>
+    <Angle angle="1.9380136014145037" k="420.4886528" type1="protein-H1" type2="protein-TG" type3="protein-C"/>
+    <Angle angle="2.008873969045473" k="393.40060000000005" type1="protein-H1" type2="protein-TP" type3="protein-C"/>
+    <Angle angle="1.9257962966505433" k="410.2085648" type1="protein-H1" type2="protein-TM" type3="protein-C"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-HP" type2="protein-CX" type3="protein-C"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-HP" type2="protein-TJ" type3="protein-C"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-HP" type2="protein-TG" type3="protein-C"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-HP" type2="protein-TP" type3="protein-C"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-HP" type2="protein-TM" type3="protein-C"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-H1" type2="protein-CX" type3="protein-CO"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-H1" type2="protein-TJ" type3="protein-CO"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-H1" type2="protein-TG" type3="protein-CO"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-H1" type2="protein-TP" type3="protein-CO"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-H1" type2="protein-TM" type3="protein-CO"/>
+    <Angle angle="2.0001473227855016" k="565.5604848" type1="protein-CX" type2="protein-C" type3="protein-N"/>
+    <Angle angle="2.035053907825388" k="585.76" type1="protein-TJ" type2="protein-C" type3="protein-N"/>
+    <Angle angle="1.9727456535291907" k="519.3992496" type1="protein-TG" type2="protein-C" type3="protein-N"/>
+    <Angle angle="2.0244073993882226" k="565.3705312000001" type1="protein-TP" type2="protein-C" type3="protein-N"/>
+    <Angle angle="1.9991001252343052" k="556.7950048" type1="protein-TM" type2="protein-C" type3="protein-N"/>
+    <Angle angle="2.035053907825388" k="585.76" type1="protein-CT" type2="protein-C" type3="protein-N"/>
+    <Angle angle="2.035053907825388" k="585.76" type1="protein-CX" type2="protein-C" type3="protein-TN"/>
+    <Angle angle="2.035053907825388" k="585.76" type1="protein-TJ" type2="protein-C" type3="protein-TN"/>
+    <Angle angle="2.035053907825388" k="585.76" type1="protein-TG" type2="protein-C" type3="protein-TN"/>
+    <Angle angle="2.035053907825388" k="585.76" type1="protein-TP" type2="protein-C" type3="protein-TN"/>
+    <Angle angle="2.035053907825388" k="585.76" type1="protein-TM" type2="protein-C" type3="protein-TN"/>
+    <Angle angle="2.035053907825388" k="585.76" type1="protein-CT" type2="protein-C" type3="protein-TN"/>
+    <Angle angle="2.035053907825388" k="585.76" type1="protein-CX" type2="protein-C" type3="protein-ND"/>
+    <Angle angle="2.035053907825388" k="585.76" type1="protein-TJ" type2="protein-C" type3="protein-ND"/>
+    <Angle angle="2.035053907825388" k="585.76" type1="protein-TG" type2="protein-C" type3="protein-ND"/>
+    <Angle angle="2.035053907825388" k="585.76" type1="protein-TP" type2="protein-C" type3="protein-ND"/>
+    <Angle angle="2.035053907825388" k="585.76" type1="protein-TM" type2="protein-C" type3="protein-ND"/>
+    <Angle angle="2.035053907825388" k="585.76" type1="protein-CT" type2="protein-C" type3="protein-ND"/>
+    <Angle angle="2.0992820242987795" k="657.8478096" type1="protein-CX" type2="protein-C" type3="protein-OD"/>
+    <Angle angle="2.101376419401173" k="669.44" type1="protein-TJ" type2="protein-C" type3="protein-OD"/>
+    <Angle angle="2.1287780886574836" k="629.2828048" type1="protein-TG" type2="protein-C" type3="protein-OD"/>
+    <Angle angle="2.122843969200703" k="643.2347712" type1="protein-TP" type2="protein-C" type3="protein-OD"/>
+    <Angle angle="2.055474260073722" k="647.1083184" type1="protein-TM" type2="protein-C" type3="protein-OD"/>
+    <Angle angle="2.101376419401173" k="669.44" type1="protein-CT" type2="protein-C" type3="protein-OD"/>
+    <Angle angle="2.0420352248333655" k="585.76" type1="protein-CX" type2="protein-CO" type3="protein-O3"/>
+    <Angle angle="2.0420352248333655" k="585.76" type1="protein-TJ" type2="protein-CO" type3="protein-O3"/>
+    <Angle angle="2.0420352248333655" k="585.76" type1="protein-TG" type2="protein-CO" type3="protein-O3"/>
+    <Angle angle="2.0420352248333655" k="585.76" type1="protein-TP" type2="protein-CO" type3="protein-O3"/>
+    <Angle angle="2.0420352248333655" k="585.76" type1="protein-TM" type2="protein-CO" type3="protein-O3"/>
+    <Angle angle="2.101376419401173" k="669.44" type1="protein-CX" type2="protein-C" type3="protein-O"/>
+    <Angle angle="1.9198621771937625" k="669.44" type1="protein-CX" type2="protein-C" type3="protein-OH"/>
+    <Angle angle="1.9390607989657" k="527.184" type1="protein-CX" type2="protein-2C" type3="protein-C"/>
+    <Angle angle="1.8954275676658419" k="418.40000000000003" type1="protein-CX" type2="protein-2C" type3="protein-SH"/>
+    <Angle angle="2.0018926520374962" k="418.40000000000003" type1="protein-CX" type2="protein-2C" type3="protein-S"/>
+    <Angle angle="1.911135530933791" k="334.72" type1="protein-CX" type2="protein-2C" type3="protein-2C"/>
+    <Angle angle="1.911135530933791" k="334.72" type1="protein-CX" type2="protein-2C" type3="protein-3C"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CX" type2="protein-2C" type3="protein-OA"/>
+    <Angle angle="1.911135530933791" k="334.72" type1="protein-CX" type2="protein-3C" type3="protein-CT"/>
+    <Angle angle="1.911135530933791" k="334.72" type1="protein-CX" type2="protein-3C" type3="protein-2C"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CX" type2="protein-3C" type3="protein-OA"/>
+    <Angle angle="1.9739673840055867" k="527.184" type1="protein-CX" type2="protein-TA" type3="protein-CC"/>
+    <Angle angle="1.9896753472735358" k="527.184" type1="protein-CX" type2="protein-TA" type3="protein-CA"/>
+    <Angle angle="2.0176006153054447" k="527.184" type1="protein-CX" type2="protein-TA" type3="protein-C*"/>
+    <Angle angle="1.911135530933791" k="334.72" type1="protein-TJ" type2="protein-CT" type3="protein-CT"/>
+    <Angle angle="1.911135530933791" k="334.72" type1="protein-TP" type2="protein-C8" type3="protein-C8"/>
+    <Angle angle="1.9739673840055867" k="527.184" type1="protein-TP" type2="protein-C8" type3="protein-CC"/>
+    <Angle angle="1.911135530933791" k="334.72" type1="protein-TM" type2="protein-2C" type3="protein-2C"/>
+    <Angle angle="1.9390607989657" k="527.184" type1="protein-TM" type2="protein-2C" type3="protein-CO"/>
+    <Angle angle="1.8954275676658419" k="418.40000000000003" type1="protein-TM" type2="protein-2C" type3="protein-SH"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CX" type2="protein-CT" type3="protein-HC"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CX" type2="protein-2C" type3="protein-HC"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CX" type2="protein-3C" type3="protein-HC"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CX" type2="protein-TA" type3="protein-HC"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-TJ" type2="protein-CT" type3="protein-HC"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-TP" type2="protein-C8" type3="protein-HC"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-TM" type2="protein-2C" type3="protein-HC"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CX" type2="protein-2C" type3="protein-H1"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CX" type2="protein-3C" type3="protein-H1"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-TM" type2="protein-2C" type3="protein-H1"/>
+    <Angle angle="1.911135530933791" k="292.88" type1="protein-HC" type2="protein-CT" type3="protein-HC"/>
+    <Angle angle="1.911135530933791" k="292.88" type1="protein-HC" type2="protein-TA" type3="protein-HC"/>
+    <Angle angle="1.911135530933791" k="292.88" type1="protein-H1" type2="protein-CT" type3="protein-H1"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-HC" type2="protein-2C" type3="protein-N3"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-2C" type2="protein-N3" type3="protein-H"/>
+    <Angle angle="1.9408061282176945" k="669.44" type1="protein-2C" type2="protein-2C" type3="protein-N3"/>
+    <Angle angle="1.911135530933791" k="334.72" type1="protein-2C" type2="protein-2C" type3="protein-2C"/>
+    <Angle angle="1.911135530933791" k="334.72" type1="protein-2C" type2="protein-2C" type3="protein-CT"/>
+    <Angle angle="2.101376419401173" k="669.44" type1="protein-2C" type2="protein-C" type3="protein-OD"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-H1" type2="protein-2C" type3="protein-OA"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-C" type2="protein-ND" type3="protein-H"/>
+    <Angle angle="2.0943951023931953" k="292.88" type1="protein-H" type2="protein-ND" type3="protein-H"/>
+    <Angle angle="2.035053907825388" k="585.76" type1="protein-2C" type2="protein-C" type3="protein-ND"/>
+    <Angle angle="1.8936822384138476" k="460.24" type1="protein-HO" type2="protein-OA" type3="protein-2C"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CT" type2="protein-3C" type3="protein-OA"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-H1" type2="protein-3C" type3="protein-OA"/>
+    <Angle angle="1.8936822384138476" k="460.24" type1="protein-HO" type2="protein-OA" type3="protein-3C"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-TA" type2="protein-CC" type3="protein-NA"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-TA" type2="protein-CC" type3="protein-NB"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-TA" type2="protein-CC" type3="protein-CV"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-TA" type2="protein-CC" type3="protein-CW"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-CV" type2="protein-CC" type3="protein-NA"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-CW" type2="protein-CC" type3="protein-NB"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-CW" type2="protein-CC" type3="protein-NA"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-CC" type2="protein-CV" type3="protein-NB"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-CC" type2="protein-CW" type3="protein-NA"/>
+    <Angle angle="2.0420352248333655" k="585.76" type1="protein-CV" type2="protein-NB" type3="protein-CR"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-CW" type2="protein-NA" type3="protein-CR"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-NB" type2="protein-CR" type3="protein-NA"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-NA" type2="protein-CR" type3="protein-NA"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-CR" type2="protein-NA" type3="protein-CC"/>
+    <Angle angle="2.0420352248333655" k="585.76" type1="protein-CR" type2="protein-NB" type3="protein-CC"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CC" type2="protein-TA" type3="protein-HC"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-CC" type2="protein-CV" type3="protein-H4"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-CC" type2="protein-CW" type3="protein-H4"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-CC" type2="protein-NA" type3="protein-H"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-CW" type2="protein-NA" type3="protein-H"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-CR" type2="protein-NA" type3="protein-H"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-NB" type2="protein-CV" type3="protein-H4"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-NA" type2="protein-CW" type3="protein-H4"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-NA" type2="protein-CR" type3="protein-H5"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-NB" type2="protein-CR" type3="protein-H5"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-TA" type2="protein-CA" type3="protein-CA"/>
+    <Angle angle="2.0943951023931953" k="527.184" type1="protein-CA" type2="protein-CA" type3="protein-CA"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-CA" type2="protein-CA" type3="protein-HA"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CA" type2="protein-TA" type3="protein-HC"/>
+    <Angle angle="2.0943951023931953" k="527.184" type1="protein-CA" type2="protein-CA" type3="protein-C"/>
+    <Angle angle="2.0943951023931953" k="527.184" type1="protein-CA" type2="protein-C" type3="protein-CA"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-CA" type2="protein-C" type3="protein-OA"/>
+    <Angle angle="1.9722220547535925" k="418.40000000000003" type1="protein-C" type2="protein-OA" type3="protein-HO"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-C" type2="protein-CA" type3="protein-HA"/>
+    <Angle angle="2.2444934180647076" k="585.76" type1="protein-TA" type2="protein-C*" type3="protein-CB"/>
+    <Angle angle="2.181661564992912" k="585.76" type1="protein-TA" type2="protein-C*" type3="protein-CW"/>
+    <Angle angle="1.8570303241219668" k="527.184" type1="protein-CB" type2="protein-C*" type3="protein-CW"/>
+    <Angle angle="1.8971728969178363" k="585.76" type1="protein-C*" type2="protein-CW" type3="protein-NA"/>
+    <Angle angle="2.3544491609403506" k="527.184" type1="protein-C*" type2="protein-CB" type3="protein-CA"/>
+    <Angle angle="1.8989182261698305" k="527.184" type1="protein-C*" type2="protein-CB" type3="protein-CN"/>
+    <Angle angle="1.9477874452256716" k="585.76" type1="protein-CN" type2="protein-NA" type3="protein-CW"/>
+    <Angle angle="2.0943951023931953" k="527.184" type1="protein-CA" type2="protein-CA" type3="protein-CB"/>
+    <Angle angle="2.0943951023931953" k="527.184" type1="protein-CA" type2="protein-CA" type3="protein-CN"/>
+    <Angle angle="2.028072590817411" k="527.184" type1="protein-CA" type2="protein-CB" type3="protein-CN"/>
+    <Angle angle="2.3177972466484698" k="585.76" type1="protein-CA" type2="protein-CN" type3="protein-NA"/>
+    <Angle angle="1.8221237390820801" k="585.76" type1="protein-CB" type2="protein-CN" type3="protein-NA"/>
+    <Angle angle="2.1415189921970423" k="527.184" type1="protein-CA" type2="protein-CN" type3="protein-CB"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-C*" type2="protein-TA" type3="protein-HC"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-C*" type2="protein-CW" type3="protein-H4"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-CB" type2="protein-CA" type3="protein-HA"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-CN" type2="protein-CA" type3="protein-HA"/>
+    <Angle angle="2.1485003092050197" k="418.40000000000003" type1="protein-CN" type2="protein-NA" type3="protein-H"/>
+    <Angle angle="1.911135530933791" k="334.72" type1="protein-C8" type2="protein-C8" type3="protein-C8"/>
+    <Angle angle="1.9408061282176945" k="669.44" type1="protein-C8" type2="protein-C8" type3="protein-N2"/>
+    <Angle angle="2.150245638457014" k="418.40000000000003" type1="protein-C8" type2="protein-N2" type3="protein-CA"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-N2" type2="protein-CA" type3="protein-N2"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-C8" type2="protein-CC" type3="protein-NA"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-C8" type2="protein-CC" type3="protein-CW"/>
+    <Angle angle="1.9408061282176945" k="669.44" type1="protein-C8" type2="protein-C8" type3="protein-NL"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-C8" type2="protein-C8" type3="protein-HC"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-C8" type2="protein-C8" type3="protein-H1"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-C8" type2="protein-C8" type3="protein-HP"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-H1" type2="protein-C8" type3="protein-N2"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-HP" type2="protein-C8" type3="protein-NL"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-C8" type2="protein-NL" type3="protein-H"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CC" type2="protein-C8" type3="protein-HC"/>
+    <Angle angle="2.0664698343612864" k="418.40000000000003" type1="protein-C8" type2="protein-N2" type3="protein-TH"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-CA" type2="protein-N2" type3="protein-TH"/>
+    <Angle angle="1.911135530933791" k="292.88" type1="protein-HC" type2="protein-C8" type3="protein-HC"/>
+    <Angle angle="1.911135530933791" k="292.88" type1="protein-H1" type2="protein-C8" type3="protein-H1"/>
+    <Angle angle="1.911135530933791" k="292.88" type1="protein-HP" type2="protein-C8" type3="protein-HP"/>
+    <Angle angle="2.0943951023931953" k="292.88" type1="protein-TH" type2="protein-N2" type3="protein-TH"/>
+    <Angle angle="2.0420352248333655" k="585.76" type1="protein-2C" type2="protein-CO" type3="protein-O3"/>
+    <Angle angle="2.199114857512855" k="669.44" type1="protein-O3" type2="protein-CO" type3="protein-O3"/>
+  </HarmonicAngleForce>
+  <PeriodicTorsionForce ordering="amber">
+    <Proper k1="15.167" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-C" type3="protein-C" type4=""/>
+    <Proper k1="12.552" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-C" type3="protein-CB" type4=""/>
+    <Proper k1="5.6484000000000005" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-C" type3="protein-NA" type4=""/>
+    <Proper k1="11.7152" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-C" type3="protein-O" type4=""/>
+    <Proper k1="10.0416" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-CA" type3="protein-N2" type4=""/>
+    <Proper k1="6.276" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-CA" type3="protein-NA" type4=""/>
+    <Proper k1="3.7656" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-CA" type3="protein-OH" type4=""/>
+    <Proper k1="22.8028" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-CB" type3="protein-CB" type4=""/>
+    <Proper k1="10.6692" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-CB" type3="protein-NB" type4=""/>
+    <Proper k1="0.0" periodicity1="3" phase1="0.0" type1="" type2="protein-CT" type3="protein-N2" type4=""/>
+    <Proper k1="0.6508630400000001" periodicity1="3" phase1="0.0" type1="" type2="protein-CT" type3="protein-N3" type4=""/>
+    <Proper k1="0.6973472800000001" periodicity1="3" phase1="0.0" type1="" type2="protein-CT" type3="protein-OH" type4=""/>
+    <Proper k1="1.046" periodicity1="3" phase1="0.0" type1="" type2="protein-CT" type3="protein-SH" type4=""/>
+    <Proper k1="1.6182875200000002" periodicity1="2" phase1="0.0" type1="" type2="protein-N" type3="protein-CX" type4=""/>
+    <Proper k1="4.0437104800000006" periodicity1="2" phase1="0.0" type1="" type2="protein-TN" type3="protein-TJ" type4=""/>
+    <Proper k1="0.65077936" periodicity1="2" phase1="0.0" type1="" type2="protein-N" type3="protein-TG" type4=""/>
+    <Proper k1="3.76806856" periodicity1="2" phase1="0.0" type1="" type2="protein-N" type3="protein-TP" type4=""/>
+    <Proper k1="2.3499017600000003" periodicity1="2" phase1="0.0" type1="" type2="protein-N" type3="protein-TM" type4=""/>
+    <Proper k1="1.4574964000000001" periodicity1="2" phase1="0.0" type1="" type2="protein-N" type3="protein-CT" type4=""/>
+    <Proper k1="0.30120616" periodicity1="3" phase1="0.0" type1="" type2="protein-NL" type3="protein-CX" type4=""/>
+    <Proper k1="0.8321139200000001" periodicity1="3" phase1="0.0" type1="" type2="protein-NL" type3="protein-TJ" type4=""/>
+    <Proper k1="0.15409672000000002" periodicity1="3" phase1="0.0" type1="" type2="protein-NL" type3="protein-TG" type4=""/>
+    <Proper k1="0.26355016000000003" periodicity1="3" phase1="0.0" type1="" type2="protein-NL" type3="protein-TP" type4=""/>
+    <Proper k1="0.31045280000000003" periodicity1="3" phase1="0.0" type1="" type2="protein-NL" type3="protein-TM" type4=""/>
+    <Proper k1="-1.80677672" periodicity1="2" phase1="0.0" type1="" type2="protein-TN" type3="protein-CT" type4=""/>
+    <Proper k1="0.53270688" periodicity1="3" phase1="0.0" type1="" type2="protein-NL" type3="protein-CT" type4=""/>
+    <Proper k1="0.00828432" periodicity1="2" phase1="0.0" type1="" type2="protein-CX" type3="protein-C" type4=""/>
+    <Proper k1="-1.1341150400000002" periodicity1="2" phase1="0.0" type1="" type2="protein-TJ" type3="protein-C" type4=""/>
+    <Proper k1="-3.0618512" periodicity1="2" phase1="0.0" type1="" type2="protein-TG" type3="protein-C" type4=""/>
+    <Proper k1="-0.81918536" periodicity1="2" phase1="0.0" type1="" type2="protein-TP" type3="protein-C" type4=""/>
+    <Proper k1="3.64518448" periodicity1="2" phase1="0.0" type1="" type2="protein-TM" type3="protein-C" type4=""/>
+    <Proper k1="-0.49651528" periodicity1="2" phase1="0.0" type1="" type2="protein-CT" type3="protein-C" type4=""/>
+    <Proper k1="-9.52127776" periodicity1="2" phase1="0.0" type1="" type2="protein-CX" type3="protein-CO" type4=""/>
+    <Proper k1="1.52188816" periodicity1="2" phase1="0.0" type1="" type2="protein-TJ" type3="protein-CO" type4=""/>
+    <Proper k1="-10.90024048" periodicity1="2" phase1="0.0" type1="" type2="protein-TG" type3="protein-CO" type4=""/>
+    <Proper k1="-11.038730880000001" periodicity1="2" phase1="0.0" type1="" type2="protein-TP" type3="protein-CO" type4=""/>
+    <Proper k1="-5.69998872" periodicity1="2" phase1="0.0" type1="" type2="protein-TM" type3="protein-CO" type4=""/>
+    <Proper k1="10.3204636" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-C" type3="protein-N" type4=""/>
+    <Proper k1="12.49003496" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-C" type3="protein-TN" type4=""/>
+    <Proper k1="8.819620960000002" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-C" type3="protein-ND" type4=""/>
+    <Proper k1="1.03102128" periodicity1="3" phase1="0.0" type1="" type2="protein-CX" type3="protein-CT" type4=""/>
+    <Proper k1="0.9144132" periodicity1="3" phase1="0.0" type1="" type2="protein-CX" type3="protein-2C" type4=""/>
+    <Proper k1="-0.31250296000000005" periodicity1="3" phase1="0.0" type1="" type2="protein-CX" type3="protein-3C" type4=""/>
+    <Proper k1="1.59130072" periodicity1="3" phase1="0.0" type1="" type2="protein-CX" type3="protein-TA" type4=""/>
+    <Proper k1="0.9190156" periodicity1="3" phase1="0.0" type1="" type2="protein-TJ" type3="protein-CT" type4=""/>
+    <Proper k1="1.3925188800000001" periodicity1="3" phase1="0.0" type1="" type2="protein-TP" type3="protein-C8" type4=""/>
+    <Proper k1="0.49128528" periodicity1="3" phase1="0.0" type1="" type2="protein-TM" type3="protein-2C" type4=""/>
+    <Proper k1="2.3836248" periodicity1="2" phase1="0.0" type1="" type2="protein-TA" type3="protein-CC" type4=""/>
+    <Proper k1="-1.92664832" periodicity1="2" phase1="0.0" type1="" type2="protein-TA" type3="protein-CA" type4=""/>
+    <Proper k1="-2.89838232" periodicity1="2" phase1="0.0" type1="" type2="protein-TA" type3="protein-C*" type4=""/>
+    <Proper k1="2.7598082400000004" periodicity1="3" phase1="0.0" type1="" type2="protein-2C" type3="protein-SH" type4=""/>
+    <Proper k1="0.9985116" periodicity1="3" phase1="0.0" type1="" type2="protein-2C" type3="protein-S" type4=""/>
+    <Proper k1="0.4920384" periodicity1="3" phase1="0.0" type1="" type2="protein-2C" type3="protein-CT" type4=""/>
+    <Proper k1="0.6024541600000001" periodicity1="3" phase1="0.0" type1="" type2="protein-2C" type3="protein-2C" type4=""/>
+    <Proper k1="0.6642100000000001" periodicity1="3" phase1="0.0" type1="" type2="protein-2C" type3="protein-N3" type4=""/>
+    <Proper k1="0.64170008" periodicity1="3" phase1="0.0" type1="" type2="protein-3C" type3="protein-CT" type4=""/>
+    <Proper k1="0.21991104000000003" periodicity1="3" phase1="0.0" type1="" type2="protein-3C" type3="protein-2C" type4=""/>
+    <Proper k1="0.90817904" periodicity1="3" phase1="0.0" type1="" type2="protein-CT" type3="protein-CT" type4=""/>
+    <Proper k1="-6.4451591200000005" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-CV" type3="protein-NB" type4=""/>
+    <Proper k1="3.0231492" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-CW" type3="protein-NA" type4=""/>
+    <Proper k1="15.001188080000002" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-CR" type3="protein-NA" type4=""/>
+    <Proper k1="0.17874048" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-CR" type3="protein-NB" type4=""/>
+    <Proper k1="5.98031672" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-CC" type3="protein-NA" type4="protein-H"/>
+    <Proper k1="15.6184536" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-CA" type3="protein-CA" type4=""/>
+    <Proper k1="25.15583976" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-CB" type3="protein-CN" type4=""/>
+    <Proper k1="8.475738" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-CN" type3="protein-NA" type4=""/>
+    <Proper k1="3.38728272" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-C*" type3="protein-CB" type4=""/>
+    <Proper k1="39.88448208" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-C*" type3="protein-CW" type4=""/>
+    <Proper k1="17.16552944" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-C" type3="protein-CA" type4=""/>
+    <Proper k1="12.05887376" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-CA" type3="protein-CB" type4=""/>
+    <Proper k1="14.821903680000002" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-CA" type3="protein-CN" type4=""/>
+    <Proper k1="0.7064684" periodicity1="3" phase1="0.0" type1="" type2="protein-C8" type3="protein-C8" type4=""/>
+    <Proper k1="3.5255220800000004" periodicity1="3" phase1="0.0" type1="" type2="protein-C8" type3="protein-N2" type4=""/>
+    <Proper k1="7.994661680000001" periodicity1="2" phase1="0.0" type1="" type2="protein-C8" type3="protein-CC" type4=""/>
+    <Proper k1="-1.22762744" periodicity1="3" phase1="0.0" type1="" type2="protein-C8" type3="protein-NL" type4=""/>
+    <Proper k1="10.12733016" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-C" type3="protein-OH" type4=""/>
+    <Proper k1="1.0649116800000002" periodicity1="3" phase1="0.0" type1="" type2="protein-CT" type3="protein-S" type4=""/>
+    <Proper k1="27.380974639999998" periodicity1="2" phase1="3.141592653589793" type1="protein-C8" type2="protein-CC" type3="protein-NA" type4="protein-CR"/>
+    <Proper k1="27.380974639999998" periodicity1="2" phase1="3.141592653589793" type1="protein-CW" type2="protein-CC" type3="protein-NA" type4="protein-CR"/>
+    <Proper k1="27.380974639999998" periodicity1="2" phase1="3.141592653589793" type1="protein-TA" type2="protein-CC" type3="protein-NA" type4="protein-CR"/>
+    <Proper k1="27.380974639999998" periodicity1="2" phase1="3.141592653589793" type1="protein-CV" type2="protein-CC" type3="protein-NA" type4="protein-CR"/>
+    <Proper k1="35.712197280000005" periodicity1="2" phase1="3.141592653589793" type1="protein-TA" type2="protein-CC" type3="protein-NB" type4="protein-CR"/>
+    <Proper k1="35.712197280000005" periodicity1="2" phase1="3.141592653589793" type1="protein-CW" type2="protein-CC" type3="protein-NB" type4="protein-CR"/>
+    <Proper k1="24.568113280000002" periodicity1="2" phase1="3.141592653589793" type1="protein-NA" type2="protein-CC" type3="protein-CV" type4="protein-H4"/>
+    <Proper k1="24.568113280000002" periodicity1="2" phase1="3.141592653589793" type1="protein-TA" type2="protein-CC" type3="protein-CV" type4="protein-H4"/>
+    <Proper k1="21.67282712" periodicity1="2" phase1="3.141592653589793" type1="protein-NB" type2="protein-CC" type3="protein-CW" type4="protein-H4"/>
+    <Proper k1="21.67282712" periodicity1="2" phase1="3.141592653589793" type1="protein-TA" type2="protein-CC" type3="protein-CW" type4="protein-H4"/>
+    <Proper k1="21.67282712" periodicity1="2" phase1="3.141592653589793" type1="protein-NA" type2="protein-CC" type3="protein-CW" type4="protein-H4"/>
+    <Proper k1="21.67282712" periodicity1="2" phase1="3.141592653589793" type1="protein-C8" type2="protein-CC" type3="protein-CW" type4="protein-H4"/>
+    <Proper k1="37.98097128" periodicity1="2" phase1="3.141592653589793" type1="protein-NA" type2="protein-CC" type3="protein-CV" type4="protein-NB"/>
+    <Proper k1="37.98097128" periodicity1="2" phase1="3.141592653589793" type1="protein-TA" type2="protein-CC" type3="protein-CV" type4="protein-NB"/>
+    <Proper k1="21.91332344" periodicity1="2" phase1="3.141592653589793" type1="protein-NB" type2="protein-CC" type3="protein-CW" type4="protein-NA"/>
+    <Proper k1="21.91332344" periodicity1="2" phase1="3.141592653589793" type1="protein-TA" type2="protein-CC" type3="protein-CW" type4="protein-NA"/>
+    <Proper k1="21.91332344" periodicity1="2" phase1="3.141592653589793" type1="protein-NA" type2="protein-CC" type3="protein-CW" type4="protein-NA"/>
+    <Proper k1="21.91332344" periodicity1="2" phase1="3.141592653589793" type1="protein-C8" type2="protein-CC" type3="protein-CW" type4="protein-NA"/>
+    <Proper k1="0.0" k2="1.6736000000000002" k3="8.368" k4="8.368" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CT" type2="protein-CT" type3="protein-N" type4="protein-C"/>
+    <Proper k1="0.0" k2="1.6736000000000002" k3="0.8368000000000001" k4="0.8368000000000001" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CT" type2="protein-CT" type3="protein-C" type4="protein-N"/>
+    <Proper k1="10.46" k2="8.368" periodicity1="2" periodicity2="1" phase1="3.141592653589793" phase2="0.0" type1="protein-H" type2="protein-N" type3="protein-C" type4="protein-O"/>
+    <Proper k1="14.644" k2="2.5104" periodicity1="2" periodicity2="3" phase1="0.0" phase2="0.0" type1="protein-CT" type2="protein-S" type3="protein-S" type4="protein-CT"/>
+    <Proper k1="3.3472000000000004" k2="0.0" k3="0.33472" periodicity1="1" periodicity2="2" periodicity3="3" phase1="0.0" phase2="0.0" phase3="3.141592653589793" type1="protein-H1" type2="protein-CT" type3="protein-C" type4="protein-O"/>
+    <Proper k1="3.3472000000000004" k2="0.0" k3="0.33472" periodicity1="1" periodicity2="2" periodicity3="3" phase1="0.0" phase2="0.0" phase3="3.141592653589793" type1="protein-HC" type2="protein-CT" type3="protein-C" type4="protein-O"/>
+    <Proper k1="0.66944" k2="1.046" periodicity1="3" periodicity2="1" phase1="0.0" phase2="0.0" type1="protein-HO" type2="protein-OH" type3="protein-CT" type4="protein-CT"/>
+    <Proper k1="0.75312" k2="1.046" k3="0.8368000000000001" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0" phase2="3.141592653589793" phase3="3.141592653589793" type1="protein-CT" type2="protein-CT" type3="protein-CT" type4="protein-CT"/>
+    <Proper k1="0.602496" k2="4.916200000000001" periodicity1="3" periodicity2="2" phase1="0.0" phase2="0.0" type1="protein-OH" type2="protein-CT" type3="protein-CT" type4="protein-OH"/>
+    <Proper k1="0.0" k2="1.046" periodicity1="3" periodicity2="1" phase1="0.0" phase2="0.0" type1="protein-H1" type2="protein-CT" type3="protein-CT" type4="protein-OH"/>
+    <Proper k1="0.0" k2="1.046" periodicity1="3" periodicity2="1" phase1="0.0" phase2="0.0" type1="protein-HC" type2="protein-CT" type3="protein-CT" type4="protein-OH"/>
+    <Proper k1="0.0" k2="6.23416" k3="0.6527040000000001" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-N" type2="protein-CT" type3="protein-CT" type4="protein-OH"/>
+    <Proper k1="-0.37057688" k2="0.19145984000000002" k3="1.2314767199999999" k4="-0.59927432" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-C" type2="protein-N" type3="protein-CX" type4="protein-C"/>
+    <Proper k1="-0.13171232000000002" k2="-2.28002896" k3="3.8781077600000002" k4="4.47846992" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-C" type2="protein-TN" type3="protein-TJ" type4="protein-C"/>
+    <Proper k1="0.41396496" k2="1.18206368" k3="2.2214948000000003" k4="0.64073776" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-C" type2="protein-N" type3="protein-TG" type4="protein-C"/>
+    <Proper k1="-0.00966504" k2="1.0844509599999999" k3="2.61776144" k4="1.50598896" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-C" type2="protein-N" type3="protein-TP" type4="protein-C"/>
+    <Proper k1="-0.995792" k2="0.05945464" k3="1.92518392" k4="-1.7311718400000002" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-C" type2="protein-N" type3="protein-TM" type4="protein-C"/>
+    <Proper k1="0.0" k2="0.32275376" k3="0.51676584" k4="7.28062024" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-C" type2="protein-N" type3="protein-CX" type4="protein-CO"/>
+    <Proper k1="0.0" k2="-6.112238240000001" k3="9.846039840000001" k4="5.60973984" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-C" type2="protein-TN" type3="protein-TJ" type4="protein-CO"/>
+    <Proper k1="0.0" k2="1.42866864" k3="1.4559064800000001" k4="9.99415344" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-C" type2="protein-N" type3="protein-TG" type4="protein-CO"/>
+    <Proper k1="0.0" k2="1.06394936" k3="3.4614232000000005" k4="3.35678136" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-C" type2="protein-N" type3="protein-TP" type4="protein-CO"/>
+    <Proper k1="0.0" k2="0.67755696" k3="-0.72312072" k4="8.75861824" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-C" type2="protein-N" type3="protein-TM" type4="protein-CO"/>
+    <Proper k1="-0.45203936" k2="0.06271816" k3="-5.21736432" k4="2.15262616" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-N" type2="protein-CX" type3="protein-C" type4="protein-N"/>
+    <Proper k1="0.0" k2="-0.52438072" k3="-5.17744896" k4="1.18085032" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-TN" type2="protein-TJ" type3="protein-C" type4="protein-N"/>
+    <Proper k1="-0.09070912" k2="0.5106572" k3="-2.7722347199999997" k4="2.2961792" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-N" type2="protein-TG" type3="protein-C" type4="protein-N"/>
+    <Proper k1="0.34057760000000004" k2="0.010794719999999999" k3="-7.35999072" k4="0.61676344" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-N" type2="protein-TP" type3="protein-C" type4="protein-N"/>
+    <Proper k1="-0.047864960000000005" k2="0.03502008" k3="-4.326130480000001" k4="3.83266952" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-N" type2="protein-TM" type3="protein-C" type4="protein-N"/>
+    <Proper k1="0.0" k2="-0.6071820800000001" k3="-5.35146152" k4="0.22819536" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-N" type2="protein-CX" type3="protein-C" type4="protein-TN"/>
+    <Proper k1="0.0" k2="-1.74882832" k3="-5.506311360000001" k4="-1.0774636800000001" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-TN" type2="protein-TJ" type3="protein-C" type4="protein-TN"/>
+    <Proper k1="0.0" k2="-2.4631208" k3="-1.6344796000000001" k4="12.87588344" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-N" type2="protein-TG" type3="protein-C" type4="protein-TN"/>
+    <Proper k1="0.0" k2="1.4470364" k3="-6.962678080000001" k4="2.14739616" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-N" type2="protein-TP" type3="protein-C" type4="protein-TN"/>
+    <Proper k1="0.0" k2="-2.87804808" k3="-4.8006797599999995" k4="2.13484416" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-N" type2="protein-TM" type3="protein-C" type4="protein-TN"/>
+    <Proper k1="0.0" k2="-0.7812783200000001" k3="-4.07973472" k4="8.747614320000002" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-NL" type2="protein-CX" type3="protein-C" type4="protein-N"/>
+    <Proper k1="0.0" k2="2.18157944" k3="-9.41923" k4="11.29914304" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-NL" type2="protein-TJ" type3="protein-C" type4="protein-N"/>
+    <Proper k1="0.0" k2="8.40456816" k3="10.370755280000001" k4="19.319578160000002" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-NL" type2="protein-TG" type3="protein-C" type4="protein-N"/>
+    <Proper k1="0.0" k2="0.33405056" k3="-3.54924536" k4="9.665918640000001" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-NL" type2="protein-TP" type3="protein-C" type4="protein-N"/>
+    <Proper k1="0.0" k2="-3.53029184" k3="-8.0920652" k4="1.7922582400000002" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-NL" type2="protein-TM" type3="protein-C" type4="protein-N"/>
+    <Proper k1="0.0" k2="0.56036312" k3="-7.974536640000001" k4="3.36891496" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-NL" type2="protein-CX" type3="protein-C" type4="protein-TN"/>
+    <Proper k1="0.0" k2="-0.0437228" k3="-8.507954800000002" k4="5.57421768" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-NL" type2="protein-TJ" type3="protein-C" type4="protein-TN"/>
+    <Proper k1="0.0" k2="5.92759832" k3="8.519167920000001" k4="8.02298736" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-NL" type2="protein-TG" type3="protein-C" type4="protein-TN"/>
+    <Proper k1="0.0" k2="1.25361008" k3="-9.765790720000002" k4="6.315329600000001" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-NL" type2="protein-TP" type3="protein-C" type4="protein-TN"/>
+    <Proper k1="0.0" k2="-2.60123464" k3="-4.50466176" k4="4.055174640000001" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-NL" type2="protein-TM" type3="protein-C" type4="protein-TN"/>
+    <Proper k1="0.0" k2="0.16317600000000002" k3="-4.89335536" k4="3.37217848" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-N" type2="protein-CX" type3="protein-C" type4="protein-ND"/>
+    <Proper k1="0.0" k2="0.38915384" k3="-4.33487504" k4="2.03689672" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-TN" type2="protein-TJ" type3="protein-C" type4="protein-ND"/>
+    <Proper k1="0.0" k2="-1.5671172" k3="-5.5787364" k4="6.730382400000001" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-N" type2="protein-TG" type3="protein-C" type4="protein-ND"/>
+    <Proper k1="0.0" k2="1.4609691200000001" k3="-6.19662952" k4="0.5118705600000001" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-N" type2="protein-TP" type3="protein-C" type4="protein-ND"/>
+    <Proper k1="0.0" k2="-1.73686208" k3="-3.08733176" k4="3.83706272" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-N" type2="protein-TM" type3="protein-C" type4="protein-ND"/>
+    <Proper k1="0.0" k2="0.0" k3="0.0" k4="0.0" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-NL" type2="protein-CX" type3="protein-C" type4="protein-ND"/>
+    <Proper k1="0.0" k2="0.0" k3="0.0" k4="0.0" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-NL" type2="protein-TJ" type3="protein-C" type4="protein-ND"/>
+    <Proper k1="0.0" k2="0.0" k3="0.0" k4="0.0" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-NL" type2="protein-TG" type3="protein-C" type4="protein-ND"/>
+    <Proper k1="0.0" k2="0.0" k3="0.0" k4="0.0" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-NL" type2="protein-TP" type3="protein-C" type4="protein-ND"/>
+    <Proper k1="0.0" k2="0.0" k3="0.0" k4="0.0" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-NL" type2="protein-TM" type3="protein-C" type4="protein-ND"/>
+    <Proper k1="-0.92587736" k2="0.67496288" k3="0.097278" k4="-3.0577508800000004" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CT" type2="protein-CX" type3="protein-N" type4="protein-C"/>
+    <Proper k1="-0.24995216" k2="0.0546012" k3="1.0593888" k4="-3.18209936" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-2C" type2="protein-CX" type3="protein-N" type4="protein-C"/>
+    <Proper k1="-0.9161286399999999" k2="-1.02796696" k3="0.70073632" k4="-3.63388768" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-3C" type2="protein-CX" type3="protein-N" type4="protein-C"/>
+    <Proper k1="-0.33530576" k2="0.38584848" k3="1.2341544800000002" k4="-2.39822696" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-TA" type2="protein-CX" type3="protein-N" type4="protein-C"/>
+    <Proper k1="1.67180088" k2="7.78387176" k3="8.7071132" k4="-12.82508968" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CT" type2="protein-TJ" type3="protein-TN" type4="protein-C"/>
+    <Proper k1="0.49078320000000003" k2="-1.2652834400000001" k3="2.7544945600000004" k4="-3.41251224" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-C8" type2="protein-TP" type3="protein-N" type4="protein-C"/>
+    <Proper k1="-0.73546352" k2="-0.049371200000000004" k3="1.8225504000000001" k4="2.32136688" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-2C" type2="protein-TM" type3="protein-N" type4="protein-C"/>
+    <Proper k1="-1.14022368" k2="-1.15131128" k3="-1.75690344" k4="3.8614554400000003" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CT" type2="protein-CX" type3="protein-C" type4="protein-N"/>
+    <Proper k1="-0.426768" k2="-1.32021936" k3="-2.0019603200000002" k4="2.81156432" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-2C" type2="protein-CX" type3="protein-C" type4="protein-N"/>
+    <Proper k1="-0.8856691200000001" k2="-1.1606416" k3="-1.6464458400000002" k4="2.91369576" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-3C" type2="protein-CX" type3="protein-C" type4="protein-N"/>
+    <Proper k1="-0.92692336" k2="-1.43703664" k3="-1.62305728" k4="2.5951678400000002" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-TA" type2="protein-CX" type3="protein-C" type4="protein-N"/>
+    <Proper k1="0.0" k2="-1.22900816" k3="-2.75842752" k4="4.715660880000001" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CT" type2="protein-TJ" type3="protein-C" type4="protein-N"/>
+    <Proper k1="-0.3661" k2="-1.56159432" k3="-1.8694112" k4="5.50836152" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-C8" type2="protein-TP" type3="protein-C" type4="protein-N"/>
+    <Proper k1="-0.7337899200000001" k2="-0.31208456" k3="1.3924352" k4="-1.2380456" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-2C" type2="protein-TM" type3="protein-C" type4="protein-N"/>
+    <Proper k1="0.0" k2="-0.58881432" k3="-1.47536208" k4="1.87978752" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CT" type2="protein-CX" type3="protein-C" type4="protein-TN"/>
+    <Proper k1="0.0" k2="-1.35720592" k3="-3.79873728" k4="1.06327992" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-2C" type2="protein-CX" type3="protein-C" type4="protein-TN"/>
+    <Proper k1="0.0" k2="-0.20254744000000002" k3="-3.2608422400000006" k4="1.8812100800000002" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-3C" type2="protein-CX" type3="protein-C" type4="protein-TN"/>
+    <Proper k1="0.0" k2="-1.6717172000000002" k3="-3.0462030400000004" k4="0.00807512" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-TA" type2="protein-CX" type3="protein-C" type4="protein-TN"/>
+    <Proper k1="0.0" k2="0.54944288" k3="-2.39320616" k4="1.13486816" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CT" type2="protein-TJ" type3="protein-C" type4="protein-TN"/>
+    <Proper k1="0.0" k2="-2.45174032" k3="-2.0632140800000003" k4="3.9029607200000003" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-C8" type2="protein-TP" type3="protein-C" type4="protein-TN"/>
+    <Proper k1="0.0" k2="-0.16133503999999999" k3="1.1756621600000001" k4="1.5270763200000002" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-2C" type2="protein-TM" type3="protein-C" type4="protein-TN"/>
+    <Proper k1="0.0" k2="-0.43400632" k3="-1.19624744" k4="4.4683028" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CT" type2="protein-CX" type3="protein-C" type4="protein-ND"/>
+    <Proper k1="0.0" k2="-0.1165244" k3="-1.5596278399999999" k4="4.07220352" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-2C" type2="protein-CX" type3="protein-C" type4="protein-ND"/>
+    <Proper k1="0.0" k2="-0.25246256" k3="-0.97629456" k4="3.71124984" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-3C" type2="protein-CX" type3="protein-C" type4="protein-ND"/>
+    <Proper k1="0.0" k2="-0.36480296" k3="-1.02223488" k4="3.9743397600000003" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-TA" type2="protein-CX" type3="protein-C" type4="protein-ND"/>
+    <Proper k1="0.0" k2="-1.17302624" k3="-2.6429491200000004" k4="4.2722824" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CT" type2="protein-TJ" type3="protein-C" type4="protein-ND"/>
+    <Proper k1="0.0" k2="-1.0599745600000001" k3="-1.3108472000000002" k4="5.70848224" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-C8" type2="protein-TP" type3="protein-C" type4="protein-ND"/>
+    <Proper k1="0.0" k2="2.01974232" k3="2.0302860000000003" k4="-0.62868784" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-2C" type2="protein-TM" type3="protein-C" type4="protein-ND"/>
+    <Proper k1="-0.33191672" k2="0.83885016" k3="1.5549417600000002" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0" phase2="0.0" phase3="0.0" type1="protein-H1" type2="protein-TG" type3="protein-N" type4="protein-C"/>
+    <Proper k1="-0.5091928" k2="3.21536216" k3="3.8989859200000003" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0" phase2="0.0" phase3="0.0" type1="protein-H1" type2="protein-TG" type3="protein-C" type4="protein-N"/>
+    <Proper k1="0.4865992" k2="5.41861472" k3="14.28087064" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0" phase2="0.0" phase3="0.0" type1="protein-H1" type2="protein-TG" type3="protein-C" type4="protein-TN"/>
+    <Proper k1="0.7083512000000001" k2="0.07376392" k3="6.58653648" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0" phase2="0.0" phase3="0.0" type1="protein-H1" type2="protein-TG" type3="protein-C" type4="protein-ND"/>
+    <Proper k1="-4.87536416" k2="24.92730968" k3="12.8348384" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0" phase2="0.0" phase3="0.0" type1="protein-HP" type2="protein-TG" type3="protein-C" type4="protein-N"/>
+    <Proper k1="-3.18335456" k2="20.615614" k3="7.74985584" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0" phase2="0.0" phase3="0.0" type1="protein-HP" type2="protein-TG" type3="protein-C" type4="protein-TN"/>
+    <Proper k1="0.0" k2="0.0" k3="0.0" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0" phase2="0.0" phase3="0.0" type1="protein-HP" type2="protein-TG" type3="protein-C" type4="protein-ND"/>
+    <Proper k1="0.86642272" k2="1.828408" k3="0.84449856" k4="-3.7907040000000003" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-N" type2="protein-CX" type3="protein-2C" type4="protein-C"/>
+    <Proper k1="0.31304688" k2="3.813716" k3="-0.83144448" k4="-1.7070301600000002" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-N" type2="protein-CX" type3="protein-2C" type4="protein-SH"/>
+    <Proper k1="-0.47789648" k2="1.31273" k3="-0.47576264" k4="-0.45316904" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-N" type2="protein-CX" type3="protein-2C" type4="protein-S"/>
+    <Proper k1="0.81349512" k2="0.58161784" k3="0.06204872" k4="0.20137592" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-N" type2="protein-CX" type3="protein-2C" type4="protein-2C"/>
+    <Proper k1="-0.57232936" k2="1.33256216" k3="0.02234256" k4="-0.9347892800000001" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-N" type2="protein-CX" type3="protein-2C" type4="protein-3C"/>
+    <Proper k1="0.20631304" k2="3.51953896" k3="0.3518744" k4="1.14398928" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-N" type2="protein-CX" type3="protein-2C" type4="protein-OA"/>
+    <Proper k1="-0.5412840800000001" k2="1.5884556" k3="-0.05811576" k4="-0.47429824000000004" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-N" type2="protein-CX" type3="protein-3C" type4="protein-CT"/>
+    <Proper k1="-0.38781496" k2="2.7953304" k3="-0.5525390400000001" k4="-0.46153704000000007" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-N" type2="protein-CX" type3="protein-3C" type4="protein-2C"/>
+    <Proper k1="-1.5324318399999999" k2="1.5116792000000001" k3="1.1116888" k4="-10.287117120000001" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-N" type2="protein-CX" type3="protein-3C" type4="protein-OA"/>
+    <Proper k1="0.41492728" k2="-1.28708208" k3="0.81613104" k4="-2.3996913600000003" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-N" type2="protein-CX" type3="protein-TA" type4="protein-CC"/>
+    <Proper k1="-0.92391088" k2="0.54417104" k3="0.07430784000000001" k4="-2.59462392" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-N" type2="protein-CX" type3="protein-TA" type4="protein-CA"/>
+    <Proper k1="-1.47260064" k2="-0.05255104" k3="0.29660376" k4="-1.9278616800000001" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-N" type2="protein-CX" type3="protein-TA" type4="protein-C*"/>
+    <Proper k1="0.0" k2="0.0" k3="-2.4313224" k4="-1.13520288" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-TN" type2="protein-TJ" type3="protein-CT" type4="protein-CT"/>
+    <Proper k1="1.34344056" k2="-1.10336264" k3="-0.20397" k4="-1.6354000800000001" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-N" type2="protein-TP" type3="protein-C8" type4="protein-C8"/>
+    <Proper k1="1.1738630399999999" k2="-3.25527752" k3="2.68704848" k4="-0.77295216" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-N" type2="protein-TP" type3="protein-C8" type4="protein-CC"/>
+    <Proper k1="-1.1334456" k2="1.09436704" k3="0.53571936" k4="-7.69169824" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-N" type2="protein-TM" type3="protein-2C" type4="protein-2C"/>
+    <Proper k1="-0.53915024" k2="2.70637856" k3="-1.86464144" k4="-16.7615224" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-N" type2="protein-TM" type3="protein-2C" type4="protein-CO"/>
+    <Proper k1="0.34651888000000003" k2="6.22545728" k3="-4.13789232" k4="-7.04476816" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-N" type2="protein-TM" type3="protein-2C" type4="protein-SH"/>
+    <Proper k1="0.0" k2="-2.8275890400000003" k3="-8.432810159999999" k4="-24.24552688" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-NL" type2="protein-CX" type3="protein-2C" type4="protein-C"/>
+    <Proper k1="0.0" k2="3.2333115200000004" k3="-2.84206568" k4="-5.774714960000001" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-NL" type2="protein-CX" type3="protein-2C" type4="protein-SH"/>
+    <Proper k1="0.07832448" k2="-8.73087832" periodicity1="2" periodicity2="1" phase1="0.0" phase2="0.0" type1="protein-NL" type2="protein-CX" type3="protein-2C" type4="protein-S"/>
+    <Proper k1="0.0" k2="-6.367504080000001" k3="-2.65629608" k4="-5.1748967200000004" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-NL" type2="protein-CX" type3="protein-2C" type4="protein-2C"/>
+    <Proper k1="0.0" k2="-0.00840984" k3="-0.87746848" k4="-2.6933663200000004" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-NL" type2="protein-CX" type3="protein-2C" type4="protein-3C"/>
+    <Proper k1="0.0" k2="-3.62819744" k3="-1.56201272" k4="-5.14602712" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-NL" type2="protein-CX" type3="protein-2C" type4="protein-OA"/>
+    <Proper k1="0.0" k2="1.83439112" k3="-0.221752" k4="1.2171256" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-NL" type2="protein-CX" type3="protein-3C" type4="protein-CT"/>
+    <Proper k1="0.0" k2="2.9944469600000003" k3="0.050249840000000004" k4="0.518816" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-NL" type2="protein-CX" type3="protein-3C" type4="protein-2C"/>
+    <Proper k1="0.0" k2="-1.27185232" k3="1.5381220800000002" k4="-14.315388640000002" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-NL" type2="protein-CX" type3="protein-3C" type4="protein-OA"/>
+    <Proper k1="0.0" k2="3.8863920800000002" k3="2.1648434400000003" k4="-5.14389328" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-NL" type2="protein-TA" type3="protein-CT" type4="protein-CC"/>
+    <Proper k1="0.0" k2="2.77679528" k3="-1.27796096" k4="-6.876404" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-NL" type2="protein-TA" type3="protein-CT" type4="protein-CA"/>
+    <Proper k1="0.0" k2="2.8779643999999998" k3="-3.17707856" k4="-6.18010272" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-NL" type2="protein-TA" type3="protein-CT" type4="protein-C*"/>
+    <Proper k1="0.0" k2="0.0" k3="-1.9125900800000002" k4="-5.67952896" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-NL" type2="protein-TJ" type3="protein-CT" type4="protein-CT"/>
+    <Proper k1="0.0" k2="-3.0373748000000003" k3="-1.41540536" k4="1.61975192" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-NL" type2="protein-TP" type3="protein-C8" type4="protein-C8"/>
+    <Proper k1="0.0" k2="-5.2285774400000005" k3="0.26083056" k4="-0.10234064" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-NL" type2="protein-TP" type3="protein-C8" type4="protein-CC"/>
+    <Proper k1="0.0" k2="-0.23924112000000003" k3="1.26038816" k4="-18.445373200000002" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-NL" type2="protein-TM" type3="protein-2C" type4="protein-2C"/>
+    <Proper k1="0.0" k2="8.75907848" k3="2.0275245600000003" k4="-28.284634959999998" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-NL" type2="protein-TM" type3="protein-2C" type4="protein-CO"/>
+    <Proper k1="0.0" k2="10.50025008" k3="-7.69989888" k4="-25.30349312" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-NL" type2="protein-TM" type3="protein-2C" type4="protein-SH"/>
+    <Proper k1="-0.27831968" k2="-2.7390556" k3="0.75106984" k4="1.54858208" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-C" type2="protein-CX" type3="protein-2C" type4="protein-C"/>
+    <Proper k1="-0.21698224000000002" k2="-2.93478312" k3="-1.12708592" k4="-4.494703840000001" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-C" type2="protein-CX" type3="protein-2C" type4="protein-SH"/>
+    <Proper k1="-0.72512904" k2="0.22694016" k3="-0.5148830400000001" k4="-1.2564970400000002" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-C" type2="protein-CX" type3="protein-2C" type4="protein-S"/>
+    <Proper k1="1.06453512" k2="-0.8232020000000001" k3="-0.63421072" k4="-1.34143224" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-C" type2="protein-CX" type3="protein-2C" type4="protein-2C"/>
+    <Proper k1="-0.79010656" k2="-2.72060416" k3="-1.30323232" k4="-1.96823728" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-C" type2="protein-CX" type3="protein-2C" type4="protein-3C"/>
+    <Proper k1="-0.28903072" k2="-0.35852696" k3="0.47538608" k4="-2.71022784" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-C" type2="protein-CX" type3="protein-2C" type4="protein-OA"/>
+    <Proper k1="-0.6907365599999999" k2="2.3824532800000005" k3="-1.24499104" k4="-1.79100304" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-C" type2="protein-CX" type3="protein-3C" type4="protein-CT"/>
+    <Proper k1="-0.06363864" k2="0.27773391999999997" k3="-2.3540020800000003" k4="0.01426744" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-C" type2="protein-CX" type3="protein-3C" type4="protein-2C"/>
+    <Proper k1="-0.86027224" k2="2.5610264" k3="0.7744584" k4="-12.492294320000001" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-C" type2="protein-CX" type3="protein-3C" type4="protein-OA"/>
+    <Proper k1="-0.23857168" k2="-3.47861944" k3="0.23714912000000002" k4="-0.22694016" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-C" type2="protein-CX" type3="protein-TA" type4="protein-CC"/>
+    <Proper k1="-0.9314420800000001" k2="-5.01523528" k3="-0.16070744" k4="-0.71575688" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-C" type2="protein-CX" type3="protein-TA" type4="protein-CA"/>
+    <Proper k1="-1.87012248" k2="-4.71570272" k3="-0.10589704" k4="-2.26044784" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-C" type2="protein-CX" type3="protein-TA" type4="protein-C*"/>
+    <Proper k1="0.0" k2="0.0" k3="-1.7952707200000002" k4="-4.79335776" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-C" type2="protein-TJ" type3="protein-CT" type4="protein-CT"/>
+    <Proper k1="1.2631914400000002" k2="-3.0878756800000002" k3="0.41040856" k4="-3.4045626400000004" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-C" type2="protein-TP" type3="protein-C8" type4="protein-C8"/>
+    <Proper k1="-0.18735952" k2="-1.42456832" k3="2.73118968" k4="-2.2863468" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-C" type2="protein-TP" type3="protein-C8" type4="protein-CC"/>
+    <Proper k1="-0.75504464" k2="-0.70492032" k3="1.42427544" k4="-6.12654752" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-C" type2="protein-TM" type3="protein-2C" type4="protein-2C"/>
+    <Proper k1="-0.45789696" k2="1.20486648" k3="0.91525" k4="-3.42054552" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-C" type2="protein-TM" type3="protein-2C" type4="protein-CO"/>
+    <Proper k1="-0.23748384" k2="3.67769416" k3="1.8510434400000002" k4="-4.7243217600000005" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-C" type2="protein-TM" type3="protein-2C" type4="protein-SH"/>
+    <Proper k1="0.0" k2="-1.31716504" k3="5.944418" k4="11.54005776" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CO" type2="protein-CX" type3="protein-2C" type4="protein-C"/>
+    <Proper k1="0.0" k2="5.54865344" k3="3.03281424" k4="-5.74429728" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CO" type2="protein-CX" type3="protein-2C" type4="protein-SH"/>
+    <Proper k1="0.0" k2="0.38697816" k3="3.07862904" k4="0.76939576" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CO" type2="protein-CX" type3="protein-2C" type4="protein-S"/>
+    <Proper k1="0.0" k2="0.71751416" k3="-0.8292688" k4="-6.92259536" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CO" type2="protein-CX" type3="protein-2C" type4="protein-2C"/>
+    <Proper k1="0.0" k2="-1.16666656" k3="-0.301248" k4="-1.4443586400000001" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CO" type2="protein-CX" type3="protein-2C" type4="protein-3C"/>
+    <Proper k1="0.0" k2="-2.57889208" k3="-15.99706376" k4="-29.61251104" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CO" type2="protein-CX" type3="protein-2C" type4="protein-OA"/>
+    <Proper k1="0.0" k2="3.5001252000000003" k3="-0.52873208" k4="-5.07180296" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CO" type2="protein-CX" type3="protein-3C" type4="protein-CT"/>
+    <Proper k1="0.0" k2="4.07789376" k3="0.45413136" k4="0.68061128" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CO" type2="protein-CX" type3="protein-3C" type4="protein-2C"/>
+    <Proper k1="0.0" k2="5.13514872" k3="-6.14675624" k4="-30.00760616" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CO" type2="protein-CX" type3="protein-3C" type4="protein-OA"/>
+    <Proper k1="0.0" k2="-3.5944744" k3="4.1679334400000005" k4="2.91277528" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CO" type2="protein-CX" type3="protein-TA" type4="protein-CC"/>
+    <Proper k1="0.0" k2="-1.94819592" k3="3.69296576" k4="1.4949432" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CO" type2="protein-CX" type3="protein-TA" type4="protein-CA"/>
+    <Proper k1="0.0" k2="3.72049648" k3="8.17905056" k4="4.85536464" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CO" type2="protein-CX" type3="protein-TA" type4="protein-C*"/>
+    <Proper k1="0.0" k2="0.0" k3="5.33539496" k4="2.6142468800000005" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CO" type2="protein-TJ" type3="protein-CT" type4="protein-CT"/>
+    <Proper k1="0.0" k2="-4.815281919999999" k3="2.8034892000000005" k4="-17.900365360000002" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CO" type2="protein-TP" type3="protein-C8" type4="protein-C8"/>
+    <Proper k1="0.0" k2="5.65752112" k3="10.9740044" k4="-8.36682848" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CO" type2="protein-TP" type3="protein-C8" type4="protein-CC"/>
+    <Proper k1="0.0" k2="-0.18857288" k3="-0.15020560000000002" k4="9.322998" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CO" type2="protein-TM" type3="protein-2C" type4="protein-CO"/>
+    <Proper k1="0.0" k2="5.93090368" k3="7.70981496" k4="7.837217760000001" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CO" type2="protein-TM" type3="protein-2C" type4="protein-SH"/>
+    <Proper k1="0.0" k2="14.552203040000002" k3="15.35958952" k4="9.013382000000002" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CO" type2="protein-TM" type3="protein-2C" type4="protein-2C"/>
+    <Proper k1="-1.39699576" k2="1.51155368" periodicity1="3" periodicity2="1" phase1="0.0" phase2="0.0" type1="protein-H1" type2="protein-CX" type3="protein-2C" type4="protein-OA"/>
+    <Proper k1="-0.10234064" k2="-7.701949040000001" periodicity1="3" periodicity2="1" phase1="0.0" phase2="0.0" type1="protein-H1" type2="protein-CX" type3="protein-3C" type4="protein-OA"/>
+    <Proper k1="8.5654848" k2="-0.6473903200000001" periodicity1="3" periodicity2="1" phase1="0.0" phase2="0.0" type1="protein-HP" type2="protein-CX" type3="protein-2C" type4="protein-OA"/>
+    <Proper k1="1.9287821600000001" k2="-9.598765440000001" periodicity1="3" periodicity2="1" phase1="0.0" phase2="0.0" type1="protein-HP" type2="protein-CX" type3="protein-3C" type4="protein-OA"/>
+    <Proper k1="0.0" k2="2.6739944" k3="-2.15103624" k4="-5.824964800000001" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CX" type2="protein-2C" type3="protein-C" type4="protein-O"/>
+    <Proper k1="0.0" k2="0.8711506400000001" k3="-1.19649848" k4="0.50258208" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CX" type2="protein-2C" type3="protein-C" type4="protein-OH"/>
+    <Proper k1="0.0" k2="-0.97771712" k3="-3.20038344" k4="-3.0478348000000004" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CX" type2="protein-2C" type3="protein-C" type4="protein-OD"/>
+    <Proper k1="0.0" k2="-0.017447280000000003" k3="-3.788612" k4="-2.49927056" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CX" type2="protein-2C" type3="protein-C" type4="protein-ND"/>
+    <Proper k1="0.0" k2="-0.66764088" k3="1.91367792" k4="-4.75946736" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CX" type2="protein-2C" type3="protein-S" type4="protein-S"/>
+    <Proper k1="0.0" k2="-2.79503752" k3="0.6363445600000001" k4="-2.7643687999999997" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CX" type2="protein-2C" type3="protein-2C" type4="protein-C"/>
+    <Proper k1="0.0" k2="1.51239048" k3="-0.25116552000000003" k4="0.06719504000000001" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CX" type2="protein-2C" type3="protein-3C" type4="protein-CT"/>
+    <Proper k1="0.0" k2="-1.1359560000000002" k3="-0.08865896000000001" k4="-0.84031456" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CX" type2="protein-2C" type3="protein-2C" type4="protein-2C"/>
+    <Proper k1="0.0" k2="0.98231952" k3="0.52839736" k4="-0.9071748800000001" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CX" type2="protein-2C" type3="protein-2C" type4="protein-S"/>
+    <Proper k1="0.0" k2="1.6127228000000002" k3="-0.21982736000000003" k4="1.16239888" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CX" type2="protein-3C" type3="protein-2C" type4="protein-CT"/>
+    <Proper k1="0.0" k2="3.06461264" k3="-0.89299112" k4="-0.35292039999999997" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CT" type2="protein-3C" type3="protein-2C" type4="protein-CT"/>
+    <Proper k1="0.0" k2="3.89099448" k3="3.31075736" k4="-0.6011989600000001" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CX" type2="protein-TA" type3="protein-CC" type4="protein-NA"/>
+    <Proper k1="0.0" k2="1.77117088" k3="2.627552" k4="0.20233824" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CX" type2="protein-TA" type3="protein-CC" type4="protein-CV"/>
+    <Proper k1="0.0" k2="2.06559896" k3="3.43242808" k4="-0.44057520000000006" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CX" type2="protein-TA" type3="protein-CC" type4="protein-NB"/>
+    <Proper k1="0.0" k2="-0.10970448000000001" k3="2.29120024" k4="-0.80303512" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CX" type2="protein-TA" type3="protein-CC" type4="protein-CW"/>
+    <Proper k1="0.0" k2="0.48358672" k3="-1.63623688" k4="-2.09292048" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CX" type2="protein-TA" type3="protein-CA" type4="protein-CA"/>
+    <Proper k1="0.0" k2="1.7152308" k3="-0.8397287999999999" k4="-2.04024392" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CX" type2="protein-TA" type3="protein-C*" type4="protein-CB"/>
+    <Proper k1="0.0" k2="-0.97294736" k3="-1.0878400000000001" k4="-2.79646008" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CX" type2="protein-TA" type3="protein-C*" type4="protein-CW"/>
+    <Proper k1="0.0" k2="0.0" k3="2.50834984" k4="0.33287904" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-TJ" type2="protein-CT" type3="protein-CT" type4="protein-CT"/>
+    <Proper k1="0.0" k2="-2.95603784" k3="0.6649212800000001" k4="-4.24855912" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-TP" type2="protein-C8" type3="protein-C8" type4="protein-C8"/>
+    <Proper k1="0.0" k2="1.60113312" k3="8.3186288" k4="0.2204968" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-TP" type2="protein-C8" type3="protein-CC" type4="protein-NA"/>
+    <Proper k1="0.0" k2="-1.1685912" k3="3.91438304" k4="4.3442472" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-TP" type2="protein-C8" type3="protein-CC" type4="protein-CW"/>
+    <Proper k1="0.0" k2="-3.0346552" k3="1.98309048" k4="-7.47500888" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-TM" type2="protein-2C" type3="protein-2C" type4="protein-CO"/>
+    <Proper k1="0.0" k2="-0.619232" k3="-3.16360608" k4="-20.644902" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-TM" type2="protein-2C" type3="protein-CO" type4="protein-O3"/>
+    <Proper k1="1.15612288" k2="0.0" k3="17.74647784" k4="-5.412129520000001" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-2C" type2="protein-S" type3="protein-S" type4="protein-2C"/>
+    <Proper k1="0.0" k2="1.01721408" k3="-2.03785904" k4="-5.74479936" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-2C" type2="protein-2C" type3="protein-C" type4="protein-O"/>
+    <Proper k1="0.0" k2="-0.7973030400000001" k3="-0.9797254400000001" k4="1.2042807199999999" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-2C" type2="protein-2C" type3="protein-C" type4="protein-OH"/>
+    <Proper k1="0.0" k2="2.0112906400000004" k3="-3.6778196800000003" k4="-3.11871176" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-2C" type2="protein-2C" type3="protein-C" type4="protein-OD"/>
+    <Proper k1="0.0" k2="1.5357372" k3="-3.7691564000000004" k4="-1.24486552" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-2C" type2="protein-2C" type3="protein-C" type4="protein-ND"/>
+    <Proper k1="0.0" k2="1.6512992800000001" k3="2.20095136" k4="-0.041965520000000006" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-2C" type2="protein-2C" type3="protein-S" type4="protein-CT"/>
+    <Proper k1="0.0" k2="-0.5955087200000001" k3="-0.52103352" k4="-1.6777840000000002" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-2C" type2="protein-2C" type3="protein-2C" type4="protein-2C"/>
+    <Proper k1="0.0" k2="0.17325944000000001" k3="-1.40691184" k4="-2.10722976" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-2C" type2="protein-2C" type3="protein-2C" type4="protein-CT"/>
+    <Proper k1="0.0" k2="0.0" k3="-0.32919712" k4="-0.32986656" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CT" type2="protein-CT" type3="protein-CT" type4="protein-TN"/>
+    <Proper k1="0.0" k2="-0.36802464" k3="-0.7042927200000001" k4="-3.74200224" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-C8" type2="protein-C8" type3="protein-C8" type4="protein-N2"/>
+    <Proper k1="0.0" k2="-3.62510128" k3="1.50824832" k4="-1.94246384" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-C8" type2="protein-C8" type3="protein-C8" type4="protein-C8"/>
+    <Proper k1="0.0" k2="1.79267664" k3="-2.07727232" k4="-9.49730344" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-2C" type2="protein-2C" type3="protein-CO" type4="protein-O3"/>
+    <Proper k1="0.0" k2="1.8402905600000001" k3="-0.6118681600000001" k4="-2.09978224" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-2C" type2="protein-2C" type3="protein-2C" type4="protein-N3"/>
+    <Proper k1="0.0" k2="0.0" k3="-2.62847248" k4="-17.80781528" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CT" type2="protein-CT" type3="protein-TN" type4="protein-C"/>
+    <Proper k1="0.0" k2="-4.3338290399999995" k3="2.65658896" k4="-3.4659000800000004" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-C8" type2="protein-C8" type3="protein-N2" type4="protein-CA"/>
+    <Proper k1="0.0" k2="-2.91327736" k3="-0.52668192" k4="-6.0113201599999995" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-C8" type2="protein-C8" type3="protein-C8" type4="protein-NL"/>
+    <Proper k1="0.0" k2="0.0" k3="-0.9386804" k4="-1.6110492" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CT" type2="protein-CT" type3="protein-TN" type4="protein-TJ"/>
+    <Proper k1="7.88257232" k2="-33.21577184" periodicity1="4" periodicity2="2" phase1="0.0" phase2="0.0" type1="protein-C8" type2="protein-N2" type3="protein-CA" type4="protein-N2"/>
+    <Proper k1="46.09173896" periodicity1="2" phase1="3.141592653589793" type1="protein-NB" type2="protein-CR" type3="protein-NA" type4="protein-CC"/>
+    <Proper k1="30.59273856" periodicity1="2" phase1="3.141592653589793" type1="protein-NA" type2="protein-CR" type3="protein-NB" type4="protein-CC"/>
+    <Proper k1="68.49777024" periodicity1="2" phase1="3.141592653589793" type1="protein-NA" type2="protein-CR" type3="protein-NA" type4="protein-CC"/>
+    <Proper k1="47.18790512" periodicity1="2" phase1="3.141592653589793" type1="protein-CC" type2="protein-CV" type3="protein-NB" type4="protein-CR"/>
+    <Proper k1="14.47597056" periodicity1="2" phase1="3.141592653589793" type1="protein-CC" type2="protein-CW" type3="protein-NA" type4="protein-CR"/>
+    <Proper k1="38.54104152" periodicity1="2" phase1="3.141592653589793" type1="protein-NA" type2="protein-CR" type3="protein-NB" type4="protein-CV"/>
+    <Proper k1="23.13162056" periodicity1="2" phase1="3.141592653589793" type1="protein-NB" type2="protein-CR" type3="protein-NA" type4="protein-CW"/>
+    <Proper k1="69.95145920000002" periodicity1="2" phase1="3.141592653589793" type1="protein-NA" type2="protein-CR" type3="protein-NA" type4="protein-CW"/>
+    <Proper k1="-5.26518744" k2="3.3569068800000004" periodicity1="2" periodicity2="1" phase1="0.0" phase2="0.0" type1="protein-H" type2="protein-N" type3="protein-C" type4="protein-OD"/>
+    <Proper k1="0.61856256" k2="-0.47689232000000004" periodicity1="3" periodicity2="2" phase1="0.0" phase2="0.0" type1="protein-HC" type2="protein-CT" type3="protein-C" type4="protein-OD"/>
+    <Proper k1="-1.46477656" k2="-0.54868976" k3="-6.04893432" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0" phase2="0.0" phase3="0.0" type1="protein-O" type2="protein-C" type3="protein-2C" type4="protein-HC"/>
+    <Proper k1="-0.38773128" periodicity1="2" phase1="0.0" type1="protein-OH" type2="protein-C" type3="protein-2C" type4="protein-HC"/>
+    <Proper k1="-11.18127976" k2="1.02135624" periodicity1="2" periodicity2="1" phase1="0.0" phase2="0.0" type1="protein-HO" type2="protein-OH" type3="protein-C" type4="protein-O"/>
+    <Proper k1="1.15553712" periodicity1="3" phase1="0.0" type1="protein-HC" type2="protein-CT" type3="protein-2C" type4="protein-3C"/>
+    <Proper k1="0.6454238400000001" periodicity1="3" phase1="0.0" type1="protein-HC" type2="protein-CT" type3="protein-3C" type4="protein-CX"/>
+    <Proper k1="1.32394312" periodicity1="3" phase1="0.0" type1="protein-CX" type2="protein-2C" type3="protein-2C" type4="protein-HC"/>
+    <Proper k1="-0.87834712" periodicity1="3" phase1="0.0" type1="protein-CT" type2="protein-2C" type3="protein-3C" type4="protein-HC"/>
+    <Proper k1="-3.6610418399999998" k2="3.45435224" k3="-0.5719109600000001" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0" phase2="0.0" phase3="0.0" type1="protein-CX" type2="protein-2C" type3="protein-SH" type4="protein-HS"/>
+    <Proper k1="0.22179384000000002" k2="-3.2756954400000002" k3="1.00110568" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0" phase2="0.0" phase3="0.0" type1="protein-OD" type2="protein-C" type3="protein-2C" type4="protein-HC"/>
+    <Proper k1="-3.00030456" periodicity1="2" phase1="0.0" type1="protein-ND" type2="protein-C" type3="protein-2C" type4="protein-HC"/>
+    <Proper k1="-7.00246792" k2="1.65376784" periodicity1="2" periodicity2="1" phase1="0.0" phase2="0.0" type1="protein-H" type2="protein-ND" type3="protein-C" type4="protein-OD"/>
+    <Proper k1="0.7950018400000001" k2="1.98673056" periodicity1="3" periodicity2="1" phase1="0.0" phase2="0.0" type1="protein-HC" type2="protein-CT" type3="protein-3C" type4="protein-OA"/>
+    <Proper k1="1.7724679200000002" periodicity1="3" phase1="0.0" type1="protein-HO" type2="protein-OA" type3="protein-2C" type4="protein-H1"/>
+    <Proper k1="6.54549144" periodicity1="3" phase1="0.0" type1="protein-HO" type2="protein-OA" type3="protein-3C" type4="protein-H1"/>
+    <Proper k1="-3.86752224" periodicity1="2" phase1="0.0" type1="protein-CA" type2="protein-C" type3="protein-OA" type4="protein-HO"/>
+    <Proper k1="-2.78909624" k2="1.6904615200000002" k3="-2.36550808" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0" phase2="0.0" phase3="0.0" type1="protein-CX" type2="protein-3C" type3="protein-OA" type4="protein-HO"/>
+    <Proper k1="-1.23884056" k2="-0.73709528" k3="2.93833952" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0" phase2="0.0" phase3="0.0" type1="protein-CT" type2="protein-3C" type3="protein-OA" type4="protein-HO"/>
+    <Proper k1="-1.01374136" k2="1.84355408" k3="-1.05662736" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0" phase2="0.0" phase3="0.0" type1="protein-CX" type2="protein-2C" type3="protein-OA" type4="protein-HO"/>
+    <Proper k1="-4.48072928" k2="-2.8734038400000004" k3="-3.56041664" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0" phase2="0.0" phase3="0.0" type1="protein-C8" type2="protein-C8" type3="protein-N2" type4="protein-TH"/>
+    <Proper k1="4.809842720000001" k2="-21.000751200000003" periodicity1="4" periodicity2="2" phase1="0.0" phase2="0.0" type1="protein-TH" type2="protein-N2" type3="protein-CA" type4="protein-N2"/>
+    <Proper k1="3.9152198400000002" periodicity1="3" phase1="0.0" type1="protein-C8" type2="protein-C8" type3="protein-NL" type4="protein-H"/>
+    <Proper k1="-0.5294015200000001" periodicity1="2" phase1="0.0" type1="protein-O3" type2="protein-CO" type3="protein-2C" type4="protein-HC"/>
+    <Improper k1="43.932" periodicity1="2" phase1="3.141592653589793" type1="protein-C" type2="" type3="" type4="protein-O"/>
+    <Improper k1="4.184" periodicity1="2" phase1="3.141592653589793" type1="protein-N" type2="" type3="" type4="protein-H"/>
+    <Improper k1="4.184" periodicity1="2" phase1="3.141592653589793" type1="protein-N2" type2="" type3="" type4="protein-H"/>
+    <Improper k1="4.184" periodicity1="2" phase1="3.141592653589793" type1="protein-NA" type2="" type3="" type4="protein-H"/>
+    <Improper k1="43.932" periodicity1="2" phase1="3.141592653589793" type1="protein-CA" type2="" type3="protein-N2" type4="protein-N2"/>
+    <Improper k1="4.184" periodicity1="2" phase1="3.141592653589793" type1="protein-N" type2="" type3="protein-CT" type4="protein-CT"/>
+    <Improper k1="4.184" periodicity1="2" phase1="3.141592653589793" type1="protein-N" type2="" type3="protein-CX" type4="protein-CT"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-CA" type2="" type3="" type4="protein-HA"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-CW" type2="" type3="" type4="protein-H4"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-CR" type2="" type3="" type4="protein-H5"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-CV" type2="" type3="" type4="protein-H4"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-CA" type2="" type3="" type4="protein-H4"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-CA" type2="" type3="" type4="protein-H5"/>
+    <Improper k1="43.932" periodicity1="2" phase1="3.141592653589793" type1="protein-CO" type2="" type3="protein-O3" type4="protein-O3"/>
+    <Improper k1="43.932" periodicity1="2" phase1="3.141592653589793" type1="protein-C" type2="" type3="" type4="protein-OD"/>
+    <Improper k1="4.184" periodicity1="2" phase1="3.141592653589793" type1="protein-ND" type2="" type3="" type4="protein-H"/>
+    <Improper k1="4.184" periodicity1="2" phase1="3.141592653589793" type1="protein-ND" type2="" type3="protein-CT" type4="protein-CT"/>
+    <Improper k1="4.184" periodicity1="2" phase1="3.141592653589793" type1="protein-ND" type2="" type3="protein-CX" type4="protein-CT"/>
+    <Improper k1="4.184" periodicity1="2" phase1="3.141592653589793" type1="protein-TN" type2="" type3="" type4="protein-H"/>
+    <Improper k1="4.184" periodicity1="2" phase1="3.141592653589793" type1="protein-TN" type2="" type3="protein-CT" type4="protein-CT"/>
+    <Improper k1="4.184" periodicity1="2" phase1="3.141592653589793" type1="protein-TN" type2="" type3="protein-CX" type4="protein-CT"/>
+    <Improper k1="4.184" periodicity1="2" phase1="3.141592653589793" type1="protein-N" type2="" type3="protein-TG" type4="protein-CT"/>
+    <Improper k1="4.184" periodicity1="2" phase1="3.141592653589793" type1="protein-N" type2="" type3="protein-TM" type4="protein-CT"/>
+    <Improper k1="4.184" periodicity1="2" phase1="3.141592653589793" type1="protein-TN" type2="" type3="protein-TM" type4="protein-CT"/>
+    <Improper k1="4.184" periodicity1="2" phase1="3.141592653589793" type1="protein-N" type2="" type3="protein-TP" type4="protein-CT"/>
+    <Improper k1="4.184" periodicity1="2" phase1="3.141592653589793" type1="protein-ND" type2="" type3="protein-TP" type4="protein-CT"/>
+    <Improper k1="4.184" periodicity1="2" phase1="3.141592653589793" type1="protein-TN" type2="" type3="protein-TP" type4="protein-CT"/>
+    <Improper k1="4.184" periodicity1="2" phase1="3.141592653589793" type1="protein-N2" type2="" type3="" type4="protein-TH"/>
+    <Improper k1="43.932" periodicity1="2" phase1="3.141592653589793" type1="protein-C" type2="protein-CT" type3="protein-O" type4="protein-OH"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-CC" type2="protein-CT" type3="protein-CV" type4="protein-NA"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-CC" type2="protein-CT" type3="protein-CW" type4="protein-NB"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-CC" type2="protein-C8" type3="protein-CW" type4="protein-NA"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-CC" type2="protein-CT" type3="protein-CW" type4="protein-NA"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-C*" type2="protein-CB" type3="protein-CT" type4="protein-CW"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-CA" type2="protein-CA" type3="protein-CA" type4="protein-CT"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-C" type2="protein-CA" type3="protein-CA" type4="protein-OH"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-CA" type2="protein-CA" type3="protein-CA" type4="protein-OH"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-C" type2="protein-H5" type3="protein-O" type4="protein-OH"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-N" type2="protein-C" type3="protein-CT" type4="protein-H"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-N" type2="protein-C" type3="protein-CX" type4="protein-H"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-N" type2="protein-C" type3="protein-CT" type4="protein-O"/>
+    <Improper k1="43.932" periodicity1="2" phase1="3.141592653589793" type1="protein-C" type2="protein-2C" type3="protein-O" type4="protein-OH"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-CA" type2="protein-2C" type3="protein-CA" type4="protein-CA"/>
+    <Improper k1="43.932" periodicity1="2" phase1="3.141592653589793" type1="protein-C" type2="protein-CT" type3="protein-OD" type4="protein-OH"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-C" type2="protein-H5" type3="protein-OD" type4="protein-OH"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-N" type2="protein-C" type3="protein-CT" type4="protein-OD"/>
+    <Improper k1="43.932" periodicity1="2" phase1="3.141592653589793" type1="protein-C" type2="protein-2C" type3="protein-OD" type4="protein-OH"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-ND" type2="protein-C" type3="protein-CT" type4="protein-H"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-ND" type2="protein-C" type3="protein-CX" type4="protein-H"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-ND" type2="protein-C" type3="protein-CT" type4="protein-O"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-ND" type2="protein-C" type3="protein-CT" type4="protein-OD"/>
+    <Improper k1="43.932" periodicity1="2" phase1="3.141592653589793" type1="protein-C" type2="protein-CT" type3="protein-O" type4="protein-OA"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-C" type2="protein-CA" type3="protein-CA" type4="protein-OA"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-CA" type2="protein-CA" type3="protein-CA" type4="protein-OA"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-C" type2="protein-H5" type3="protein-O" type4="protein-OA"/>
+    <Improper k1="43.932" periodicity1="2" phase1="3.141592653589793" type1="protein-C" type2="protein-2C" type3="protein-O" type4="protein-OA"/>
+    <Improper k1="43.932" periodicity1="2" phase1="3.141592653589793" type1="protein-C" type2="protein-CT" type3="protein-OA" type4="protein-OD"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-C" type2="protein-H5" type3="protein-OA" type4="protein-OD"/>
+    <Improper k1="43.932" periodicity1="2" phase1="3.141592653589793" type1="protein-C" type2="protein-2C" type3="protein-OA" type4="protein-OD"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-TN" type2="protein-C" type3="protein-CT" type4="protein-H"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-TN" type2="protein-C" type3="protein-CX" type4="protein-H"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-TN" type2="protein-C" type3="protein-CT" type4="protein-O"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-TN" type2="protein-C" type3="protein-CT" type4="protein-OD"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-N" type2="protein-C" type3="protein-H" type4="protein-TG"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-N" type2="protein-C" type3="protein-H" type4="protein-TM"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-TN" type2="protein-C" type3="protein-H" type4="protein-TM"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-N" type2="protein-C" type3="protein-H" type4="protein-TP"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-ND" type2="protein-C" type3="protein-H" type4="protein-TP"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-TN" type2="protein-C" type3="protein-H" type4="protein-TP"/>
+    <Improper k1="4.184" periodicity1="2" phase1="3.141592653589793" type1="protein-TN" type2="protein-C" type3="protein-CT" type4="protein-TJ"/>
+    <Improper k1="43.932" periodicity1="2" phase1="3.141592653589793" type1="protein-C" type2="protein-N" type3="protein-OD" type4="protein-TJ"/>
+    <Improper k1="43.932" periodicity1="2" phase1="3.141592653589793" type1="protein-C" type2="protein-OD" type3="protein-TJ" type4="protein-TN"/>
+    <Improper k1="43.932" periodicity1="2" phase1="3.141592653589793" type1="protein-C" type2="protein-ND" type3="protein-OD" type4="protein-TJ"/>
+    <Improper k1="43.932" periodicity1="2" phase1="3.141592653589793" type1="protein-CO" type2="protein-O3" type3="protein-O3" type4="protein-TJ"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-CC" type2="protein-CV" type3="protein-NA" type4="protein-TA"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-CC" type2="protein-CW" type3="protein-NB" type4="protein-TA"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-CA" type2="protein-CA" type3="protein-CA" type4="protein-TA"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-C*" type2="protein-CB" type3="protein-CW" type4="protein-TA"/>
+  </PeriodicTorsionForce>
+  <NonbondedForce coulomb14scale="0.8333333333333334" lj14scale="0.5">
+    <UseAttributeFromResidue name="charge"/>
+    <Atom epsilon="0.359824" sigma="0.3399669508423535" type="protein-C"/>
+    <Atom epsilon="0.359824" sigma="0.3399669508423535" type="protein-CA"/>
+    <Atom epsilon="0.359824" sigma="0.3399669508423535" type="protein-CB"/>
+    <Atom epsilon="0.359824" sigma="0.3399669508423535" type="protein-CC"/>
+    <Atom epsilon="0.359824" sigma="0.3399669508423535" type="protein-CN"/>
+    <Atom epsilon="0.359824" sigma="0.3399669508423535" type="protein-CR"/>
+    <Atom epsilon="0.4577296" sigma="0.3399669508423535" type="protein-CT"/>
+    <Atom epsilon="0.359824" sigma="0.3399669508423535" type="protein-CV"/>
+    <Atom epsilon="0.359824" sigma="0.3399669508423535" type="protein-CW"/>
+    <Atom epsilon="0.359824" sigma="0.3399669508423535" type="protein-C*"/>
+    <Atom epsilon="0.4577296" sigma="0.3399669508423535" type="protein-CX"/>
+    <Atom epsilon="0.06568879999999999" sigma="0.1299999409510383" type="protein-H"/>
+    <Atom epsilon="0.06568879999999999" sigma="0.2649532787749369" type="protein-HC"/>
+    <Atom epsilon="0.06568879999999999" sigma="0.2471353044121301" type="protein-H1"/>
+    <Atom epsilon="0.06276" sigma="0.25996424595335105" type="protein-HA"/>
+    <Atom epsilon="0.06276" sigma="0.2510552587719476" type="protein-H4"/>
+    <Atom epsilon="0.06276" sigma="0.24214627159054422" type="protein-H5"/>
+    <Atom epsilon="0.0" sigma="1.0" type="protein-HO"/>
+    <Atom epsilon="0.06568879999999999" sigma="0.10690784617684071" type="protein-HS"/>
+    <Atom epsilon="0.06568879999999999" sigma="0.19599771799087468" type="protein-HP"/>
+    <Atom epsilon="0.7112800000000001" sigma="0.3249998523775958" type="protein-N"/>
+    <Atom epsilon="0.7112800000000001" sigma="0.3249998523775958" type="protein-NA"/>
+    <Atom epsilon="0.7112800000000001" sigma="0.3249998523775958" type="protein-NB"/>
+    <Atom epsilon="0.7112800000000001" sigma="0.3249998523775958" type="protein-N2"/>
+    <Atom epsilon="0.7112800000000001" sigma="0.3249998523775958" type="protein-N3"/>
+    <Atom epsilon="0.87864" sigma="0.2959921901149463" type="protein-O"/>
+    <Atom epsilon="0.8803136" sigma="0.3066473387839048" type="protein-OH"/>
+    <Atom epsilon="1.046" sigma="0.35635948725613575" type="protein-S"/>
+    <Atom epsilon="1.046" sigma="0.35635948725613575" type="protein-SH"/>
+    <Atom epsilon="0.359824" sigma="0.3399669508423535" type="protein-CO"/>
+    <Atom epsilon="0.4577296" sigma="0.3399669508423535" type="protein-2C"/>
+    <Atom epsilon="0.4577296" sigma="0.3399669508423535" type="protein-3C"/>
+    <Atom epsilon="0.4577296" sigma="0.3399669508423535" type="protein-C8"/>
+    <Atom epsilon="0.87864" sigma="0.2959921901149463" type="protein-O3"/>
+    <Atom epsilon="0.87864" sigma="0.2959921901149463" type="protein-OD"/>
+    <Atom epsilon="0.7112800000000001" sigma="0.3249998523775958" type="protein-ND"/>
+    <Atom epsilon="0.8803136" sigma="0.3066473387839048" type="protein-OA"/>
+    <Atom epsilon="0.7112800000000001" sigma="0.3249998523775958" type="protein-NL"/>
+    <Atom epsilon="0.7112800000000001" sigma="0.3249998523775958" type="protein-TN"/>
+    <Atom epsilon="0.4577296" sigma="0.3399669508423535" type="protein-TJ"/>
+    <Atom epsilon="0.4577296" sigma="0.3399669508423535" type="protein-TG"/>
+    <Atom epsilon="0.4577296" sigma="0.3399669508423535" type="protein-TP"/>
+    <Atom epsilon="0.4577296" sigma="0.3399669508423535" type="protein-TM"/>
+    <Atom epsilon="0.06568879999999999" sigma="0.15000008263405806" type="protein-TH"/>
+    <Atom epsilon="0.4577296" sigma="0.3399669508423535" type="protein-TA"/>
+  </NonbondedForce>
 </ForceField>


### PR DESCRIPTION
This is a more complete fix for #2003.  This adds the files that were regenerated in https://github.com/choderalab/openmm-forcefields/pull/62.  The changes to protein.ff14SB.xml are simple, but nearly every line of protein.ff15ipq.xml has changed.  However, this seems to be nothing more than reordering the attributes within each tag.