### PR TITLE
CHARMM36 supports disulfide bonds

### DIFF
--- a/wrappers/python/tests/TestForceField.py
+++ b/wrappers/python/tests/TestForceField.py
@@ -845,6 +845,14 @@ class TestForceField(unittest.TestCase):
         self.assertEqual(system1_indexes, [51, 56, 54, 55])
         self.assertEqual(system2_indexes, [51, 55, 54, 56])
 
+    def test_Disulfides(self):
+        """Test that various force fields handle disulfides correctly."""
+        pdb = PDBFile('systems/bpti.pdb')
+        for ff in ['amber99sb.xml', 'amber14-all.xml', 'charmm36.xml', 'amberfb15.xml', 'amoeba2013.xml']:
+            forcefield = ForceField(ff)
+            system = forcefield.createSystem(pdb.topology)
+
+
 class AmoebaTestForceField(unittest.TestCase):
     """Test the ForceField.createSystem() method with the AMOEBA forcefield."""
 


### PR DESCRIPTION
Fixes #2039.  I created the patch by hand.  I added a test case that verifies it can create a System for a protein with disulfide bonds, but I haven't checked that it produces identical forces to CHARMM.  @jchodera can you check that?

This fixes the problem in most cases, but the molecule a user discovered the problem in (5UIW) still does not work.  It's an unusual case, and a full fix for it will take bigger changes than I feel safe doing in a patch release.  The problem is that it contains two CYS residues that are adjacent to each other along the chain, and each of them forms a disulfide bond.  The code for applying multi-residue patches ends up matching the patch to the two adjacent residues.  They have the right types, after all, and they're bonded to each other.  But then it's unable to match the two residues they form the disulfide bonds to and it gets an error.  I'll try to come up with a fix for that in 7.3.

In the process of testing this, I also discovered another problem: `addMembrane()` doesn't work with CHARMM36 because it doesn't handle CustomNonbondedForces.  I'll send another PR to fix that.