### PR TITLE
Fix unicode error in sphinx compilation

### DIFF
--- a/docs-source/usersguide/theory.rst
+++ b/docs-source/usersguide/theory.rst
@@ -851,7 +851,7 @@ by the user.  That is, the interaction energy of each angle is given by
 
 
 where :math:`f(\theta)` is a user defined mathematical expression.  The angle
-:math:`\theta` is guaranteed to be in the range [-π, π].  Like PeriodicTorsionForce, it
+:math:`\theta` is guaranteed to be in the range :math:`[-\pi, +\pi]`\ .  Like PeriodicTorsionForce, it
 is defined to be zero when the first and last particles are on the same side of
 the bond formed by the middle two particles (the *cis* configuration).
 
@@ -973,7 +973,7 @@ of four particles.  That is, the interaction energy of each bond is given by
 where *f*\ (\ *...*\ ) is a user defined mathematical expression.  It may
 depend on an arbitrary set of positions {\ :math:`x_i`\ }, distances {\ :math:`r_i`\ },
 angles {\ :math:`\theta_i`\ }, and dihedral angles {\ :math:`\phi_i`\ }
-guaranteed to be in the range [-π, π]. 
+guaranteed to be in the range :math:`[-\pi, +\pi]`\ .
 
 Each distance, angle, or dihedral is defined by specifying a sequence of
 particles chosen from among the particles that make up the bond.  A distance


### PR DESCRIPTION
I noticed the [conda-dev-builds](https://travis-ci.org/omnia-md/conda-dev-recipes/jobs/515150822#L5957-L5975) were failing with:
```
LaTeX Warning: Hyper reference `theory:writing-custom-expressions' on page 125 
undefined on input line 9061.
[125]
! Package inputenc Error: Unicode character π (U+3C0)
(inputenc)                not set up for use with LaTeX.
See the inputenc package documentation for explanation.
Type  H <return>  for immediate help.
 ...                                              
                                                  
l.9122 ... is guaranteed to be in the range {[}-π
                                                  , π{]}.  Like PeriodicTor...
? 
No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
```
I've changed the unsupported unicode characters to `:math:` expressions.