### PR TITLE
Improved ion addition to both addSolvent() and addMembrane()

### DIFF
--- a/wrappers/python/simtk/openmm/app/modeller.py
+++ b/wrappers/python/simtk/openmm/app/modeller.py
@@ -336,7 +336,7 @@ class Modeller(object):
         # while ensuring ions are not placed too close to each other.
         modeller = Modeller(self.topology, self.positions)
 
-        replaceableList = list(replaceableMols)
+        replaceableList = list(replaceableMols.keys())
         numAddedIons = 0
         numTrials = 10  # Attempts to add ions N times before quitting
         toReplace = []  # list of molecules to be replaced

--- a/wrappers/python/simtk/openmm/app/modeller.py
+++ b/wrappers/python/simtk/openmm/app/modeller.py
@@ -312,7 +312,7 @@ class Modeller(object):
         for i in range(nonbonded.getNumParticles()):
             nb_i = nonbonded.getParticleParameters(i)
             totalCharge += nb_i[0].value_in_unit(elementary_charge)
-        # Round up to integer
+        # Round to nearest integer
         totalCharge = int(floor(0.5 + totalCharge))
 
         # Figure out how many ions to add based on requested params/concentration
@@ -475,17 +475,6 @@ class Modeller(object):
             if box is None:
                 raise ValueError('Neither the box size, box vectors, nor padding was specified, and the Topology does not define unit cell dimensions')
         invBox = Vec3(1.0/box[0], 1.0/box[1], 1.0/box[2])
-
-        # Identify the ion types.
-
-        posIonElements = {'Cs+':elem.cesium, 'K+':elem.potassium, 'Li+':elem.lithium, 'Na+':elem.sodium, 'Rb+':elem.rubidium}
-        negIonElements = {'Cl-':elem.chlorine, 'Br-':elem.bromine, 'F-':elem.fluorine, 'I-':elem.iodine}
-        if positiveIon not in posIonElements:
-            raise ValueError('Illegal value for positive ion: %s' % positiveIon)
-        if negativeIon not in negIonElements:
-            raise ValueError('Illegal value for negative ion: %s' % negativeIon)
-        positiveElement = posIonElements[positiveIon]
-        negativeElement = negIonElements[negativeIon]
 
         # Have the ForceField build a System for the solute from which we can determine van der Waals radii.
 
@@ -1309,18 +1298,7 @@ class Modeller(object):
         patchCenterPos = (patchMinPos+patchMaxPos)/2
         nx = int(ceil((proteinSize[0]+2*minimumPadding)/patchSize[0]))
         ny = int(ceil((proteinSize[1]+2*minimumPadding)/patchSize[1]))
-
-        # Identify the ion types.
-
-        posIonElements = {'Cs+':elem.cesium, 'K+':elem.potassium, 'Li+':elem.lithium, 'Na+':elem.sodium, 'Rb+':elem.rubidium}
-        negIonElements = {'Cl-':elem.chlorine, 'Br-':elem.bromine, 'F-':elem.fluorine, 'I-':elem.iodine}
-        if positiveIon not in posIonElements:
-            raise ValueError('Illegal value for positive ion: %s' % positiveIon)
-        if negativeIon not in negIonElements:
-            raise ValueError('Illegal value for negative ion: %s' % negativeIon)
-        positiveElement = posIonElements[positiveIon]
-        negativeElement = negIonElements[negativeIon]
-        
+       
         # Record the bonds for each residue.
         
         resBonds = defaultdict(list)

--- a/wrappers/python/simtk/openmm/app/modeller.py
+++ b/wrappers/python/simtk/openmm/app/modeller.py
@@ -1544,7 +1544,7 @@ class Modeller(object):
                 if residue.name == 'HOH':
                     for atom in residue.atoms():
                         if atom.element == elem.oxygen:
-                            waterPos[residue] = modeller.positions[atom.index].value_in_unit(nanometer)
+                            waterPos[residue] = modeller.positions[atom.index]
 
         # Calculate lipid Z boundaries
         lipidNames = {res.name for res in patch.topology.residues() if res.name != 'HOH'}
@@ -1564,7 +1564,7 @@ class Modeller(object):
         waterResidues = list(waterPos)
         for wRes in waterResidues:
             waterZ = waterPos[wRes][2]
-            if lowerZBoundary < waterZ < upperZBoundary:
+            if lowerZBoundary < waterZ.value_in_unit(nanometer) < upperZBoundary:
                 del waterPos[wRes]
 
         self._addIons(forcefield, waterPos, positiveIon=positiveIon, negativeIon=negativeIon, ionicStrength=ionicStrength, neutralize=neutralize)


### PR DESCRIPTION
After the discussion in #2100, addressing #2099, I implemented a private `addIons` method that replaces waters (or any molecule really) by ions, up to a given concentration or to a certain number of ions. I replaced the ion addition routines in each `addSolvent` and `addMembrane` by a call to the new `addIons`.

Tested locally and it works for both membrane and non-membrane systems. I cannot figure out what would be a proper test for this though, to add to the unit tests.

Suggestions are welcome!