### PR TITLE
Fixed error related to autoclear buffers on OpenCL

### DIFF
--- a/platforms/opencl/src/OpenCLContext.cpp
+++ b/platforms/opencl/src/OpenCLContext.cpp
@@ -729,7 +729,7 @@ void OpenCLContext::clearAutoclearBuffers() {
         executeKernel(clearTwoBuffersKernel, max(autoclearBufferSizes[base], autoclearBufferSizes[base+1]), 128);
     }
     else if (total-base == 1) {
-        clearBuffer(*autoclearBuffers[base], autoclearBufferSizes[base]);
+        clearBuffer(*autoclearBuffers[base], autoclearBufferSizes[base]*4);
     }
 }
 


### PR DESCRIPTION
This fixes an error that under somewhat exotic circumstances would cause incorrect results.  When *exactly* seven autoclear buffers were added to the OpenCLContext, the last one would only get partially cleared.  This only happened on OpenCL, not any other platform.

This came up in https://simtk.org/plugins/phpBB/viewtopicPhpbb.php?f=161&t=10692&p=29834.