### PR TITLE
Ensuring opened files are properly closed

### DIFF
--- a/wrappers/python/simtk/openmm/app/gromacsgrofile.py
+++ b/wrappers/python/simtk/openmm/app/gromacsgrofile.py
@@ -133,39 +133,40 @@ class GromacsGroFile(object):
         xyz      = []
         ln       = 0
         frame    = 0
-        for line in open(file):
-            if ln == 0:
-                comms.append(line.strip())
-            elif ln == 1:
-                na = int(line.strip())
-            elif _is_gro_coord(line):
-                if frame == 0: # Create the list of residues, atom names etc. only if it's the first frame.
-                    (thisresnum, thisresname, thisatomname) = [line[i*5:i*5+5].strip() for i in range(3)]
-                    resname.append(thisresname)
-                    resid.append(int(thisresnum))
-                    atomname.append(thisatomname)
-                    thiselem = thisatomname
-                    if len(thiselem) > 1:
-                        thiselem = thiselem[0] + sub('[A-Z0-9]','',thiselem[1:])
-                        try:
-                            elements.append(elem.get_by_symbol(thiselem))
-                        except KeyError:
-                            elements.append(None)
-                firstDecimalPos = line.index('.', 20)
-                secondDecimalPos = line.index('.', firstDecimalPos+1)
-                digits = secondDecimalPos-firstDecimalPos
-                pos = [float(line[20+i*digits:20+(i+1)*digits]) for i in range(3)]
-                xyz.append(Vec3(pos[0], pos[1], pos[2]))
-            elif _is_gro_box(line) and ln == na + 2:
-                sline = line.split()
-                boxes.append(_construct_box_vectors(line))
-                xyzs.append(xyz*nanometers)
-                xyz = []
-                ln = -1
-                frame += 1
-            else:
-                raise Exception("Unexpected line in .gro file: "+line)
-            ln += 1
+        with open(file) as grofile:
+            for line in grofile:
+                if ln == 0:
+                    comms.append(line.strip())
+                elif ln == 1:
+                    na = int(line.strip())
+                elif _is_gro_coord(line):
+                    if frame == 0: # Create the list of residues, atom names etc. only if it's the first frame.
+                        (thisresnum, thisresname, thisatomname) = [line[i*5:i*5+5].strip() for i in range(3)]
+                        resname.append(thisresname)
+                        resid.append(int(thisresnum))
+                        atomname.append(thisatomname)
+                        thiselem = thisatomname
+                        if len(thiselem) > 1:
+                            thiselem = thiselem[0] + sub('[A-Z0-9]','',thiselem[1:])
+                            try:
+                                elements.append(elem.get_by_symbol(thiselem))
+                            except KeyError:
+                                elements.append(None)
+                    firstDecimalPos = line.index('.', 20)
+                    secondDecimalPos = line.index('.', firstDecimalPos+1)
+                    digits = secondDecimalPos-firstDecimalPos
+                    pos = [float(line[20+i*digits:20+(i+1)*digits]) for i in range(3)]
+                    xyz.append(Vec3(pos[0], pos[1], pos[2]))
+                elif _is_gro_box(line) and ln == na + 2:
+                    sline = line.split()
+                    boxes.append(_construct_box_vectors(line))
+                    xyzs.append(xyz*nanometers)
+                    xyz = []
+                    ln = -1
+                    frame += 1
+                else:
+                    raise Exception("Unexpected line in .gro file: "+line)
+                ln += 1
 
         ## The atom positions read from the file.  If the file contains multiple frames, these are the positions in the first frame.
         self.positions = xyzs[0]

--- a/wrappers/python/simtk/openmm/app/pdbxfile.py
+++ b/wrappers/python/simtk/openmm/app/pdbxfile.py
@@ -75,6 +75,7 @@ class PDBxFile(object):
         reader = PdbxReader(inputFile)
         data = []
         reader.read(data)
+        inputFile.close()
         block = data[0]
 
         # Build the topology.

--- a/wrappers/python/simtk/openmm/app/pdbxfile.py
+++ b/wrappers/python/simtk/openmm/app/pdbxfile.py
@@ -70,12 +70,15 @@ class PDBxFile(object):
         # Load the file.
 
         inputFile = file
+        ownHandle = False
         if isinstance(file, str):
             inputFile = open(file)
+            ownHandle = True
         reader = PdbxReader(inputFile)
         data = []
         reader.read(data)
-        inputFile.close()
+        if ownHandle:
+            inputFile.close()
         block = data[0]
 
         # Build the topology.

--- a/wrappers/python/tests/TestAmberPrmtopFile.py
+++ b/wrappers/python/tests/TestAmberPrmtopFile.py
@@ -293,7 +293,8 @@ class TestAmberPrmtopFile(unittest.TestCase):
             context = Context(system, integrator, Platform.getPlatformByName("Reference"))
             context.setPositions(pdb.positions)
             state1 = context.getState(getForces=True)
-            state2 = XmlSerializer.deserialize(open('systems/alanine-dipeptide-implicit-forces/'+file[i]+'.xml').read())
+            with open('systems/alanine-dipeptide-implicit-forces/'+file[i]+'.xml') as infile:
+                state2 = XmlSerializer.deserialize(infile.read())
             for f1, f2, in zip(state1.getForces().value_in_unit(kilojoules_per_mole/nanometer), state2.getForces().value_in_unit(kilojoules_per_mole/nanometer)):
                 diff = norm(f1-f2)
                 self.assertTrue(diff < 0.1 or diff/norm(f1) < 1e-4)

--- a/wrappers/python/tests/TestPdbFile.py
+++ b/wrappers/python/tests/TestPdbFile.py
@@ -67,12 +67,13 @@ class TestPdbFile(unittest.TestCase):
 
     def test_BinaryStream(self):
         """Test reading a stream that was opened in binary mode."""
-        pdb = PDBFile(open('systems/triclinic.pdb', 'rb'))
+        with open('systems/triclinic.pdb', 'rb') as infile:
+            pdb = PDBFile(infile)
         self.assertEqual(len(pdb.positions), 8)
 
     def test_ExtraParticles(self):
         """Test reading, and writing and re-reading of a file containing extra particle atoms."""
-        pdb = PDBFile('systems/tip5p.pdb')  
+        pdb = PDBFile('systems/tip5p.pdb')
         for atom in pdb.topology.atoms():
             if atom.index > 2:
                 self.assertEqual(None, atom.element)


### PR DESCRIPTION
Addressing some `ResourceWarning`s appearing in Python tests. `GromacsGroFile` and `PDBxFile` were both keeping their input file handles open indefinitely. The other cases in the test scripts are fairly harmless, but reducing the number of warnings is never a bad thing.