### PR TITLE
Avoid repeated matching of duplicate impropers

### DIFF
--- a/wrappers/python/simtk/openmm/app/forcefield.py
+++ b/wrappers/python/simtk/openmm/app/forcefield.py
@@ -1972,7 +1972,7 @@ class PeriodicTorsionGenerator(object):
         for torsion in data.propers:
             type1, type2, type3, type4 = [data.atomType[data.atoms[torsion[i]]] for i in range(4)]
             sig = (type1, type2, type3, type4)
-            sig = frozenset((sig, sig[:-1]))
+            sig = frozenset((sig, sig[::-1]))
             match = proper_cache.get(sig, None)
             if match == -1:
                 continue

--- a/wrappers/python/simtk/openmm/app/forcefield.py
+++ b/wrappers/python/simtk/openmm/app/forcefield.py
@@ -1998,17 +1998,28 @@ class PeriodicTorsionGenerator(object):
                     if match.k[i] != 0:
                         force.addTorsion(torsion[0], torsion[1], torsion[2], torsion[3], match.periodicity[i], match.phase[i], match.k[i])
         impr_cache = {}
+        # from collections import defaultdict
         for torsion in data.impropers:
-            t1, t2, t3, t4 = [data.atomType[data.atoms[torsion[i]]] for i in range(4)]
-            sig = (t1, frozenset((t2,t3,t4)))
+            t1, t2, t3, t4 = tatoms = [data.atomType[data.atoms[torsion[i]]] for i in range(4)]
+            sig = (t1, t2, t3, t4)
+            # tcount = defaultdict(int)
+            # for t in (t2,t3,t4):
+            #     tcount[t] += 1
+            # sig = (t1, frozenset((atype, count) for atype, count in tcount.items()))
             match = impr_cache.get(sig, None)
             if match == -1:
                 # Previously checked, and doesn't appear in the database
                 continue
+            elif match:
+                i1, i2, i3, i4, tordef = match
+                a1, a2, a3, a4 = (torsion[i] for i in (i1, i2, i3, i4))
+                match = (a1, a2, a3, a4, tordef)
             if match is None:
                 match = _matchImproper(data, torsion, self)
                 if match is not None:
-                    impr_cache[sig] = match
+                    order = match[:4]
+                    i1, i2, i3, i4 = tuple(torsion.index(a) for a in order)
+                    impr_cache[sig] = (i1, i2, i3, i4, match[-1])
                 else:
                     impr_cache[sig] = -1
             if match is not None:

--- a/wrappers/python/simtk/openmm/app/forcefield.py
+++ b/wrappers/python/simtk/openmm/app/forcefield.py
@@ -266,13 +266,13 @@ class ForceField(object):
                     atomIndices = template.atomIndices
                     for ia, atom in enumerate(residue.findall('Atom')):
                         params = {}
-                        a_attrib = atom.attrib
-                        atomName = a_attrib.pop('name')
+                        for key in atom.attrib:
+                            if key not in ('name', 'type'):
+                                params[key] = _convertParameterToNumber(atom.attrib[key])
+                        atomName = atom.attrib['name']
                         if atomName in atomIndices:
                             raise ValueError('Residue '+resName+' contains multiple atoms named '+atomName)
-                        typeName = a_attrib.pop('type')
-                        for key in atom.attrib:
-                            params[key] = _convertParameterToNumber(atom.attrib[key])
+                        typeName = atom.attrib['type']
                         atomIndices[atomName] = ia
                         template.atoms.append(ForceField._TemplateAtomData(atomName, typeName, self._atomTypes[typeName].element, params))
                     for site in residue.findall('VirtualSite'):

--- a/wrappers/python/simtk/openmm/app/forcefield.py
+++ b/wrappers/python/simtk/openmm/app/forcefield.py
@@ -1990,14 +1990,25 @@ class PeriodicTorsionGenerator(object):
                 for i in range(len(match.phase)):
                     if match.k[i] != 0:
                         force.addTorsion(torsion[0], torsion[1], torsion[2], torsion[3], match.periodicity[i], match.phase[i], match.k[i])
+        impr_cache = {}
         for torsion in data.impropers:
-            match = _matchImproper(data, torsion, self)
+            t1, t2, t3, t4 = [data.atomType[data.atoms[torsion[i]]] for i in range(4)]
+            sig = (t1, frozenset((t2,t3,t4)))
+            match = impr_cache.get(sig, None)
+            if match == -1:
+                # Previously checked, and doesn't appear in the database
+                continue
+            if match is None:
+                match = _matchImproper(data, torsion, self)
+                if match is not None:
+                    impr_cache[sig] = match
+                else:
+                    impr_cache[sig] = -1
             if match is not None:
                 (a1, a2, a3, a4, tordef) = match
                 for i in range(len(tordef.phase)):
                     if tordef.k[i] != 0:
                         force.addTorsion(a1, a2, a3, a4, tordef.periodicity[i], tordef.phase[i], tordef.k[i])
-
 parsers["PeriodicTorsionForce"] = PeriodicTorsionGenerator.parseElement
 
 

--- a/wrappers/python/simtk/openmm/app/forcefield.py
+++ b/wrappers/python/simtk/openmm/app/forcefield.py
@@ -1998,14 +1998,9 @@ class PeriodicTorsionGenerator(object):
                     if match.k[i] != 0:
                         force.addTorsion(torsion[0], torsion[1], torsion[2], torsion[3], match.periodicity[i], match.phase[i], match.k[i])
         impr_cache = {}
-        # from collections import defaultdict
         for torsion in data.impropers:
             t1, t2, t3, t4 = tatoms = [data.atomType[data.atoms[torsion[i]]] for i in range(4)]
             sig = (t1, t2, t3, t4)
-            # tcount = defaultdict(int)
-            # for t in (t2,t3,t4):
-            #     tcount[t] += 1
-            # sig = (t1, frozenset((atype, count) for atype, count in tcount.items()))
             match = impr_cache.get(sig, None)
             if match == -1:
                 # Previously checked, and doesn't appear in the database


### PR DESCRIPTION
Doing some profiling of simulation startup in a large forcefield with 2922 different improper definitions, outside of `new_Context()` the repeated calls to `_matchImproper()` in `PeriodicTorsionGenerator` are far and away the most expensive (3.5 seconds for a 229-residue protein vs. about 200ms for the next-most-expensive call). By caching the improper definitions (or lack thereof) for signatures that have already been seen, the number of calls to `_matchImproper()` is reduced from ~2500 to 92, bringing the time cost down to 125 ms.

Incidentally, the `createForce()` methods in `RBTorsionGenerator` and `CustomTorsionGenerator` are near-identical copies of that in `PeriodicTorsionGenerator`. Looks like these could be quite easily refactored as subclasses of a generic base class?
