### PR TITLE
Adding alternative names of terminal nucleic acids (5' and 3') and atoms H2', H2'', H5' and H5''.

### DIFF
--- a/wrappers/python/simtk/openmm/app/data/pdbNames.xml
+++ b/wrappers/python/simtk/openmm/app/data/pdbNames.xml
@@ -25,12 +25,12 @@
   <Atom name="O4'" alt1="O4*"/>
   <Atom name="O5'" alt1="O5*"/>
   <Atom name="H1'" alt1="H1*"/>
-  <Atom name="H2'" alt1="H2*" alt2="1H2*" alt3="1H2'"/>
-  <Atom name="H2''" alt1="2H2*" alt2="2H2'"/>
+  <Atom name="H2'" alt1="H2*" alt2="1H2*" alt3="1H2'" alt4="H2'1"/>
+  <Atom name="H2''" alt1="2H2*" alt2="2H2'" alt3="H2'2"/>
   <Atom name="H3'" alt1="H3*"/>
   <Atom name="H4'" alt1="H4*"/>
-  <Atom name="H5'" alt1="1H5*" alt2="1H5'"/>
-  <Atom name="H5''" alt1="2H5*" atl2="2H5'"/>
+  <Atom name="H5'" alt1="1H5*" alt2="1H5'" alt3="H5'1"/>
+  <Atom name="H5''" alt1="2H5*" atl2="2H5'" alt3="H5'2"/>
   <Atom name="HO2'" alt1="2HO*"/>
   <Atom name="HO3'" alt1="H3T"/>
   <Atom name="HO5'" alt1="H5T"/>
@@ -252,19 +252,19 @@
   <Atom name="H42" alt1="2H4"/>
  </Residue>
  <Residue name="U" alt1="URA" type="Nucleic"/>
- <Residue name="DA" alt1="DAD" type="Nucleic">
+ <Residue name="DA" alt1="DAD" alt2="DA3" alt3="DA5" type="Nucleic">
   <Atom name="H61" alt1="1H6"/>
   <Atom name="H62" alt1="2H6"/>
  </Residue>
- <Residue name="DG" alt1="DGU" type="Nucleic">
+ <Residue name="DG" alt1="DGU" alt2="DG3" alt3="DG5" type="Nucleic">
   <Atom name="H21" alt1="1H2"/>
   <Atom name="H22" alt1="2H2"/>
  </Residue>
- <Residue name="DC" alt1="DCY" type="Nucleic">
+ <Residue name="DC" alt1="DCY" alt2="DC3" alt3="DC5" type="Nucleic">
   <Atom name="H41" alt1="1H4"/>
   <Atom name="H42" alt1="2H4"/>
  </Residue>
- <Residue name="DT" alt1="THY" type="Nucleic">
+ <Residue name="DT" alt1="THY" alt2="DT3" alt3="DT5" type="Nucleic">
   <Atom name="C7" alt1="C5M"/>
   <Atom name="H71" alt1="1H5M"/>
   <Atom name="H72" alt1="2H5M"/>


### PR DESCRIPTION
Adding alternative names of terminal nucleic acids (5' and 3' as DG5 and DG3).
Adding alternative names of atoms H2', H2'', H5' and H5'' for nucleic acids.

These few changes allow working with PDB files with DNA coming from tleap without renaming atoms and residues (see https://github.com/pandegroup/openmm/issues/2313).