### PR TITLE
minor fix for a NameError in getAtomIndexByName

### DIFF
--- a/wrappers/python/simtk/openmm/app/forcefield.py
+++ b/wrappers/python/simtk/openmm/app/forcefield.py
@@ -601,7 +601,7 @@ class ForceField(object):
 
             # Provide a helpful error message if atom name not found.
             msg =  "Atom name '%s' not found in residue template '%s'.\n" % (atom_name, self.name)
-            msg += "Possible atom names are: %s" % str(atomIndices.keys())
+            msg += "Possible atom names are: %s" % str(list(map(lambda x: x.name, self.atoms)))
             raise ValueError(msg)
 
         def addBond(self, atom1, atom2):


### PR DESCRIPTION
When an atom does not exist in the defined atom types, instead of raising an error with the available atom names, a NameError is raised because atomIndices is not in scope.