### PR TITLE
Optimized conversion of 1D Numpy array to C++ vector<double>

### DIFF
--- a/wrappers/python/src/swig_doxygen/swig_lib/python/header.i
+++ b/wrappers/python/src/swig_doxygen/swig_lib/python/header.i
@@ -20,6 +20,16 @@ PyObject *copyVVec3ToList(std::vector<Vec3> vVec3) {
   return pyList;
 }
 
+int isNumpyAvailable() {
+    static bool initialized = false;
+    static bool available = false;
+    if (!initialized) {
+        initialized = true;
+        available = (_import_array() >= 0);
+    }
+    return available;
+}
+
 } // namespace OpenMM
 %}
 


### PR DESCRIPTION
Fixes #2337.  If you supply a 1D Numpy array containing 32 or 64 bit ints or floats, it copies the data directly without going through all the overhead of creating Python objects for each element.