### PR TITLE
Properly define GBSAOBC alpha beta gamma constants to be doubles.

### DIFF
--- a/platforms/reference/src/SimTKReference/ObcParameters.cpp
+++ b/platforms/reference/src/SimTKReference/ObcParameters.cpp
@@ -103,13 +103,13 @@ ObcParameters::ObcType ObcParameters::getObcType() const {
 
 void ObcParameters::setObcTypeParameters(ObcParameters::ObcType obcType) {
     if (obcType == ObcTypeI) {
-        _alphaObc   = 0.8L;
-        _betaObc    = 0.0L;
-        _gammaObc   = 2.91L;
+        _alphaObc   = 0.8;
+        _betaObc    = 0.0;
+        _gammaObc   = 2.91;
     } else {
-        _alphaObc   = 1.0L;
-        _betaObc    = 0.8L;
-        _gammaObc   = 4.85L;
+        _alphaObc   = 1.0;
+        _betaObc    = 0.8;
+        _gammaObc   = 4.85;
     }
     _obcType = obcType;
 }

--- a/platforms/reference/src/SimTKReference/ObcParameters.cpp
+++ b/platforms/reference/src/SimTKReference/ObcParameters.cpp
@@ -103,13 +103,13 @@ ObcParameters::ObcType ObcParameters::getObcType() const {
 
 void ObcParameters::setObcTypeParameters(ObcParameters::ObcType obcType) {
     if (obcType == ObcTypeI) {
-        _alphaObc   = 0.8f;
-        _betaObc    = 0.0f;
-        _gammaObc   = 2.91f;
+        _alphaObc   = 0.8L;
+        _betaObc    = 0.0L;
+        _gammaObc   = 2.91L;
     } else {
-        _alphaObc   = 1.0f;
-        _betaObc    = 0.8f;
-        _gammaObc   = 4.85f;
+        _alphaObc   = 1.0L;
+        _betaObc    = 0.8L;
+        _gammaObc   = 4.85L;
     }
     _obcType = obcType;
 }


### PR DESCRIPTION
This took me way too long to find. There's no reason why these should be defined as floats. I was comparing against my tensorflow reference implementation and found a discrepancy in double precision.