### PR TITLE
Add a Jenkinsfile to drive the pipeline

### DIFF
--- a/devtools/Jenkinsfile
+++ b/devtools/Jenkinsfile
@@ -1,15 +1,6 @@
 pipeline {
     agent any
 
-    post {
-        success {
-            setBuildStatus("Build succeeded", "SUCCESS");
-        }
-        failure {
-            setBuildStatus("Build failed", "FAILURE");
-        }
-    }
-
     stages {
         stage("Build and test") {
             agent {
@@ -21,15 +12,4 @@ pipeline {
             }
         }
     }
-}
-
-// Function for setting GitHub build status
-void setBuildStatus(String message, String state) {
-  step([
-      $class: "GitHubCommitStatusSetter",
-      reposSource: [$class: "ManuallyEnteredRepositorySource", url: "https://github.com/pandegroup/openmm"],
-      contextSource: [$class: "ManuallyEnteredCommitContextSource", context: "ci/jenkins/build-status"],
-      errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
-      statusResultSource: [ $class: "ConditionalStatusResultSource", results: [[$class: "AnyBuildResult", message: message, state: state]] ]
-  ]);
 }

--- a/devtools/Jenkinsfile
+++ b/devtools/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
             }
             steps {
                 sh 'git clean -fxd; git checkout .'
-                sh 'CUDA=9.0 devtools/ci/jenkins/install.sh'
+                sh 'CUDA_VERSION=9.0 devtools/ci/jenkins/install.sh'
             }
         }
     }

--- a/devtools/Jenkinsfile
+++ b/devtools/Jenkinsfile
@@ -1,0 +1,35 @@
+pipeline {
+    agent any
+
+    post {
+        success {
+            setBuildStatus("Build succeeded", "SUCCESS");
+        }
+        failure {
+            setBuildStatus("Build failed", "FAILURE");
+        }
+    }
+
+    stages {
+        stage("Build and test") {
+            agent {
+                label "cuda && linux"
+            }
+            steps {
+                sh 'git clean -fxd; git checkout .'
+                sh 'CUDA=9.0 devtools/ci/jenkins/install.sh'
+            }
+        }
+    }
+}
+
+// Function for setting GitHub build status
+void setBuildStatus(String message, String state) {
+  step([
+      $class: "GitHubCommitStatusSetter",
+      reposSource: [$class: "ManuallyEnteredRepositorySource", url: "https://github.com/pandegroup/openmm"],
+      contextSource: [$class: "ManuallyEnteredCommitContextSource", context: "ci/jenkins/build-status"],
+      errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
+      statusResultSource: [ $class: "ConditionalStatusResultSource", results: [[$class: "AnyBuildResult", message: message, state: state]] ]
+  ]);
+}

--- a/devtools/ci/jenkins/install.sh
+++ b/devtools/ci/jenkins/install.sh
@@ -11,12 +11,14 @@ cmake --version
 echo "Using g++ (`which g++`) version:"
 g++ --version
 
-module load cuda/9.0
+if [ ! -z $CUDA_VERSION ]; then
+  module load cuda/${CUDA_VERSION}
+  export OPENMM_CUDA_COMPILER=`which nvcc`
+fi
 
 # Constants
 CONDAENV=openmm-test-3.5
 INSTALL_DIRECTORY="`pwd`/install"
-export OPENMM_CUDA_COMPILER=`which nvcc`
 
 # Create a conda environment, but clean up after one first. If it doesn't exist, don't complain.
 # But since we are invoking this shell with -e (exit on all errors), we need || true to prevent this
@@ -37,7 +39,7 @@ make PythonInstall
 # Now run the tests
 python -m simtk.testInstallation
 cd python/tests && py.test -v && cd ../..
-python devtools/run-ctest.py --job-duration=120 --timeout 300
+python devtools/run-ctest.py --job-duration=120 --timeout 300 --parallel=2
 
 # Now remove the conda environment
 source deactivate

--- a/devtools/packaging/install.sh
+++ b/devtools/packaging/install.sh
@@ -26,10 +26,10 @@ fi
 
 # Make sure it's a supported Python version.
 
-pythonOk=$(${pythonBin} -c "import sys; v=sys.version_info; print((v[0]==2 and v[1]>5) or v[0]>2)")
+pythonOk=$(${pythonBin} -c "import sys; v=sys.version_info; print((v[0]==2 and v[1]>6) or v[0]>2)")
 if [ ${pythonOk} != "True" ]
 then
-  echo "Unsupported Python version.  Only versions 2.6 and higher are supported."
+  echo "Unsupported Python version.  Only versions 2.7 and higher are supported."
   exit
 fi
 

--- a/devtools/run-ctest.py
+++ b/devtools/run-ctest.py
@@ -43,6 +43,17 @@ def main():
         help="Timeout for individual tests (seconds). Default=180",
         type=str,
         default='180')
+    parser.add_argument(
+        '--in-order',
+        help='Run the tests in order',
+        type=bool,
+        default=False,
+        action='store_true')
+    parser.add_argument(
+        '--parallel',
+        help='Number of processors to use',
+        type=int,
+        default=1)
 
     args = parser.parse_args()
 
@@ -68,10 +79,11 @@ def execute_tests(options):
         shutil.rmtree('Testing')
     return call(['ctest',
                  '--output-on-failure',
-                 '--schedule-random',
+                 '--parallel', str(options.parallel),
                  '-T', 'Test',
                  '--timeout', options.timeout,
-                 '--stop-time', stop_time.strftime('%H:%M:%S')])
+                 '--stop-time', stop_time.strftime('%H:%M:%S')] +
+                 (['--schedule-random'] if options.in_order else []))
 
 
 def execute_failed_tests(options):
@@ -95,10 +107,11 @@ def execute_failed_tests(options):
     stop_time = start_time + timedelta(minutes=options.job_duration)
     return call(['ctest',
                  '--output-on-failure',
-                 '--schedule-random',
+                 '--parallel', str(options.parallel),
                  '-R', '|'.join(failed_tests),
                  '--timeout', options.timeout,
-                 '--stop-time', stop_time.strftime('%H:%M:%S')])
+                 '--stop-time', stop_time.strftime('%H:%M:%S')] +
+                 (['--schedule-random'] if options.in_order else []))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* Also tweaks the installation script for Jenkins to be more amenable to running other variants in parallel
* Restrict packaging script to only accept Python 2.7, since I think that's long been the minimum supported Python version
* Allow run-ctest.py to run tests in parallel (and take advantage of that in the Jenkins tests).

The other side-benefit this has is that it moves the job configuration from the Jenkins job into source control here, making it easy to recover from something happening to Jenkins (has now happened twice).