### PR TITLE
Support for multiple paths in OPENMM_PLUGIN_DIR

### DIFF
--- a/olla/include/openmm/Platform.h
+++ b/olla/include/openmm/Platform.h
@@ -213,26 +213,24 @@ public:
      */
     static void loadPluginLibrary(const std::string& file);
     /**
-     * Load multiple dynamic libraries (DLLs) which contain OpenMM plugins from a single directory.
-     * This method loops over every file contained in the specified directory and calls loadPluginLibrary()
+     * Load multiple dynamic libraries (DLLs) which contain OpenMM plugins from one or more directories.
+     * Multiple fully-qualified paths can be joined together with ':' on unix-like systems
+     * (or ';' on windows-like systems); each will be searched for plugins, in-order. For example,
+     * '/foo/plugins:/bar/plugins' will search both `/foo/plugins` and `/bar/plugins`. If an
+     * identically-named plugin is encountered twice it will be loaded at both points; be careful!!!
+     *
+     * This method loops over every file contained in the specified directories and calls loadPluginLibrary()
      * for each one.  If an error occurs while trying to load a particular file, that file is simply
      * ignored. You can retrieve a list of all such errors by calling getPluginLoadFailures().
      *
-     * @param directory    the path to the directory containing libraries to load
+     * @param directory    a ':' (unix) or ';' (windows) deliminated list of paths containing libraries to load
      * @return the names of all files which were successfully loaded as libraries
      */
     static std::vector<std::string> loadPluginsFromDirectory(const std::string& directory);
     /**
      * Get the default directory from which to load plugins.  If the environment variable
      * OPENMM_PLUGIN_DIR is set, this returns its value.  Otherwise, it returns a platform
-     * specific default location.
-     *
-     * On unix-like systems, OPENMM_PLUGIN_DIR is allowed to either be a
-     * single, fully-qualified path (e.g., /foo/plugins) or a ':'-concatenated
-     * set of fully-qualified paths (e.g., /foo/plugins:bar/plugins). On
-     * windows-like systems, the same is true, but the path separator is '\\'
-     * and the path concatenator is ';'. If an identically-named plugin is
-     * encountered twice it will be loaded at both points; be careful!!!
+     * specific default location. 
      *
      * @return the path to the default plugin directory
      */

--- a/olla/include/openmm/Platform.h
+++ b/olla/include/openmm/Platform.h
@@ -35,7 +35,6 @@
 #include <map>
 #include <string>
 #include <vector>
-#include <sstream>
 #include "openmm/internal/windowsExport.h"
 
 namespace OpenMM {
@@ -227,6 +226,13 @@ public:
      * Get the default directory from which to load plugins.  If the environment variable
      * OPENMM_PLUGIN_DIR is set, this returns its value.  Otherwise, it returns a platform
      * specific default location.
+     *
+     * On unix-like systems, OPENMM_PLUGIN_DIR is allowed to either be a
+     * single, fully-qualified path (e.g., /foo/plugins) or a ':'-concatenated
+     * set of fully-qualified paths (e.g., /foo/plugins:bar/plugins). On
+     * windows-like systems, the same is true, but the path separator is '\\'
+     * and the path concatenator is ';'. If an identically-named plugin is
+     * encountered twice it will be loaded at both points; be careful!!!
      *
      * @return the path to the default plugin directory
      */

--- a/olla/include/openmm/Platform.h
+++ b/olla/include/openmm/Platform.h
@@ -35,6 +35,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <sstream>
 #include "openmm/internal/windowsExport.h"
 
 namespace OpenMM {

--- a/olla/src/Platform.cpp
+++ b/olla/src/Platform.cpp
@@ -37,7 +37,6 @@
 #include "openmm/internal/ContextImpl.h"
 #ifdef WIN32
 #include <windows.h>
-#include <sstream>
 #else
 #ifndef __PNACL__
     #include <dlfcn.h>
@@ -45,6 +44,7 @@
 #include <dirent.h>
 #include <cstdlib>
 #endif
+#include <sstream>
 #include <set>
 #include <algorithm>
 

--- a/olla/src/Platform.cpp
+++ b/olla/src/Platform.cpp
@@ -261,31 +261,42 @@ void Platform::loadPluginLibrary(const string& file) {
 vector<string> Platform::loadPluginsFromDirectory(const string& directory) {
     vector<string> files;
     char dirSeparator;
+    char pathSeparator;
+    stringstream sdirectory(directory);
 #ifdef WIN32
     dirSeparator = '\\';
+    pathSeparator = ';';
     WIN32_FIND_DATA fileInfo;
-    string filePattern(directory + dirSeparator + "*.dll");
-    HANDLE findHandle = FindFirstFile(filePattern.c_str(), &fileInfo);
-    if (findHandle != INVALID_HANDLE_VALUE) {
-        do {
-            if (fileInfo.cFileName[0] != '.')
-                files.push_back(string(fileInfo.cFileName));
-        } while (FindNextFile(findHandle, &fileInfo));
-        FindClose(findHandle);
+
+    for (string path; std::getline(sdirectory, path, pathSeparator);) {
+        string filePattern(path + dirSeparator + "*.dll");
+        HANDLE findHandle = FindFirstFile(filePattern.c_str(), &fileInfo);
+        if (findHandle != INVALID_HANDLE_VALUE) {
+            do {
+                if (fileInfo.cFileName[0] != '.')
+                    files.push_back(path+dirSeparator+string(fileInfo.cFileName));
+            } while (FindNextFile(findHandle, &fileInfo));
+            FindClose(findHandle);
+        }
     }
     vector<HMODULE> plugins;
 #else
-    dirSeparator = '/';
     DIR* dir;
+    dirSeparator = '/';
+    pathSeparator = ':';
     struct dirent *entry;
-    dir = opendir(directory.c_str());
-    if (dir != NULL) {
-        while ((entry = readdir(dir)) != NULL) {
-            if (entry->d_name[0] != '.')
-                files.push_back(string(entry->d_name));
+
+    for (string path; std::getline(sdirectory, path, pathSeparator);) {
+        dir = opendir(path.c_str());
+        if (dir != NULL) {
+            while ((entry = readdir(dir)) != NULL) {
+                if (entry->d_name[0] != '.')
+                    files.push_back(path+dirSeparator+string(entry->d_name));
+            }
+            closedir(dir);
         }
-        closedir(dir);
     }
+
     vector<void*> plugins;
 #endif
     vector<string> loadedLibraries;
@@ -294,7 +305,7 @@ vector<string> Platform::loadPluginsFromDirectory(const string& directory) {
 
     for (unsigned int i = 0; i < files.size(); ++i) {
         try {
-            plugins.push_back(loadOneLibrary(directory+dirSeparator+files[i]));
+            plugins.push_back(loadOneLibrary(files[i]));
             loadedLibraries.push_back(files[i]);
         } catch (OpenMMException& ex) {
 	    pluginLoadFailures.push_back(ex.what());


### PR DESCRIPTION
Sometimes you can't have all your plugins in one place, e.g., due to a modular modules system where third party plugins may be built and loaded into immutable locations independent of the main openmm install. This patch supports path styles for OPENMM_PLUGIN_DIR of the type `some_path/plugins:other_path/plugins:etc`, to ease such use cases.