### PR TITLE
Fix uninitialized variable when Coulomb terms are missing

### DIFF
--- a/platforms/cuda/src/CudaKernels.cpp
+++ b/platforms/cuda/src/CudaKernels.cpp
@@ -1628,8 +1628,8 @@ void CudaCalcNonbondedForceKernel::initialize(const System& system, const Nonbon
     bool useCutoff = (nonbondedMethod != NoCutoff);
     bool usePeriodic = (nonbondedMethod != NoCutoff && nonbondedMethod != CutoffNonPeriodic);
     doLJPME = (nonbondedMethod == LJPME && hasLJ);
-    if (hasCoulomb)
-        usePosqCharges = cu.requestPosqCharges();
+    usePosqCharges = hasCoulomb ? cu.requestPosqCharges() : false;
+
     map<string, string> defines;
     defines["HAS_COULOMB"] = (hasCoulomb ? "1" : "0");
     defines["HAS_LENNARD_JONES"] = (hasLJ ? "1" : "0");

--- a/platforms/opencl/src/OpenCLKernels.cpp
+++ b/platforms/opencl/src/OpenCLKernels.cpp
@@ -1620,8 +1620,7 @@ void OpenCLCalcNonbondedForceKernel::initialize(const System& system, const Nonb
     bool useCutoff = (nonbondedMethod != NoCutoff);
     bool usePeriodic = (nonbondedMethod != NoCutoff && nonbondedMethod != CutoffNonPeriodic);
     doLJPME = (nonbondedMethod == LJPME && hasLJ);
-    if (hasCoulomb)
-        usePosqCharges = cl.requestPosqCharges();
+    usePosqCharges = hasCoulomb ? cl.requestPosqCharges() : false;
     map<string, string> defines;
     defines["HAS_COULOMB"] = (hasCoulomb ? "1" : "0");
     defines["HAS_LENNARD_JONES"] = (hasLJ ? "1" : "0");


### PR DESCRIPTION
The CUDA NonbondedForce routines check for the presence of Coulomb terms, setting `hasCoulomb` accordingly.  If this boolean is false the variable `usePosqCharges` is undefined, leading to the charge elements of `posq` sometimes being clobbered, sometimes not.  This has no consequence for the NonbondedForce (Coulomb terms are off), but I have a plugin that store some charges in `posq` that is affected when the charges in NonbondedForce are zeroed (I use it for LJPME terms).  I'm sure what I'm doing is bad design, but this simple fix gets things up and running for me.  The full test suite passes for me on a P100.