### PR TITLE
Documentation: Conda+GPU need to pin packages.

### DIFF
--- a/docs-source/usersguide/application.rst
+++ b/docs-source/usersguide/application.rst
@@ -80,7 +80,13 @@ where :code:`cuda92` should be replaced with the particular CUDA version
 installed on your computer.  Supported values are :code:`cuda75`, :code:`cuda80`,
 :code:`cuda90`, :code:`cuda91`, :code:`cuda92`, and :code:`cuda100`.  Because
 different CUDA releases are not binary compatible with each other, OpenMM can
-only work with the particular CUDA version it was compiled with.
+only work with the particular CUDA version it was compiled with. You most likely 
+want to also install the corresponding version of the cuda package :code:`cuda92`
+and the corresponding version of :code:`cudatoolkit` from the default channel
+::
+
+   conda install -c omnia/label/cuda92 cuda92
+   conda install 'cudatoolkit==9.2'
 
 4. Verify your installation by typing the following command:
 ::


### PR DESCRIPTION
Add into the documentation that when installing with conda you likely
need to pin `cudatoolkit` and `cudaXY` or openmm might just fail to find
CUDA.

-- 

At least we struggled with that on our cluster for a couple of hours. Not sure this is the *only* thing that helped; but at least it was necessary without our version of cuda (9.0), on centos 7.

It would be nice if these were pinned in each openmm from each label; but I'm not sure if this is possible as you do not explicitely depend on it 
